### PR TITLE
feat: passthrough the nickname if existing key is used

### DIFF
--- a/front-end/src/renderer/pages/AccountSetup/components/KeyPairs.vue
+++ b/front-end/src/renderer/pages/AccountSetup/components/KeyPairs.vue
@@ -38,7 +38,7 @@ const createTooltips = useCreateTooltips();
 const userPasswordModalRef = inject<USER_PASSWORD_MODAL_TYPE>(USER_PASSWORD_MODAL_KEY);
 
 /* State */
-const nickname = ref('');
+const nickname = ref(props.selectedPersonalKeyPair?.nickname || '');
 
 const privateKeyRef = ref<HTMLSpanElement | null>(null);
 const privateKeyHidden = ref(true);


### PR DESCRIPTION
**Description**:
This pull request passes through the nickname of a selected key when setting up the account for new organization

**Related issue(s)**:

Fixes #
#914 