### PR TITLE
Share key pair alert hidden in personal mode

### DIFF
--- a/src/renderer/pages/AccountSetup/components/KeyPairs.vue
+++ b/src/renderer/pages/AccountSetup/components/KeyPairs.vue
@@ -240,15 +240,17 @@ defineExpose({
       <label class="form-label">ED25519 Public Key</label>
       <p class="text-break text-secondary">{{ publicKey }}</p>
     </div>
-    <hr class="my-6" />
-    <div class="alert alert-secondary d-flex align-items-start mb-0" role="alert">
-      <i class="bi bi-exclamation-triangle text-warning me-3"></i>
+    <template v-if="user.data.mode === 'organization'">
+      <hr class="my-6" />
+      <div class="alert alert-secondary d-flex align-items-start mb-0" role="alert">
+        <i class="bi bi-exclamation-triangle text-warning me-3"></i>
 
-      <div>
-        <p class="fw-semibold">Sharing Key Pair</p>
-        <p>Share this Key Pair from Settings > List of Keys.</p>
+        <div>
+          <p class="fw-semibold">Sharing Key Pair</p>
+          <p>Share this Key Pair from Settings > List of Keys.</p>
+        </div>
       </div>
-    </div>
+    </template>
 
     <!-- <p v-if="keyExists" class="mt-3 text-danger">This key is already restored.</p> -->
     <!-- <div class="d-flex flex-column align-items-center gap-4 mt-8">


### PR DESCRIPTION
**Description**:
This PR hides the share key pair modal in the Account Setup step