### PR TITLE
901 change transaction creation confirmation buttons to say 'confirm'

### DIFF
--- a/front-end/src/renderer/components/Transaction/TransactionGroupProcessor.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionGroupProcessor.vue
@@ -473,7 +473,7 @@ defineExpose({
             >Cancel</AppButton
           >
           <AppButton color="primary" type="button" @click.prevent="handleConfirmTransaction"
-            >Submit</AppButton
+            >Confirm</AppButton
           >
         </div>
       </div>

--- a/front-end/src/renderer/components/Transaction/TransactionProcessor/components/ConfirmTransactionHandler.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionProcessor/components/ConfirmTransactionHandler.vue
@@ -151,7 +151,7 @@ defineExpose({
             data-testid="button-sign-transaction"
             :loading="signing"
             :disabled="signing"
-            >Sign</AppButton
+            >Confirm</AppButton
           >
         </div>
       </form>


### PR DESCRIPTION
**Description**:
Updated both single transaction and group transaction creation confirmation modals to use 'confirm' as the saving text.

**Related issue(s)**:

Fixes #901 

**Checklist**

- [x] Tested (unit, integration, etc.)
