### PR TITLE
fix: smart collating

### DIFF
--- a/back-end/apps/chain/src/transaction-status/transaction-status.service.ts
+++ b/back-end/apps/chain/src/transaction-status/transaction-status.service.ts
@@ -229,7 +229,9 @@ export class TransactionStatusService {
     });
   }
 
-  private async _updateTransactionStatus(transaction: Transaction): Promise<TransactionStatus | undefined> {
+  private async _updateTransactionStatus(
+    transaction: Transaction,
+  ): Promise<TransactionStatus | undefined> {
     /* Returns if the transaction is null */
     if (!transaction) return;
 
@@ -256,7 +258,7 @@ export class TransactionStatusService {
     let newStatus = TransactionStatus.WAITING_FOR_SIGNATURES;
 
     if (isAbleToSign) {
-      const sdkTransaction = await smartCollate(transaction);
+      const sdkTransaction = await smartCollate(transaction, this.mirrorNodeService);
 
       if (sdkTransaction !== null) {
         newStatus = TransactionStatus.WAITING_FOR_EXECUTION;
@@ -313,7 +315,7 @@ export class TransactionStatusService {
 
     const callback = async () => {
       try {
-        const sdkTransaction = await smartCollate(transaction);
+        const sdkTransaction = await smartCollate(transaction, this.mirrorNodeService);
 
         // If the transaction is still too large,
         // set it to failed with the TRANSACTION_OVERSIZE status code

--- a/back-end/libs/common/src/utils/sdk/transaction.ts
+++ b/back-end/libs/common/src/utils/sdk/transaction.ts
@@ -259,13 +259,16 @@ export const verifyTransactionBodyWithoutNodeAccountIdSignature = (
   }
 };
 
-export async function smartCollate(transaction: Transaction): Promise<SDKTransaction | null> {
+export async function smartCollate(
+  transaction: Transaction,
+  mirrorNodeService: MirrorNodeService,
+): Promise<SDKTransaction | null> {
   const sdkTransaction = SDKTransaction.fromBytes(transaction.transactionBytes);
 
   if (await isTransactionOverMaxSize(sdkTransaction)) {
     const signatureKey = await computeSignatureKey(
       sdkTransaction,
-      this.mirrorNodeService,
+      mirrorNodeService,
       transaction.network,
     );
 


### PR DESCRIPTION
**Description**:
This PR fixes the smart collating.
The problem was that the functions tried to user `this.mirrorNodeService`, while not in the context of a class that has injected it
