### PR TITLE
feat: allow submission of canceled transaction

### DIFF
--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -338,10 +338,19 @@ export class TransactionsService {
     /* Check if the transaction already exists */
     const countExisting = await this.repo.count({
       where: [
-        { transactionId: sdkTransaction.transactionId.toString() },
-        { transactionBytes: dto.transactionBytes },
+        {
+          transactionId: sdkTransaction.transactionId.toString(),
+          status: Not(
+            In([
+              TransactionStatus.EXECUTED,
+              TransactionStatus.CANCELED,
+              TransactionStatus.REJECTED,
+            ]),
+          ),
+        },
       ],
     });
+
     if (countExisting > 0) throw new BadRequestException(ErrorCodes.TEX);
 
     const client = await getClientFromNetwork(dto.mirrorNetwork);

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -340,13 +340,7 @@ export class TransactionsService {
       where: [
         {
           transactionId: sdkTransaction.transactionId.toString(),
-          status: Not(
-            In([
-              TransactionStatus.EXECUTED,
-              TransactionStatus.CANCELED,
-              TransactionStatus.REJECTED,
-            ]),
-          ),
+          status: Not(In([TransactionStatus.CANCELED, TransactionStatus.REJECTED])),
         },
       ],
     });

--- a/back-end/apps/api/test/spec/transaction.e2e-spec.ts
+++ b/back-end/apps/api/test/spec/transaction.e2e-spec.ts
@@ -137,7 +137,7 @@ describe('Transactions (e2e)', () => {
       );
     });
 
-    it('(POST) should create a transaction with and ID of an canceled transaction', async () => {
+    it('(POST) should create a transaction with and ID of a canceled transaction', async () => {
       const transaction = await createTransaction();
 
       const { body: newTransaction } = await endpoint.post(transaction, null, userAuthToken);

--- a/back-end/apps/api/test/spec/transaction.e2e-spec.ts
+++ b/back-end/apps/api/test/spec/transaction.e2e-spec.ts
@@ -137,7 +137,7 @@ describe('Transactions (e2e)', () => {
       );
     });
 
-    it('(POST) should create a transaction with and ID of an cancelled transaction', async () => {
+    it('(POST) should create a transaction with and ID of an canceled transaction', async () => {
       const transaction = await createTransaction();
 
       const { body: newTransaction } = await endpoint.post(transaction, null, userAuthToken);

--- a/back-end/apps/api/test/spec/transaction.e2e-spec.ts
+++ b/back-end/apps/api/test/spec/transaction.e2e-spec.ts
@@ -152,15 +152,17 @@ describe('Transactions (e2e)', () => {
       const user = await createUser('test@test.com', '1234567890', false, UserStatus.NONE);
       const token = await login(app, { ...user, password: '1234567890' });
 
-      const { status } = await endpoint.post(transaction, null, token);
+      const { status, body } = await endpoint.post(transaction, null, token);
       const countAfter = await repo.count();
 
       expect(status).toEqual(401);
-      // expect(body).toMatchObject(
-      //   expect.objectContaining({
-      //     message: 'You should have at least one key to perform this action.',
-      //   }),
-      // );
+      expect(body).toMatchObject(
+        expect.objectContaining({
+          error: 'Unauthorized',
+          message: 'You should have at least one key to perform this action.',
+          statusCode: 401,
+        }),
+      );
       expect(countAfter).toEqual(countBefore);
     });
 
@@ -216,21 +218,15 @@ describe('Transactions (e2e)', () => {
       delete transaction.creatorKeyId;
       delete transaction.mirrorNetwork;
 
-      const { status } = await endpoint.post(transaction, null, userAuthToken);
+      const { status, body } = await endpoint.post(transaction, null, userAuthToken);
       const countAfter = await repo.count();
 
       expect(status).toEqual(400);
-      // expect(body).toMatchObject(
-      //   expect.objectContaining({
-      //     message: [
-      //       'name must be a string',
-      //       'description must be a string',
-      //       'creatorKeyId must be a number conforming to the specified constraints',
-      //       'network must be one of the following values: mainnet, testnet, previewnet, local-node',
-      //       'network should not be empty',
-      //     ],
-      //   }),
-      // );
+      expect(body).toMatchObject(
+        expect.objectContaining({
+          code: ErrorCodes.IB,
+        }),
+      );
       expect(countAfter).toEqual(countBefore);
     });
 

--- a/back-end/apps/api/test/spec/transaction.e2e-spec.ts
+++ b/back-end/apps/api/test/spec/transaction.e2e-spec.ts
@@ -137,6 +137,35 @@ describe('Transactions (e2e)', () => {
       );
     });
 
+    it('(POST) should create a transaction with and ID of an cancelled transaction', async () => {
+      const transaction = await createTransaction();
+
+      const { body: newTransaction } = await endpoint.post(transaction, null, userAuthToken);
+      testsAddedTransactionsCountUser++;
+
+      const cancelEndpoint = new Endpoint(server, '/transactions/cancel');
+      const cancelRes = await cancelEndpoint.patch(
+        null,
+        newTransaction.id.toString(),
+        userAuthToken,
+      );
+      expect(cancelRes.status).toEqual(200);
+
+      const { status, body } = await endpoint.post(transaction, null, userAuthToken);
+      testsAddedTransactionsCountUser++;
+
+      expect(status).toEqual(201);
+      expect(body.transactionBytes).not.toEqual(transaction.transactionBytes);
+      expect(body).toMatchObject(
+        expect.objectContaining({
+          name: transaction.name,
+          description: transaction.description,
+          status: TransactionStatus.WAITING_FOR_SIGNATURES,
+          creatorKeyId: transaction.creatorKeyId,
+        }),
+      );
+    });
+
     it('(POST) should not create a transaction if user is not verified', async () => {
       const countBefore = await repo.count();
       await endpoint.post(await createTransaction(), null, userNewAuthToken).expect(403);

--- a/back-end/libs/common/src/database/entities/transaction.entity.ts
+++ b/back-end/libs/common/src/database/entities/transaction.entity.ts
@@ -66,7 +66,7 @@ export class Transaction {
   @Column({ length: 256 })
   description: string;
 
-  @Column({ unique: true })
+  @Column()
   transactionId: string;
 
   @Column()


### PR DESCRIPTION
**Description**:
This pull request enables the submission of transactions with an ID that has already been sent but is canceled or rejected

**Related issue(s)**:

Fixes #
#1079 

**Checklist**

- [X] Tested (unit, integration, etc.)
