### PR TITLE
1147 add feature to resend new user emails

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -639,9 +639,6 @@ This product includes software (@types/ms@0.7.34) developed at
 This product includes software (@types/node-forge@1.3.11) developed at
 (https://github.com/DefinitelyTyped/DefinitelyTyped).
 
-This product includes software (@types/node@20.14.8) developed at
-(https://github.com/DefinitelyTyped/DefinitelyTyped).
-
 This product includes software (@types/node@22.10.1) developed at
 (https://github.com/DefinitelyTyped/DefinitelyTyped).
 
@@ -952,6 +949,10 @@ Copyright Ryan Zimmerman. All Rights Reserved.
 The Initial Developer of atomic-sleep@1.0.0,
 is David Mark Clements (https://github.com/davidmarkclements/atomic-sleep).
 Copyright David Mark Clements. All Rights Reserved.
+
+The Initial Developer of axios@1.7.7,
+is Matt Zabriskie (https://github.com/axios/axios).
+Copyright Matt Zabriskie. All Rights Reserved.
 
 The Initial Developer of axios@1.7.8,
 is Matt Zabriskie (https://github.com/axios/axios).
@@ -2933,7 +2934,7 @@ The Initial Developer of typescript@5.6.3,
 is Microsoft Corp. (https://github.com/microsoft/TypeScript).
 Copyright Microsoft Corp.. All Rights Reserved.
 
-This product includes software (undici-types@5.26.5) developed at
+This product includes software (undici-types@6.20.0) developed at
 (https://github.com/nodejs/undici).
 
 The Initial Developer of unique-filename@2.0.1,

--- a/NOTICE
+++ b/NOTICE
@@ -639,6 +639,9 @@ This product includes software (@types/ms@0.7.34) developed at
 This product includes software (@types/node-forge@1.3.11) developed at
 (https://github.com/DefinitelyTyped/DefinitelyTyped).
 
+This product includes software (@types/node@20.14.8) developed at
+(https://github.com/DefinitelyTyped/DefinitelyTyped).
+
 This product includes software (@types/node@22.10.1) developed at
 (https://github.com/DefinitelyTyped/DefinitelyTyped).
 
@@ -2930,7 +2933,7 @@ The Initial Developer of typescript@5.6.3,
 is Microsoft Corp. (https://github.com/microsoft/TypeScript).
 Copyright Microsoft Corp.. All Rights Reserved.
 
-This product includes software (undici-types@6.20.0) developed at
+This product includes software (undici-types@5.26.5) developed at
 (https://github.com/nodejs/undici).
 
 The Initial Developer of unique-filename@2.0.1,

--- a/back-end/apps/api/src/auth/auth.service.ts
+++ b/back-end/apps/api/src/auth/auth.service.ts
@@ -48,12 +48,10 @@ export class AuthService {
 
     const existingUser = await this.usersService.getUser({ email: dto.email }, true);
     let user: User;
-    if (existingUser) {
-      console.log(existingUser);
-      return;
-    }
+
     if (existingUser && !existingUser.deletedAt && existingUser.status === UserStatus.NEW) {
-      user = await this.usersService.updateUser(user, { password: tempPassword });
+      const hashedPass = await this.usersService.getSaltedHash(tempPassword);
+      user = await this.usersService.updateUserById(existingUser.id, { password: hashedPass });
     } else {
       user = await this.usersService.createUser(dto.email, tempPassword);
     }

--- a/back-end/apps/api/src/auth/auth.service.ts
+++ b/back-end/apps/api/src/auth/auth.service.ts
@@ -46,7 +46,17 @@ export class AuthService {
   async signUpByAdmin(dto: SignUpUserDto, url: string): Promise<User> {
     const tempPassword = this.generatePassword();
 
-    const user = await this.usersService.createUser(dto.email, tempPassword);
+    const existingUser = await this.usersService.getUser({ email: dto.email }, true);
+    let user: User;
+    if (existingUser) {
+      console.log(existingUser);
+      return;
+    }
+    if (existingUser && !existingUser.deletedAt && existingUser.status === UserStatus.NEW) {
+      user = await this.usersService.updateUser(user, { password: tempPassword });
+    } else {
+      user = await this.usersService.createUser(dto.email, tempPassword);
+    }
 
     this.notificationsService.emit<undefined, NotifyEmailDto>(NOTIFY_EMAIL, {
       subject: 'Hedera Transaction Tool Registration',
@@ -141,7 +151,9 @@ export class AuthService {
   /* Generate a random password */
   private generatePassword() {
     const getRandomLetters = (length: number) =>
-      Array.from({ length }, () => String.fromCharCode(97 + Math.floor(Math.random() * 26))).join('');
+      Array.from({ length }, () => String.fromCharCode(97 + Math.floor(Math.random() * 26))).join(
+        '',
+      );
 
     return `${getRandomLetters(5)}-${getRandomLetters(5)}`;
   }

--- a/back-end/apps/api/test/spec/auth.e2e-spec.ts
+++ b/back-end/apps/api/test/spec/auth.e2e-spec.ts
@@ -161,12 +161,7 @@ describe('Auth (e2e)', () => {
     it('(POST) should update password and resend email if users status is NEW and the sender is an admin', async () => {
       const userRepo = await getRepository(User);
 
-      const user = await userRepo.save({
-        email: validEmail,
-        status: UserStatus.NEW,
-        deletedAt: null,
-        password: 'oldHashedPassword',
-      });
+      const user = await getUser('userNew');
 
       await endpoint
         .post({ email: user.email }, null, adminAuthToken)
@@ -175,21 +170,23 @@ describe('Auth (e2e)', () => {
           expect(res.body).toEqual({
             email: user.email,
             createdAt: expect.any(String),
+            id: expect.any(Number),
           });
         });
 
       const updatedUser = await userRepo.findOne({ where: { email: user.email } });
 
       expect(updatedUser).toBeDefined();
-      expect(updatedUser?.password).not.toBe('oldHashedPassword');
+      expect(updatedUser?.password).not.toBe(user.password);
       expect(updatedUser?.status).toBe(UserStatus.NEW);
     });
 
     it('(POST) should not register new user if already exists', async () => {
+      const user = await getUser('user');
       await endpoint
         .post(
           {
-            email: validEmail,
+            email: user.email,
           },
           null,
           adminAuthToken,

--- a/front-end/src/renderer/components/Contacts/ContactDetails.vue
+++ b/front-end/src/renderer/components/Contacts/ContactDetails.vue
@@ -15,7 +15,7 @@ import { addContact, updateContact } from '@renderer/services/contactsService';
 import { getAccountsByPublicKeysParallel } from '@renderer/services/mirrorNodeDataService';
 import { signUp } from '@renderer/services/organization';
 
-import { isLoggedInOrganization, isUserLoggedIn } from '@renderer/utils';
+import { getErrorMessage, isLoggedInOrganization, isUserLoggedIn } from '@renderer/utils';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppInput from '@renderer/components/ui/AppInput.vue';
@@ -102,7 +102,7 @@ const handleResend = async () => {
     }
     toast.success('Email sent successfully');
   } catch (error: unknown) {
-    toast.error('Error while sending email. Please try again.');
+    toast.error(getErrorMessage(error, 'Error while sending email. Please try again.'));
   }
 };
 

--- a/front-end/src/renderer/components/Contacts/ContactDetails.vue
+++ b/front-end/src/renderer/components/Contacts/ContactDetails.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { HederaAccount } from '@prisma/client';
 import type { AccountInfo, Contact } from '@main/shared/interfaces';
+import { useToast } from 'vue-toast-notification';
 
 import { onBeforeMount, ref, watch } from 'vue';
 
@@ -12,6 +13,7 @@ import useContactsStore from '@renderer/stores/storeContacts';
 
 import { addContact, updateContact } from '@renderer/services/contactsService';
 import { getAccountsByPublicKeysParallel } from '@renderer/services/mirrorNodeDataService';
+import { signUp } from '@renderer/services/organization';
 
 import { isLoggedInOrganization, isUserLoggedIn } from '@renderer/utils';
 
@@ -25,6 +27,9 @@ const props = defineProps<{
   contact: Contact;
   linkedAccounts: HederaAccount[];
 }>();
+
+/* Composables */
+const toast = useToast();
 
 /* Stores */
 const user = useUserStore();
@@ -89,6 +94,18 @@ const handleAccountsLookup = async () => {
   );
 };
 
+const handleResend = async () => {
+  try {
+    if (user.selectedOrganization?.serverUrl) {
+      const email = props.contact.user.email;
+      await signUp(user.selectedOrganization.serverUrl, email);
+    }
+    toast.success('Email sent successfully');
+  } catch (error: unknown) {
+    toast.error('Error while sending email. Please try again.');
+  }
+};
+
 /* Hooks */
 onBeforeMount(async () => {
   await handleAccountsLookup();
@@ -126,13 +143,23 @@ watch(
         ></span>
       </p>
     </div>
-    <div class="d-flex gap-3">
+    <div
+      v-if="
+        isLoggedInOrganization(user.selectedOrganization) &&
+        user.selectedOrganization.admin &&
+        contact.user.id !== user.selectedOrganization.userId
+      "
+      class="d-flex gap-3"
+    >
       <AppButton
-        v-if="
-          isLoggedInOrganization(user.selectedOrganization) &&
-          user.selectedOrganization.admin &&
-          contact.user.id !== user.selectedOrganization.userId
-        "
+        v-if="contact.user.status === 'NEW'"
+        data-testid="button-resend-email-from-contact-list"
+        class="min-w-unset"
+        color="secondary"
+        @click="handleResend"
+        >Resend email</AppButton
+      >
+      <AppButton
         data-testid="button-remove-account-from-contact-list"
         class="min-w-unset"
         color="danger"


### PR DESCRIPTION
**Description**:

Backend Changes:

- Integrated the resend email with temporary password feature (only admin)  to newly registered users.
- Unit Tests:
Added unit tests to validate the logic for resending emails and updating user details.
- e2e Tests:
Implemented e2e tests to ensure the feature works as expected through API endpoints.

Frontend Changes:

- Updated the frontend interface to support the resend email feature.
- Added UI element for triggering the resend email action (only to users with status === 'NEW').
- Included error and success handling (toast messages).


**Related issue(s)**:
#1147 


