### PR TITLE
fix: retain valid start in groups

### DIFF
--- a/front-end/src/renderer/pages/CreateTransaction/components/Account/ApproveHbarAllowance.vue
+++ b/front-end/src/renderer/pages/CreateTransaction/components/Account/ApproveHbarAllowance.vue
@@ -128,6 +128,7 @@ const handleLoadFromDraft = async () => {
   } else if (route.query.groupIndex) {
     draftTransactionBytes =
       transactionGroup.groupItems[Number(route.query.groupIndex)].transactionBytes.toString();
+    validStart.value = transactionGroup.groupItems[Number(route.query.groupIndex)].validStart;
   }
 
   if (draftTransactionBytes) {

--- a/front-end/src/renderer/pages/CreateTransaction/components/Account/CreateAccount.vue
+++ b/front-end/src/renderer/pages/CreateTransaction/components/Account/CreateAccount.vue
@@ -189,6 +189,7 @@ const handleLoadFromDraft = async () => {
   } else if (route.query.groupIndex) {
     draftTransactionBytes =
       transactionGroup.groupItems[Number(route.query.groupIndex)].transactionBytes.toString();
+    validStart.value = transactionGroup.groupItems[Number(route.query.groupIndex)].validStart;
   }
 
   if (draftTransactionBytes) {

--- a/front-end/src/renderer/pages/CreateTransaction/components/Account/DeleteAccount.vue
+++ b/front-end/src/renderer/pages/CreateTransaction/components/Account/DeleteAccount.vue
@@ -138,6 +138,7 @@ const handleLoadFromDraft = async () => {
   } else if (route.query.groupIndex) {
     draftTransactionBytes =
       transactionGroup.groupItems[Number(route.query.groupIndex)].transactionBytes.toString();
+    validStart.value = transactionGroup.groupItems[Number(route.query.groupIndex)].validStart;
   }
 
   if (draftTransactionBytes) {

--- a/front-end/src/renderer/pages/CreateTransaction/components/Account/UpdateAccount.vue
+++ b/front-end/src/renderer/pages/CreateTransaction/components/Account/UpdateAccount.vue
@@ -166,6 +166,7 @@ const handleLoadFromDraft = async () => {
   } else if (route.query.groupIndex) {
     draftTransactionBytes =
       transactionGroup.groupItems[Number(route.query.groupIndex)].transactionBytes.toString();
+    validStart.value = transactionGroup.groupItems[Number(route.query.groupIndex)].validStart;
   }
 
   if (draftTransactionBytes) {

--- a/front-end/src/renderer/pages/CreateTransaction/components/File/AppendToFile.vue
+++ b/front-end/src/renderer/pages/CreateTransaction/components/File/AppendToFile.vue
@@ -149,6 +149,7 @@ const handleLoadFromDraft = async () => {
   } else if (route.query.groupIndex) {
     draftTransactionBytes =
       transactionGroup.groupItems[Number(route.query.groupIndex)].transactionBytes.toString();
+    validStart.value = transactionGroup.groupItems[Number(route.query.groupIndex)].validStart;
   }
 
   if (draftTransactionBytes) {

--- a/front-end/src/renderer/pages/CreateTransaction/components/File/CreateFile.vue
+++ b/front-end/src/renderer/pages/CreateTransaction/components/File/CreateFile.vue
@@ -197,6 +197,7 @@ const handleLoadFromDraft = async () => {
   } else if (route.query.groupIndex) {
     draftTransactionBytes =
       transactionGroup.groupItems[Number(route.query.groupIndex)].transactionBytes.toString();
+    validStart.value = transactionGroup.groupItems[Number(route.query.groupIndex)].validStart;
   }
 
   if (draftTransactionBytes) {

--- a/front-end/src/renderer/pages/CreateTransaction/components/File/UpdateFile.vue
+++ b/front-end/src/renderer/pages/CreateTransaction/components/File/UpdateFile.vue
@@ -162,6 +162,7 @@ const handleLoadFromDraft = async () => {
   } else if (route.query.groupIndex) {
     draftTransactionBytes =
       transactionGroup.groupItems[Number(route.query.groupIndex)].transactionBytes.toString();
+    validStart.value = transactionGroup.groupItems[Number(route.query.groupIndex)].validStart;
   }
 
   if (draftTransactionBytes) {

--- a/front-end/src/renderer/pages/CreateTransaction/components/Misc/Freeze.vue
+++ b/front-end/src/renderer/pages/CreateTransaction/components/Misc/Freeze.vue
@@ -122,6 +122,7 @@ const handleLoadFromDraft = async () => {
   } else if (route.query.groupIndex) {
     draftTransactionBytes =
       transactionGroup.groupItems[Number(route.query.groupIndex)].transactionBytes.toString();
+    validStart.value = transactionGroup.groupItems[Number(route.query.groupIndex)].validStart;
   }
 
   if (draftTransactionBytes) {

--- a/front-end/src/renderer/pages/CreateTransaction/components/Transfer/TransferHbar.vue
+++ b/front-end/src/renderer/pages/CreateTransaction/components/Transfer/TransferHbar.vue
@@ -163,6 +163,7 @@ const handleLoadFromDraft = async () => {
   } else if (route.query.groupIndex) {
     draftTransactionBytes =
       transactionGroup.groupItems[Number(route.query.groupIndex)].transactionBytes.toString();
+    validStart.value = transactionGroup.groupItems[Number(route.query.groupIndex)].validStart;
   }
 
   if (draftTransactionBytes) {
@@ -197,7 +198,6 @@ const handleLoadFromDraft = async () => {
               );
             }
           }
-
           transfers.value = loadedTransfers;
         } catch {
           /* Empty */


### PR DESCRIPTION
Signed-off-by: Tim Schmidt <tim@launchbadge.com>

**Description**:
ensure that valid start is set correctly when editing a transaction in a group

**Related issue(s)**:
#812 

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
