### PR TITLE
fix: miscellaneous fixes for styling in transaction group

### DIFF
--- a/front-end/src/renderer/components/Transaction/TransactionGroupProcessor.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionGroupProcessor.vue
@@ -452,19 +452,25 @@ defineExpose({
       class="large-modal"
       :close-on-click-outside="false"
       :close-on-escape="false"
+      scrollable
     >
-      <div class="p-5">
-        <div>
-          <i class="bi bi-x-lg cursor-pointer" @click="isConfirmShown = false"></i>
+      <template #header>
+        <div class="d-flex flex-column w-100">
+          <div>
+            <i class="bi bi-x-lg cursor-pointer" @click="isConfirmShown = false"></i>
+          </div>
+          <div class="text-center">
+            <i class="bi bi-arrow-left-right large-icon"></i>
+          </div>
+          <h3 class="text-center text-title text-bold mt-5">Confirm Transaction Group</h3>
+          <hr class="separator my-5" />
         </div>
-        <div class="text-center">
-          <i class="bi bi-arrow-left-right large-icon"></i>
-        </div>
-        <h3 class="text-center text-title text-bold mt-5">Confirm Transaction Group</h3>
-        <hr class="separator my-5" />
+      </template>
+      <template #default>
         <div
           v-for="groupItem in transactionGroup.groupItems"
           :key="groupItem.transactionBytes.toString()"
+          class="px-5"
         >
           <div class="d-flex p-4 transaction-group-row justify-content-between">
             <div>{{ getTransactionType(groupItem.transactionBytes) }}</div>
@@ -479,10 +485,12 @@ defineExpose({
             </div>
           </div>
         </div>
+      </template>
 
-        <hr class="separator my-5" />
+      <template #footer>
+        <hr class="separator m-5" />
 
-        <div class="flex-between-centered gap-4">
+        <div class="flex-between-centered gap-4 w-100 px-5 pb-5">
           <AppButton type="button" color="borderless" @click="isConfirmShown = false"
             >Cancel</AppButton
           >
@@ -490,7 +498,7 @@ defineExpose({
             >Confirm</AppButton
           >
         </div>
-      </div>
+      </template>
     </AppModal>
     <!-- Executing modal -->
     <AppModal

--- a/front-end/src/renderer/components/ui/AppModal.vue
+++ b/front-end/src/renderer/components/ui/AppModal.vue
@@ -7,10 +7,12 @@ const props = withDefaults(
     show: boolean;
     closeOnEscape?: boolean;
     closeOnClickOutside?: boolean;
+    scrollable?: boolean;
   }>(),
   {
     closeOnEscape: true,
     closeOnClickOutside: true,
+    scrollable: false,
   },
 );
 
@@ -55,7 +57,9 @@ onBeforeUnmount(() => {
   >
     <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" ref="modalRef">
       <div class="modal-content">
+        <div v-if="scrollable" class="modal-header pb-0"><slot name="header"></slot></div>
         <div class="modal-body"><slot></slot></div>
+        <div v-if="scrollable" class="modal-footer p-0"><slot name="footer"></slot></div>
       </div>
     </div>
   </div>

--- a/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
+++ b/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
@@ -281,7 +281,7 @@ async function handleOnFileChanged(e: Event) {
             }
             transactionGroup.addGroupItem({
               transactionBytes,
-              type: 'TransferTransaction',
+              type: 'Transfer Transaction',
               accountId: '',
               seq: transactionGroup.groupItems.length.toString(),
               keyList: keys,
@@ -339,8 +339,8 @@ onBeforeRouteLeave(async to => {
 });
 </script>
 <template>
-  <div>
-    <div class="p-5 overflow-y-auto" style="height: 100%">
+  <div class="p-5">
+    <div class="flex-column-100 overflow-hidden">
       <div class="d-flex align-items-center">
         <AppButton type="button" color="secondary" class="btn-icon-only me-4" @click="handleBack">
           <i class="bi bi-arrow-left"></i>
@@ -348,7 +348,7 @@ onBeforeRouteLeave(async to => {
 
         <h2 class="text-title text-bold">Create Transaction Group</h2>
       </div>
-      <form class="mt-5" @submit.prevent="handleSaveGroup">
+      <form class="mt-5 flex-column-100" @submit.prevent="handleSaveGroup">
         <div class="d-flex justify-content-between">
           <div class="form-group col">
             <label class="form-label"
@@ -421,7 +421,7 @@ onBeforeRouteLeave(async to => {
           </AppButton>
         </div>
         <hr class="separator my-5 w-100" />
-        <div v-if="!groupEmpty">
+        <div v-if="!groupEmpty" class="fill-remaining pb-10">
           <div class="text-end mb-5">
             {{ `${transactionGroup.groupItems.length} Transactions` }}
           </div>
@@ -444,7 +444,7 @@ onBeforeRouteLeave(async to => {
                       : createTransactionId(groupItem.payerAccountId, groupItem.validStart)
                 }}
               </div>
-              <div class="d-flex col">
+              <div class="d-flex col justify-content-end">
                 <AppButton
                   type="button"
                   class="transaction-group-button-borderless"

--- a/front-end/src/renderer/stores/storeTransactionGroup.ts
+++ b/front-end/src/renderer/stores/storeTransactionGroup.ts
@@ -121,6 +121,7 @@ const useTransactionGroupStore = defineStore('transactionGroup', () => {
       approvers: baseItem.approvers,
       payerAccountId: baseItem.payerAccountId,
       validStart: newDate,
+      description: baseItem.description,
     };
     groupItems.value.splice(index + 1, 0, newItem);
     setModified();


### PR DESCRIPTION
**Description**:
fixes:
- Spacing on individual transaction buttons is incorrect
- Transfer Transaction title is incorrect on import
- duplicated transactions don't show second column
- Header/Footer should be sticky on confirm group modal
- Create Transaction Group Title area should be sticky


**Related issue(s)**:

Fixes #1193

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
