### PR TITLE
update sending email to use the proper domain and local part

### DIFF
--- a/back-end/apps/notifications/src/email/email.service.ts
+++ b/back-end/apps/notifications/src/email/email.service.ts
@@ -22,7 +22,7 @@ export class EmailService {
   async notifyEmail({ email, subject, text }: NotifyEmailDto) {
     // send mail with defined transport object
     const info = await this.transporter.sendMail({
-      from: '"Transaction Tool" no-reply@transactiontool.com', // sender address
+      from: '"Transaction Tool" no-reply@hederatransactiontool.com', // sender address
       to: email, // list of receivers
       subject: subject, // Subject line
       text: text, // plain text body

--- a/back-end/apps/notifications/src/fan-out/fan-out.service.spec.ts
+++ b/back-end/apps/notifications/src/fan-out/fan-out.service.spec.ts
@@ -116,7 +116,7 @@ describe('Fan Out Service', () => {
       await service.fanOutNew(notification, receivers);
 
       expect(emailService.processEmail).toHaveBeenCalledWith({
-        from: '"Transaction Tool" info@transactiontool.com',
+        from: '"Transaction Tool" no-reply@hederatransactiontool.com',
         to: [receivers[0].user.email],
         subject: NotificationTypeEmailSubjects.TRANSACTION_EXECUTED,
         text: notification.content,
@@ -156,7 +156,7 @@ describe('Fan Out Service', () => {
       await service.fanOutNew(notification, receivers);
 
       expect(emailService.processEmail).toHaveBeenCalledWith({
-        from: '"Transaction Tool" info@transactiontool.com',
+        from: '"Transaction Tool" no-reply@hederatransactiontool.com',
         to: [receivers[0].user.email],
         subject: NotificationTypeEmailSubjects.TRANSACTION_EXECUTED,
         text: notification.content,
@@ -263,7 +263,7 @@ describe('Fan Out Service', () => {
       await service.fanOutNew(notification, receivers);
 
       expect(emailService.processEmail).toHaveBeenCalledWith({
-        from: '"Transaction Tool" info@transactiontool.com',
+        from: '"Transaction Tool" no-reply@hederatransactiontool.com',
         to: [receivers[0].user.email],
         subject: NotificationTypeEmailSubjects.TRANSACTION_EXECUTED,
         text: notification.content,
@@ -305,7 +305,7 @@ describe('Fan Out Service', () => {
       await service.fanOutNew(notification, receivers);
 
       expect(emailService.processEmail).toHaveBeenCalledWith({
-        from: '"Transaction Tool" info@transactiontool.com',
+        from: '"Transaction Tool" no-reply@hederatransactiontool.com',
         to: [receivers[0].user.email],
         subject: NotificationTypeEmailSubjects.TRANSACTION_EXECUTED,
         text: notification.content,

--- a/back-end/apps/notifications/src/fan-out/fan-out.service.ts
+++ b/back-end/apps/notifications/src/fan-out/fan-out.service.ts
@@ -125,7 +125,7 @@ export class FanOutService {
 
     if (emails.length > 0) {
       const mailOptions: SendMailOptions = {
-        from: '"Transaction Tool" info@transactiontool.com',
+        from: '"Transaction Tool" no-reply@hederatransactiontool.com',
         to: emails,
         subject: NotificationTypeEmailSubjects[notification.type],
         text: notification.content,


### PR DESCRIPTION
**Description**:
info@transactiontool.com -> no-reply@hederatransactiontool.com

**Related issue(s)**:

Fixes #827 

**Checklist**

- [x] Tested (unit, integration, etc.)
