### PR TITLE
fix: missing env variable from develop deployment

### DIFF
--- a/back-end/k8s/dev/deployments/api-deployment.yaml
+++ b/back-end/k8s/dev/deployments/api-deployment.yaml
@@ -39,6 +39,8 @@ spec:
               value: 'postgres'
             - name: POSTGRES_SYNCHRONIZE
               value: 'true'
+            - name: POSTGRES_MAX_POOL_SIZE
+              value: '2'
             - name: JWT_SECRET
               value: 'some-secret-value'
             - name: JWT_EXPIRATION

--- a/back-end/k8s/dev/deployments/chain-deployment.yaml
+++ b/back-end/k8s/dev/deployments/chain-deployment.yaml
@@ -36,5 +36,7 @@ spec:
               value: 'postgres'
             - name: POSTGRES_SYNCHRONIZE
               value: 'true'
+            - name: POSTGRES_MAX_POOL_SIZE
+              value: '2'
             - name: REDIS_URL
               value: 'redis://redis-service:6379'

--- a/back-end/k8s/dev/deployments/notifications-deployment.yaml
+++ b/back-end/k8s/dev/deployments/notifications-deployment.yaml
@@ -53,6 +53,8 @@ spec:
               value: 'postgres'
             - name: POSTGRES_SYNCHRONIZE
               value: 'true'
+            - name: POSTGRES_MAX_POOL_SIZE
+              value: '2'
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
**Description**:
This pull request adds the new POSTGRES_MAX_POOL_SIZE env variable inside the deployment files for the local Kubernetes deployment