### PR TITLE
fix: update jest.config.ts with maxWorkers setting for CI

### DIFF
--- a/back-end/apps/api/jest.config.ts
+++ b/back-end/apps/api/jest.config.ts
@@ -16,4 +16,8 @@ const config: Config = {
   },
 };
 
+if (process.env.CI) {
+  config.maxWorkers = 2; // This is to prevent Jest from starving the worker in CI environments and causing instability
+}
+
 export default config;

--- a/back-end/apps/chain/jest.config.ts
+++ b/back-end/apps/chain/jest.config.ts
@@ -16,4 +16,8 @@ const config: Config = {
   },
 };
 
+if (process.env.CI) {
+  config.maxWorkers = 2; // This is to prevent Jest from starving the worker in CI environments and causing instability
+}
+
 export default config;

--- a/back-end/apps/notifications/jest.config.ts
+++ b/back-end/apps/notifications/jest.config.ts
@@ -16,4 +16,8 @@ const config: Config = {
   },
 };
 
+if (process.env.CI) {
+  config.maxWorkers = 2; // This is to prevent Jest from starving the worker in CI environments and causing instability
+}
+
 export default config;


### PR DESCRIPTION
**Description**:
This PR sets the `maxWorkers` setting to `2` in CI environments (where environment variable CI=true) to prevent jest from starving the CI runner causing instability in test runs.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
