### PR TITLE
Valid start updated on continue draft

### DIFF
--- a/src/renderer/components/Transaction/TransactionIdControls.vue
+++ b/src/renderer/components/Transaction/TransactionIdControls.vue
@@ -8,7 +8,6 @@ import { useRoute } from 'vue-router';
 import useAccountId from '@renderer/composables/useAccountId';
 
 import { getDraft } from '@renderer/services/transactionDraftsService';
-import { getDateTimeLocalInputValue } from '@renderer/utils';
 import { getTransactionFromBytes } from '@renderer/utils/transactions';
 
 import AppInput from '@renderer/components/ui/AppInput.vue';
@@ -49,9 +48,6 @@ const loadFromDraft = async (id: string) => {
     if (transactionId.accountId) {
       account.accountId.value = transactionId.accountId.toString();
       emit('update:payerId', transactionId.accountId.toString());
-    }
-    if (transactionId.validStart) {
-      emit('update:validStart', getDateTimeLocalInputValue(transactionId.validStart.toDate()));
     }
   }
 

--- a/src/renderer/pages/CreateTransaction/components/Transfer/TransferHbar.vue
+++ b/src/renderer/pages/CreateTransaction/components/Transfer/TransferHbar.vue
@@ -100,9 +100,6 @@ const handleLoadFromDraft = async () => {
       if (transactionId.accountId) {
         payerData.accountId.value = transactionId.accountId.toString();
       }
-      if (transactionId.validStart) {
-        validStart.value = getDateTimeLocalInputValue(transactionId.validStart.toDate());
-      }
     }
 
     if (draftTransaction.maxTransactionFee) {


### PR DESCRIPTION
**Description**:
This pull request removes the auto-population of the valid start of a draft transaction. Now the valid start will automatically be updated to the current time 