### PR TITLE
chore: replace pnpm/action-setup with a step-security maintained one

### DIFF
--- a/.github/workflows/test-backend.yaml
+++ b/.github/workflows/test-backend.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        uses: step-security/action-setup@303e8a1dabc4295b9b4ca0f4198fd42f7861406e # v4.0.0
         with:
           version: 9
 


### PR DESCRIPTION
**Description**:
pnpm/action-setup has to be replaced with a variant maintained by step-security in all workflows utilizing the action.

**Related issue(s)**:

Fixes #1262 

**Notes for reviewer**:
N/A

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
