### PR TITLE
fix: instead of using useAccountId(), directly set payer account id

### DIFF
--- a/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
+++ b/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
@@ -226,7 +226,7 @@ async function handleOnFileChanged(e: Event) {
           keyList: keys,
           observers: [],
           approvers: [],
-          payerAccountId: payerData.accountId.value,
+          payerAccountId: senderAccount,
           validStart: validStart,
         });
       }


### PR DESCRIPTION
Signed-off-by: Tim Schmidt <tim@launchbadge.com>

**Description**:
Fixes the assignment of payer account id for csv imports.  Was attempting to use useAccountId(), but accountId in this composable is set via a watch (probably during transaction creation) which will not be set in this case.  Instead, assign payer account id directly.

**Related issue(s)**:
#764 

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
