### PR TITLE
fix: updated color of the dropdown to be the same as other components

### DIFF
--- a/front-end/src/renderer/components/ui/AppDropDown.vue
+++ b/front-end/src/renderer/components/ui/AppDropDown.vue
@@ -67,7 +67,7 @@ watch(
   <div ref="dropdownRef" class="dropdown">
     <AppButton
       :color="(colorOnActive && active) || !colorOnActive ? color : undefined"
-      class="d-flex align-items-center justify-content-center"
+      class="d-flex align-items-center justify-content-center text-body"
       data-bs-toggle="dropdown"
       data-bs-auto-close="true"
       data-bs-popper-config='{"strategy":"fixed"}'


### PR DESCRIPTION
**Description**:
AppDropDown wasn't using the text-body class. This caused the text color to be incorrect in light mode.

**Related issue(s)**:

Fixes #1321 

**Notes for reviewer**:
Thanks for showing me how to do this, Svet!
