### PR TITLE
713 content refreshing transaction panes

### DIFF
--- a/back-end/apps/chain/src/transaction-status/transaction-status.service.ts
+++ b/back-end/apps/chain/src/transaction-status/transaction-status.service.ts
@@ -147,11 +147,13 @@ export class TransactionStatusService {
           },
         );
       }
-    });
 
-    this.notificationsService.emit<undefined, NotifyClientDto>(NOTIFY_CLIENT, {
-      message: TRANSACTION_ACTION,
-      content: '',
+      if (transactions.length > 0) {
+        this.notificationsService.emit<undefined, NotifyClientDto>(NOTIFY_CLIENT, {
+          message: TRANSACTION_ACTION,
+          content: '',
+        });
+      }
     });
   }
 
@@ -262,6 +264,8 @@ export class TransactionStatusService {
     const newStatus = isAbleToSign
       ? TransactionStatus.WAITING_FOR_EXECUTION
       : TransactionStatus.WAITING_FOR_SIGNATURES;
+
+    if (transaction.status === newStatus) return;
 
     await this.transactionRepo.update(
       {


### PR DESCRIPTION
**Description**:
Automatic notifications sent from the back-end should only be sent if a change is manually, or automatically, made to a transaction.

**Related issue(s)**:

Fixes #713 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
