### PR TITLE
feat: remove mnemonic information of another user from response

### DIFF
--- a/back-end/apps/api/src/user-keys/user-keys.controller.spec.ts
+++ b/back-end/apps/api/src/user-keys/user-keys.controller.spec.ts
@@ -99,18 +99,26 @@ describe('UserKeysController', () => {
   });
 
   describe('getKeys', () => {
-    it('should return an array of keys', async () => {
+    it('should return an array of keys with full key', async () => {
       const result = [userKey];
 
-      userKeysService.getUserKeys.mockResolvedValue(result);
+      userKeysService.getUserKeysRestricted.mockResolvedValue(result);
 
-      expect(await controller.getUserKeys(1)).toBe(result);
+      expect(await controller.getUserKeys(user, 1)).toBe(result);
+    });
+
+    it('should return an array of keys without mnemonic if not owner', async () => {
+      const result = [userKey].map(key => ({ ...key, mnemonicHash: undefined, index: undefined }));
+
+      userKeysService.getUserKeysRestricted.mockResolvedValue(result);
+
+      expect(await controller.getUserKeys({ id: 2, ...user }, 1)).toBe(result);
     });
 
     it('should return an empty array if no keys exist', async () => {
-      userKeysService.getUserKeys.mockResolvedValue([]);
+      userKeysService.getUserKeysRestricted.mockResolvedValue([]);
 
-      expect(await controller.getUserKeys(1)).toEqual([]);
+      expect(await controller.getUserKeys(user, 1)).toEqual([]);
     });
   });
 

--- a/back-end/apps/api/src/user-keys/user-keys.controller.ts
+++ b/back-end/apps/api/src/user-keys/user-keys.controller.ts
@@ -48,8 +48,11 @@ export class UserKeysController {
     type: [UserKeyDto],
   })
   @Get()
-  getUserKeys(@Param('userId', ParseIntPipe) userId: number): Promise<UserKey[]> {
-    return this.userKeysService.getUserKeys(userId);
+  getUserKeys(
+    @GetUser() user: User,
+    @Param('userId', ParseIntPipe) userId: number,
+  ): Promise<UserKey[]> {
+    return this.userKeysService.getUserKeysRestricted(user, userId);
   }
 
   @ApiOperation({

--- a/back-end/apps/api/src/user-keys/user-keys.service.ts
+++ b/back-end/apps/api/src/user-keys/user-keys.service.ts
@@ -13,7 +13,7 @@ export const MAX_USER_KEYS = 20;
 export class UserKeysService {
   constructor(@InjectRepository(UserKey) private repo: Repository<UserKey>) {}
 
-  // Get the user key for the provided userKeyId.
+  // Get the user key for the provided where clause.
   getUserKey(
     where: FindOptionsWhere<UserKey>,
     relations?: FindOptionsRelations<UserKey>,
@@ -61,9 +61,19 @@ export class UserKeysService {
   }
 
   // Get the list of user keys for the provided userId
-  async getUserKeys(userId: number): Promise<UserKey[]> {
+  async getUserKeysRestricted(user: User, userId: number): Promise<UserKey[]> {
     if (!userId) return [];
-    return this.repo.find({ where: { userId } });
+    return this.repo.find({
+      where: { userId },
+      select: {
+        id: true,
+        userId: true,
+        mnemonicHash: user.id === userId,
+        index: user.id === userId,
+        publicKey: true,
+        deletedAt: true,
+      },
+    });
   }
 
   // Remove the user key for the provided userKeyId.

--- a/back-end/apps/api/test/spec/user-keys.e2e-spec.ts
+++ b/back-end/apps/api/test/spec/user-keys.e2e-spec.ts
@@ -45,11 +45,15 @@ describe('User Keys (e2e)', () => {
     });
 
     it('(GET) should get keys of other user if verified', async () => {
-      const res = await endpoint.get('/1/keys', userAuthToken).expect(200);
+      const res = await endpoint.get(`/${admin.id}/keys`, userAuthToken).expect(200);
 
       const actualUserKeys = await getUserKeys(1);
 
       expect(res.body).toHaveLength(actualUserKeys.length);
+      res.body.forEach(key => {
+        expect(key).not.toHaveProperty('mnemonicHash');
+        expect(key).not.toHaveProperty('index');
+      });
     });
 
     it('(GET) should get users keys if verified', async () => {
@@ -58,6 +62,10 @@ describe('User Keys (e2e)', () => {
       const actualUserKeys = await getUserKeys(2);
 
       expect(res.body).toHaveLength(actualUserKeys.length);
+      res.body.forEach(key => {
+        expect(key).toHaveProperty('mnemonicHash');
+        expect(key).toHaveProperty('index');
+      });
     });
 
     it('(GET) should not be able to get user keys if not verified', async () => {

--- a/front-end/src/renderer/stores/storeTransactionGroup.ts
+++ b/front-end/src/renderer/stores/storeTransactionGroup.ts
@@ -121,7 +121,6 @@ const useTransactionGroupStore = defineStore('transactionGroup', () => {
       approvers: baseItem.approvers,
       payerAccountId: baseItem.payerAccountId,
       validStart: newDate,
-      description: baseItem.description,
     };
     groupItems.value.splice(index + 1, 0, newItem);
     setModified();


### PR DESCRIPTION
**Description**:
This pull request removes the mnemonicHash and the index of the key object when making a request for another user's keys

**Related issue(s)**:

Fixes #
#1123 

**Checklist**

- [X] Tested (unit, integration, etc.)
