### PR TITLE
feat: password inputs now show the 'reveal input' button by default.

### DIFF
--- a/front-end/src/renderer/components/DataMigration/DecryptMnemonicPhrase.vue
+++ b/front-end/src/renderer/components/DataMigration/DecryptMnemonicPhrase.vue
@@ -2,8 +2,8 @@
 import { ref } from 'vue';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
-import AppInput from '@renderer/components/ui/AppInput.vue';
 import AppModal from '@renderer/components/ui/AppModal.vue';
+import AppPasswordInput from '@renderer/components/ui/AppPasswordInput.vue';
 
 /* Props */
 defineProps<{
@@ -55,10 +55,9 @@ const handleClose = () => {
 
         <div class="form-group mt-4">
           <label class="form-label">Password</label>
-          <AppInput
+          <AppPasswordInput
             v-model="password"
             size="small"
-            type="password"
             name="password"
             :filled="true"
             placeholder="Type the password to decrypt the mnemonic phrase"

--- a/front-end/src/renderer/components/ForgotPasswordModal.vue
+++ b/front-end/src/renderer/components/ForgotPasswordModal.vue
@@ -16,6 +16,7 @@ import AppModal from '@renderer/components/ui/AppModal.vue';
 import AppInput from '@renderer/components/ui/AppInput.vue';
 import AppCustomIcon from '@renderer/components/ui/AppCustomIcon.vue';
 import OTPInput from '@renderer/components/OTPInput.vue';
+import AppPasswordInput from '@renderer/components/ui/AppPasswordInput.vue';
 
 /* Props */
 const props = defineProps<{
@@ -214,33 +215,30 @@ watch(
           </div>
 
           <div v-else-if="shouldSetNewPassword">
-            <AppInput
+            <AppPasswordInput
               v-if="isUserLoggedIn(user.personal) && !user.personal.useKeychain"
               v-model="personalPassword"
               :filled="true"
               class="mt-4"
               :class="{ 'is-invalid': personalPasswordInvalid }"
-              type="password"
               placeholder="Personal Password"
             />
             <div v-if="personalPasswordInvalid" class="invalid-feedback">
               Incorrect personal password
             </div>
-            <AppInput
+            <AppPasswordInput
               v-model="newPassword"
               :filled="true"
               class="mt-4"
               :class="{ 'is-invalid': newPasswordInvalid }"
-              type="password"
               placeholder="New Password"
             />
             <div v-if="newPasswordInvalid" class="invalid-feedback">Invalid password.</div>
-            <AppInput
+            <AppPasswordInput
               v-model="confirmPassword"
               :filled="true"
               class="mt-4"
               :class="{ 'is-invalid': inputConfirmPasswordInvalid }"
-              type="password"
               placeholder="Confirm New Password"
             />
             <div v-if="inputConfirmPasswordInvalid" class="invalid-feedback">

--- a/front-end/src/renderer/components/KeyPair/ImportEncrypted/components/DecryptKeyModal.vue
+++ b/front-end/src/renderer/components/KeyPair/ImportEncrypted/components/DecryptKeyModal.vue
@@ -21,8 +21,8 @@ import {
 } from '@renderer/utils';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
-import AppInput from '@renderer/components/ui/AppInput.vue';
 import AppModal from '@renderer/components/ui/AppModal.vue';
+import AppPasswordInput from '@renderer/components/ui/AppPasswordInput.vue';
 
 /* Props */
 const props = defineProps<{
@@ -225,10 +225,9 @@ watch(
 
         <div class="form-group mt-4">
           <label class="form-label">Enter Decryption Password</label>
-          <AppInput
+          <AppPasswordInput
             v-model="decryptPassword"
             size="small"
-            type="password"
             name="decrypt-key-password"
             :filled="true"
             :disabled="decrypting"

--- a/front-end/src/renderer/components/UserPasswordModal.vue
+++ b/front-end/src/renderer/components/UserPasswordModal.vue
@@ -9,8 +9,8 @@ import { isLoggedInWithPassword, isUserLoggedIn } from '@renderer/utils';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppModal from '@renderer/components/ui/AppModal.vue';
-import AppInput from '@renderer/components/ui/AppInput.vue';
 import AppCustomIcon from '@renderer/components/ui/AppCustomIcon.vue';
+import AppPasswordInput from '@renderer/components/ui/AppPasswordInput.vue';
 
 /* Stores */
 const user = useUserStore();
@@ -96,11 +96,10 @@ defineExpose({
         </p>
         <div class="form-group mt-5 mb-4">
           <label class="form-label">Password</label>
-          <AppInput
+          <AppPasswordInput
             v-model="password"
             data-testid="input-encrypt-password"
             size="small"
-            type="password"
             :filled="true"
           />
         </div>

--- a/front-end/src/renderer/components/ui/AppPasswordInput.vue
+++ b/front-end/src/renderer/components/ui/AppPasswordInput.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { computed, ref, useAttrs } from 'vue';
+
+import AppInput from './AppInput.vue';
+
+/* Props */
+const props = withDefaults(
+  defineProps<{
+    modelValue?: string | number;
+    filled?: boolean;
+    size?: 'small' | 'large' | undefined;
+    autoTrim?: boolean;
+    showIcon?: boolean;
+  }>(),
+  {
+    showIcon: true,
+  },
+);
+
+/* Emits */
+const emit = defineEmits(['update:modelValue']);
+
+/* Composables */
+const attrs = useAttrs();
+
+/* State */
+const isPasswordVisible = ref(false);
+
+/* Computed */
+const mergedProps = computed(() => ({
+  ...props,
+  ...attrs,
+}));
+
+/* Functions */
+const togglePasswordVisibility = () => {
+  isPasswordVisible.value = !isPasswordVisible.value;
+};
+</script>
+
+<template>
+  <div
+    class="password-input-wrapper d-flex align-items-center position-relative"
+  >
+    <AppInput
+      class="pe-7"
+      v-bind="mergedProps"
+      :type="isPasswordVisible ? 'text' : 'password'"
+      @update:modelValue="$emit('update:modelValue', $event)"
+    />
+    <button
+      v-if="props.showIcon"
+      type="button"
+      class="position-absolute border-0 bg-transparent cursor-pointer"
+      style="right: 10px;"
+      @click="togglePasswordVisibility"
+    >
+      <span :class="isPasswordVisible ? 'bi bi-eye-slash' : 'bi bi-eye'" />
+    </button>
+  </div>
+</template>

--- a/front-end/src/renderer/pages/AccountSetup/components/NewPassword.vue
+++ b/front-end/src/renderer/pages/AccountSetup/components/NewPassword.vue
@@ -14,7 +14,7 @@ import { updateOrganizationCredentials } from '@renderer/services/organizationCr
 import { assertIsLoggedInOrganization, assertUserLoggedIn, getErrorMessage } from '@renderer/utils';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
-import AppInput from '@renderer/components/ui/AppInput.vue';
+import AppPasswordInput from '@renderer/components/ui/AppPasswordInput.vue';
 
 /* Props */
 const props = defineProps<{
@@ -112,31 +112,28 @@ watch(confirmPassword, val => {
     <p class="text-main text-center mt-5">Please enter new password</p>
     <form @submit="handleFormSubmit" class="row justify-content-center w-100 mt-5">
       <div class="col-12 col-md-8 col-lg-6">
-        <AppInput
+        <AppPasswordInput
           v-model="currentPassword"
           :filled="true"
           :class="{ 'is-invalid': currentPasswordInvalid }"
-          type="password"
           placeholder="Current Password"
         />
         <div v-if="currentPasswordInvalid" class="invalid-feedback">
           Current password is required.
         </div>
-        <AppInput
+        <AppPasswordInput
           v-model="newPassword"
           :filled="true"
           class="mt-4"
           :class="{ 'is-invalid': newPasswordInvalid }"
-          type="password"
           placeholder="New Password"
         />
         <div v-if="newPasswordInvalid" class="invalid-feedback">Invalid password.</div>
-        <AppInput
+        <AppPasswordInput
           v-model="confirmPassword"
           :filled="true"
           class="mt-4"
           :class="{ 'is-invalid': inputConfirmPasswordInvalid }"
-          type="password"
           placeholder="Confirm New Password"
         />
         <div v-if="inputConfirmPasswordInvalid" class="invalid-feedback">

--- a/front-end/src/renderer/pages/Migrate/components/DecryptRecoveryPhraseForm.vue
+++ b/front-end/src/renderer/pages/Migrate/components/DecryptRecoveryPhraseForm.vue
@@ -2,7 +2,7 @@
 import { ref, watch } from 'vue';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
-import AppInput from '@renderer/components/ui/AppInput.vue';
+import AppPasswordInput from '@renderer/components/ui/AppPasswordInput.vue';
 
 /* Types */
 export type ModelValue = {
@@ -53,10 +53,9 @@ watch(inputRecoveryPhrasePassword, () => (inputRecoveryPhrasePasswordError.value
       <!-- Mnemonic Password -->
       <div class="mt-5">
         <label data-testid="label-password" class="form-label">Recovery Phrase Password</label>
-        <AppInput
+        <AppPasswordInput
           v-model="inputRecoveryPhrasePassword"
           :filled="true"
-          type="password"
           :class="{ 'is-invalid': inputRecoveryPhrasePasswordError }"
           placeholder="Enter password"
           data-testid="input-recovery-phrase-decryption-password"

--- a/front-end/src/renderer/pages/Migrate/components/SetupOrganizationForm.vue
+++ b/front-end/src/renderer/pages/Migrate/components/SetupOrganizationForm.vue
@@ -7,6 +7,7 @@ import { isPasswordStrong, isUrl } from '@renderer/utils';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppInput from '@renderer/components/ui/AppInput.vue';
+import AppPasswordInput from '@renderer/components/ui/AppPasswordInput.vue';
 
 /* Types */
 export type ModelValue = {
@@ -145,10 +146,9 @@ watch(inputNewOrganizationPassword, pass => {
         <label data-testid="label-temp-password" class="form-label"
           >Temporary Organization Password</label
         >
-        <AppInput
+        <AppPasswordInput
           v-model="inputTemporaryOrganizationPassword"
           :filled="true"
-          type="password"
           placeholder="Enter password"
           data-testid="input-temporary-organization-password"
         />
@@ -157,10 +157,9 @@ watch(inputNewOrganizationPassword, pass => {
       <!-- New Organization Password -->
       <div class="mt-4">
         <label data-testid="label-new-password" class="form-label">New Organization Password</label>
-        <AppInput
+        <AppPasswordInput
           v-model="inputNewOrganizationPassword"
           :filled="true"
-          type="password"
           placeholder="Enter password"
           data-testid="input-new-organization-password"
         />

--- a/front-end/src/renderer/pages/Migrate/components/SetupPersonalForm.vue
+++ b/front-end/src/renderer/pages/Migrate/components/SetupPersonalForm.vue
@@ -10,6 +10,7 @@ import { isEmail, isPasswordStrong } from '@renderer/utils';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppInput from '@renderer/components/ui/AppInput.vue';
+import AppPasswordInput from '@renderer/components/ui/AppPasswordInput.vue';
 
 /* Types */
 export type ModelValue =
@@ -213,10 +214,9 @@ watch(inputPassword, pass => {
       <!-- Password -->
       <div :key="useKeychain.toString()">
         <label data-testid="label-password" class="form-label mt-4">Password</label>
-        <AppInput
+        <AppPasswordInput
           v-model="inputPassword"
           :filled="true"
-          type="password"
           :class="{ 'is-invalid': inputPasswordInvalid }"
           :disabled="useKeychain"
           placeholder="Enter password"

--- a/front-end/src/renderer/pages/OrganizationLogin/OrganizationLogin.vue
+++ b/front-end/src/renderer/pages/OrganizationLogin/OrganizationLogin.vue
@@ -17,6 +17,7 @@ import { assertUserLoggedIn, getErrorMessage, isLoggedOutOrganization } from '@r
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppInput from '@renderer/components/ui/AppInput.vue';
 import ForgotPasswordModal from '@renderer/components/ForgotPasswordModal.vue';
+import AppPasswordInput from '@renderer/components/ui/AppPasswordInput.vue';
 
 /* Stores */
 const user = useUserStore();
@@ -115,11 +116,7 @@ onBeforeRouteLeave(async () => {
 
   if (!user.selectedOrganization) return true;
 
-  if (user.selectedOrganization.loginRequired) {
-    return false;
-  }
-
-  return true;
+  return !user.selectedOrganization.loginRequired;
 });
 </script>
 <template>
@@ -141,11 +138,10 @@ onBeforeRouteLeave(async () => {
         />
         <div v-if="inputEmailInvalid" class="invalid-feedback">Invalid e-mail.</div>
         <label class="form-label mt-4">Password</label>
-        <AppInput
+        <AppPasswordInput
           v-model="inputPassword"
           :filled="true"
           data-testid="input-login-password-for-organization"
-          type="password"
           :class="{ 'is-invalid': inputPasswordInvalid }"
           placeholder="Enter password"
         />

--- a/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
@@ -20,8 +20,8 @@ import {
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppModal from '@renderer/components/ui/AppModal.vue';
-import AppInput from '@renderer/components/ui/AppInput.vue';
 import AppCustomIcon from '@renderer/components/ui/AppCustomIcon.vue';
+import AppPasswordInput from '@renderer/components/ui/AppPasswordInput.vue';
 
 /* Stores */
 const user = useUserStore();
@@ -112,20 +112,18 @@ const handleResetData = async () => {
       <h3 class="text-main">Password</h3>
       <div class="form-group mt-4">
         <label class="form-label">Current Password <span class="text-danger">*</span></label>
-        <AppInput
+        <AppPasswordInput
           v-model="currentPassword"
           data-testid="input-current-password"
-          type="password"
           placeholder="Enter Current Password"
           :filled="true"
         />
       </div>
       <div class="mt-4 form-group">
         <label class="form-label">New Password <span class="text-danger">*</span></label>
-        <AppInput
+        <AppPasswordInput
           v-model="newPassword"
           data-testid="input-new-password"
-          type="password"
           placeholder="Enter New Password"
           :filled="true"
         />

--- a/front-end/src/renderer/pages/UserLogin/UserLogin.vue
+++ b/front-end/src/renderer/pages/UserLogin/UserLogin.vue
@@ -27,6 +27,7 @@ import AppInput from '@renderer/components/ui/AppInput.vue';
 import AppModal from '@renderer/components/ui/AppModal.vue';
 import AppCustomIcon from '@renderer/components/ui/AppCustomIcon.vue';
 import AppCheckBox from '@renderer/components/ui/AppCheckBox.vue';
+import AppPasswordInput from '@renderer/components/ui/AppPasswordInput.vue';
 
 /* Stores */
 const user = useUserStore();
@@ -289,10 +290,10 @@ watch(inputEmail, pass => {
           Invalid e-mail.
         </div>
         <label data-testid="label-password" class="form-label mt-4">Password</label>
-        <AppInput
+        <AppPasswordInput
           v-model="inputPassword"
           :filled="true"
-          type="password"
+          :show-icon="!shouldRegister"
           :class="{ 'is-invalid': inputPasswordInvalid }"
           placeholder="Enter password"
           :data-bs-toggle="shouldRegister ? 'tooltip' : ''"


### PR DESCRIPTION
**Description**:
Password inputs have a reveal button added by default. In only a couple of cases, where a confirm password input is present, the reveal button is not visible. 

**Related issue(s)**:

Fixes #1291 
