### PR TITLE
feat: improve accounts & files pages

### DIFF
--- a/automation/pages/AccountPage.js
+++ b/automation/pages/AccountPage.js
@@ -16,6 +16,7 @@ class AccountPage extends BasePage {
   // Buttons
   editButtonSelector = 'button-edit-account';
   removeButtonSelector = 'button-remove-account-card';
+  removeMultipleButtonSelector = 'button-remove-multiple-accounts';
   addNewButtonSelector = 'button-add-new-account';
   createNewLinkSelector = 'link-create-new-account';
   addExistingLinkSelector = 'link-add-existing-account';
@@ -53,6 +54,10 @@ class AccountPage extends BasePage {
 
   async clickOnRemoveButton() {
     await this.click(this.removeButtonSelector);
+  }
+
+  async clickOnRemoveMultipleButton() {
+    await this.click(this.removeMultipleButtonSelector);
   }
 
   async clickOnAddNewButton() {

--- a/automation/pages/FilePage.js
+++ b/automation/pages/FilePage.js
@@ -13,6 +13,7 @@ class FilePage extends BasePage {
 
   // Buttons
   removeFileCardButtonSelector = 'button-remove-file-card';
+  removeMultipleButtonSelector = 'button-remove-multiple-files';
   updateFileButtonSelector = 'button-update-file';
   appendFileButtonSelector = 'button-append-file';
   readFileButtonSelector = 'button-read-file';
@@ -45,6 +46,10 @@ class FilePage extends BasePage {
 
   async clickOnRemoveFileCardButton() {
     await this.click(this.removeFileCardButtonSelector);
+  }
+
+  async clickOnRemoveMultipleButton() {
+    await this.click(this.removeMultipleButtonSelector);
   }
 
   async clickOnUpdateFileButton() {

--- a/automation/tests/workflowTests.test.js
+++ b/automation/tests/workflowTests.test.js
@@ -193,7 +193,7 @@ test.describe('Workflow tests', () => {
     await accountPage.clickOnAccountCheckbox(accountFromList);
     await accountPage.clickOnAccountCheckbox(newAccountId);
     await loginPage.waitForToastToDisappear();
-    await accountPage.clickOnRemoveButton();
+    await accountPage.clickOnRemoveMultipleButton();
     await accountPage.unlinkAccounts();
     await accountPage.addAccountToUnliked(newAccountId);
     await accountPage.addAccountToUnliked(accountFromList);
@@ -343,7 +343,7 @@ test.describe('Workflow tests', () => {
     await filePage.clickOnSelectManyFilesButton();
     await filePage.clickOnFileCheckbox(fileFromPage);
     await filePage.clickOnFileCheckbox(fileId);
-    await filePage.clickOnRemoveFileCardButton();
+    await filePage.clickOnRemoveMultipleButton();
     await filePage.clickOnConfirmUnlinkFileButton();
 
     await filePage.addFileToUnliked(fileFromPage);

--- a/front-end/src/main/windows/mainWindow.ts
+++ b/front-end/src/main/windows/mainWindow.ts
@@ -21,7 +21,7 @@ async function createWindow() {
     width: Math.round(width * 0.9),
     height: Math.round(height * 0.9),
     minWidth: 960,
-    minHeight: 400,
+    minHeight: 750,
     webPreferences: {
       preload,
       nodeIntegration: false,

--- a/front-end/src/renderer/components/KeyPair/ImportEncrypted/components/EncryptedKeysBox.vue
+++ b/front-end/src/renderer/components/KeyPair/ImportEncrypted/components/EncryptedKeysBox.vue
@@ -52,17 +52,17 @@ watch(
 
 <template>
   <div v-if="keys.length > 0" class="border rounded p-3 mt-4">
+    <div class="d-flex flex-row align-items-center gap-3 border-bottom mb-2">
+      <AppCheckBox
+        :checked="isAllSelected"
+        @update:checked="handleSelectAll"
+        name="select-all-keys"
+        data-testid="checkbox-select-all-keys-component"
+        class="cursor-pointer"
+      />
+      <span>Select all</span>
+    </div>
     <ul class="overflow-x-hidden" style="max-height: 30vh">
-      <li class="d-flex flex-row align-items-center gap-3 border-bottom mb-2">
-        <AppCheckBox
-          :checked="isAllSelected"
-          @update:checked="handleSelectAll"
-          name="select-all-keys"
-          :data-testid="'checkbox-select-all-keys-component'"
-          class="cursor-pointer"
-        />
-        <span>Select all</span>
-      </li>
       <li v-for="(key, index) in keys" :key="key" class="d-flex flex-row align-items-center gap-3">
         <AppCheckBox
           :checked="localSelectedKeys.includes(key)"

--- a/front-end/src/renderer/pages/Accounts/Accounts.vue
+++ b/front-end/src/renderer/pages/Accounts/Accounts.vue
@@ -320,7 +320,7 @@ onMounted(async () => {
                 class="min-w-unset ms-auto"
                 color="danger"
                 :disabled="selectedAccountIds.length < 1"
-                data-testid="button-remove-account-card"
+                data-testid="button-remove-multiple-accounts"
                 @click="isUnlinkAccountModalShown = true"
                 ><span class="bi bi-trash"></span
               ></AppButton>

--- a/front-end/src/renderer/pages/Accounts/Accounts.vue
+++ b/front-end/src/renderer/pages/Accounts/Accounts.vue
@@ -103,6 +103,8 @@ const handleUnlinkAccount = async () => {
 
   isUnlinkAccountModalShown.value = false;
 
+  selectedAccountIds.value = [];
+  selectAll.value = false;
   toast.success('Account Unlinked!');
 };
 
@@ -238,64 +240,61 @@ onMounted(async () => {
             </ul>
           </div>
           <div class="d-flex align-items-center justify-content-between my-3">
-            <div class="rounded px-3">
-              <div class="dropdown">
-                <AppButton
-                  class="d-flex align-items-center text-dark-emphasis min-w-unset border-0 p-0"
-                  data-bs-toggle="dropdown"
-                  ><i class="bi bi-arrow-down-up me-2"></i> Sort by</AppButton
+            <div class="dropdown">
+              <AppButton
+                class="d-flex align-items-center text-dark-emphasis min-w-unset border-0 p-0"
+                data-bs-toggle="dropdown"
+                ><i class="bi bi-arrow-down-up me-2"></i> Sort by</AppButton
+              >
+              <ul class="dropdown-menu text-small">
+                <li
+                  class="dropdown-item"
+                  :selected="sorting.account_id === 'asc' ? true : undefined"
+                  @click="handleSortAccounts('account_id', 'asc')"
                 >
-                <ul class="dropdown-menu text-small">
-                  <li
-                    class="dropdown-item"
-                    :selected="sorting.account_id === 'asc' ? true : undefined"
-                    @click="handleSortAccounts('account_id', 'asc')"
-                  >
-                    Account ID Asc
-                  </li>
-                  <li
-                    class="dropdown-item"
-                    :selected="sorting.account_id === 'desc' ? true : undefined"
-                    @click="handleSortAccounts('account_id', 'desc')"
-                  >
-                    Account ID Dsc
-                  </li>
-                  <li
-                    class="dropdown-item"
-                    :selected="sorting.nickname === 'asc' ? true : undefined"
-                    @click="handleSortAccounts('nickname', 'asc')"
-                  >
-                    Nickname A-Z
-                  </li>
-                  <li
-                    class="dropdown-item"
-                    :selected="sorting.nickname === 'desc' ? true : undefined"
-                    @click="handleSortAccounts('nickname', 'desc')"
-                  >
-                    Nickname Z-A
-                  </li>
-                  <li
-                    class="dropdown-item"
-                    :selected="sorting.created_at === 'asc' ? true : undefined"
-                    @click="handleSortAccounts('created_at', 'asc')"
-                  >
-                    Date Added Asc
-                  </li>
-                  <li
-                    class="dropdown-item"
-                    :selected="sorting.created_at === 'desc' ? true : undefined"
-                    @click="handleSortAccounts('created_at', 'desc')"
-                  >
-                    Date Added Dsc
-                  </li>
-                </ul>
-              </div>
+                  Account ID Asc
+                </li>
+                <li
+                  class="dropdown-item"
+                  :selected="sorting.account_id === 'desc' ? true : undefined"
+                  @click="handleSortAccounts('account_id', 'desc')"
+                >
+                  Account ID Dsc
+                </li>
+                <li
+                  class="dropdown-item"
+                  :selected="sorting.nickname === 'asc' ? true : undefined"
+                  @click="handleSortAccounts('nickname', 'asc')"
+                >
+                  Nickname A-Z
+                </li>
+                <li
+                  class="dropdown-item"
+                  :selected="sorting.nickname === 'desc' ? true : undefined"
+                  @click="handleSortAccounts('nickname', 'desc')"
+                >
+                  Nickname Z-A
+                </li>
+                <li
+                  class="dropdown-item"
+                  :selected="sorting.created_at === 'asc' ? true : undefined"
+                  @click="handleSortAccounts('created_at', 'asc')"
+                >
+                  Date Added Asc
+                </li>
+                <li
+                  class="dropdown-item"
+                  :selected="sorting.created_at === 'desc' ? true : undefined"
+                  @click="handleSortAccounts('created_at', 'desc')"
+                >
+                  Date Added Dsc
+                </li>
+              </ul>
             </div>
 
-            <div>
+            <div class="transition-bg rounded px-3" :class="{ 'bg-secondary': selectMany }">
               <AppButton
-                class="d-flex transition-bg align-items-center text-dark-emphasis min-w-unset border-0 p-3"
-                :class="{ 'bg-secondary': selectMany }"
+                class="d-flex align-items-center text-dark-emphasis min-w-unset border-0 p-1"
                 data-testid="button-select-many-accounts"
                 @click="handleToggleSelectMode"
               >
@@ -306,7 +305,7 @@ onMounted(async () => {
 
           <hr class="separator mb-5" />
           <div class="fill-remaining pe-3">
-            <div v-if="selectMany" class="d-flex flex-row flex-nowrap mb-4">
+            <div v-if="selectMany" class="d-flex flex-row align-items-center flex-nowrap mb-4">
               <AppCheckBox
                 name="select-card"
                 class="cursor-pointer"
@@ -315,6 +314,15 @@ onMounted(async () => {
                 @update:checked="handleSelectAllAccounts"
               />
               <label class="ms-2">Select all</label>
+              <AppButton
+                size="small"
+                class="min-w-unset ms-auto"
+                color="danger"
+                :disabled="selectedAccountIds.length < 1"
+                data-testid="button-remove-account-card"
+                @click="isUnlinkAccountModalShown = true"
+                ><span class="bi bi-trash"></span
+              ></AppButton>
             </div>
             <template v-for="(account, index) in accounts" :key="account.account_id">
               <div class="d-flex align-items-center mt-3">
@@ -387,6 +395,7 @@ onMounted(async () => {
                 </div>
                 <div class="d-flex gap-3">
                   <AppButton
+                    v-if="!selectMany"
                     class="min-w-unset"
                     color="danger"
                     :disabled="selectedAccountIds.length < 1"

--- a/front-end/src/renderer/pages/Accounts/Accounts.vue
+++ b/front-end/src/renderer/pages/Accounts/Accounts.vue
@@ -151,9 +151,9 @@ const handleSortAccounts = async (
   await fetchAccounts();
 };
 
-const handleSelectAllAccounts = (isChecked: boolean) => {
-  selectAll.value = isChecked;
-  if (isChecked) {
+const handleSelectAllAccounts = () => {
+  selectAll.value = !selectAll.value;
+  if (selectAll.value) {
     selectedAccountIds.value = accounts.value.map(account => account.account_id);
   } else {
     selectedAccountIds.value = [];
@@ -306,14 +306,15 @@ onMounted(async () => {
           <hr class="separator mb-5" />
           <div class="fill-remaining pe-3">
             <div v-if="selectMany" class="d-flex flex-row align-items-center flex-nowrap mb-4">
-              <AppCheckBox
-                name="select-card"
-                class="cursor-pointer"
-                type="checkbox"
-                :checked="selectAll"
-                @update:checked="handleSelectAllAccounts"
-              />
-              <label class="ms-2">Select all</label>
+              <div class="cursor-pointer d-flex" @click="handleSelectAllAccounts">
+                <AppCheckBox
+                  name="select-card"
+                  class="cursor-pointer"
+                  type="checkbox"
+                  :checked="selectAll"
+                />
+                <span class="ms-4">Select all</span>
+              </div>
               <AppButton
                 size="small"
                 class="min-w-unset ms-auto"

--- a/front-end/src/renderer/pages/Accounts/Accounts.vue
+++ b/front-end/src/renderer/pages/Accounts/Accounts.vue
@@ -59,7 +59,7 @@ const hbarDollarAmount = computed(() => {
   return getDollarAmount(network.currentRate, accountData.accountInfo.value.balance.toBigNumber());
 });
 
-const selectAll = computed(() => {
+const allSelected = computed(() => {
   return (
     selectedAccountIds.value.length > 0 && selectedAccountIds.value.length === accounts.value.length
   );
@@ -154,7 +154,7 @@ const handleSortAccounts = async (
 };
 
 const handleSelectAllAccounts = () => {
-  if (selectedAccountIds.value.length !== accounts.value.length) {
+  if (!allSelected.value) {
     selectedAccountIds.value = accounts.value.map(account => account.account_id);
   } else {
     selectedAccountIds.value = [];
@@ -311,7 +311,7 @@ onMounted(async () => {
                   name="select-card"
                   class="cursor-pointer"
                   type="checkbox"
-                  :checked="selectAll"
+                  :checked="allSelected"
                 />
                 <span class="ms-4">Select all</span>
               </div>
@@ -405,7 +405,7 @@ onMounted(async () => {
                     ><span class="bi bi-trash"></span> Remove</AppButton
                   >
                   <div
-                    v-if="!accountData.accountInfo.value?.deleted && !selectMany && !selectAll"
+                    v-if="!accountData.accountInfo.value?.deleted && !selectMany && !allSelected"
                     class="border-start ps-3"
                   >
                     <div class="dropdown">

--- a/front-end/src/renderer/pages/Accounts/Accounts.vue
+++ b/front-end/src/renderer/pages/Accounts/Accounts.vue
@@ -49,7 +49,6 @@ const sorting = ref<{
   created_at: 'desc',
 });
 const selectMany = ref(false);
-const selectAll = ref(false);
 
 /* Computed */
 const hbarDollarAmount = computed(() => {
@@ -58,6 +57,12 @@ const hbarDollarAmount = computed(() => {
   }
 
   return getDollarAmount(network.currentRate, accountData.accountInfo.value.balance.toBigNumber());
+});
+
+const selectAll = computed(() => {
+  return (
+    selectedAccountIds.value.length > 0 && selectedAccountIds.value.length === accounts.value.length
+  );
 });
 
 /* Handlers */
@@ -72,7 +77,6 @@ const handleSelectAccount = (accountId: string) => {
     accountData.accountId.value = accountId;
     selectedAccountIds.value = [accountId];
   }
-  selectAll.value = selectedAccountIds.value.length === accounts.value.length;
 };
 
 const handleCheckBoxUpdate = (isChecked: boolean, accountId: string) => {
@@ -88,7 +92,6 @@ const handleCheckBoxUpdate = (isChecked: boolean, accountId: string) => {
           : accounts.value[0].account_id || '';
     }
   }
-  selectAll.value = selectedAccountIds.value.length === accounts.value.length;
 };
 
 const handleUnlinkAccount = async () => {
@@ -104,7 +107,6 @@ const handleUnlinkAccount = async () => {
   isUnlinkAccountModalShown.value = false;
 
   selectedAccountIds.value = [];
-  selectAll.value = false;
   toast.success('Account Unlinked!');
 };
 
@@ -152,8 +154,7 @@ const handleSortAccounts = async (
 };
 
 const handleSelectAllAccounts = () => {
-  selectAll.value = !selectAll.value;
-  if (selectAll.value) {
+  if (selectedAccountIds.value.length !== accounts.value.length) {
     selectedAccountIds.value = accounts.value.map(account => account.account_id);
   } else {
     selectedAccountIds.value = [];
@@ -162,7 +163,6 @@ const handleSelectAllAccounts = () => {
 
 const handleToggleSelectMode = () => {
   selectMany.value = !selectMany.value;
-  selectAll.value = false;
   if (selectMany.value === false) {
     selectedAccountIds.value = accounts.value.length > 0 ? [accounts.value[0].account_id] : [];
   } else {

--- a/front-end/src/renderer/pages/Accounts/Accounts.vue
+++ b/front-end/src/renderer/pages/Accounts/Accounts.vue
@@ -405,7 +405,7 @@ onMounted(async () => {
                     ><span class="bi bi-trash"></span> Remove</AppButton
                   >
                   <div
-                    v-if="!accountData.accountInfo.value?.deleted && !selectMany && !allSelected"
+                    v-if="!accountData.accountInfo.value?.deleted && !selectMany"
                     class="border-start ps-3"
                   >
                     <div class="dropdown">

--- a/front-end/src/renderer/pages/Files/Files.vue
+++ b/front-end/src/renderer/pages/Files/Files.vue
@@ -153,7 +153,7 @@ const selectedFileIdWithChecksum = computed(
       .split('-'),
 );
 
-const selectAll = computed(() => {
+const allSelected = computed(() => {
   return selectedFileIds.value.length > 0 && selectedFileIds.value.length === files.value.length;
 });
 
@@ -285,7 +285,7 @@ const handleSortFiles = async (
 };
 
 const handleSelectAllFiles = () => {
-  if (selectedFileIds.value.length !== files.value.length) {
+  if (!allSelected.value) {
     selectedFileIds.value = files.value.map(file => file.file_id);
   } else {
     selectedFileIds.value = [];
@@ -506,7 +506,7 @@ watch(files, newFiles => {
                   name="select-card"
                   class="cursor-pointer"
                   type="checkbox"
-                  :checked="selectAll"
+                  :checked="allSelected"
                 />
                 <span class="ms-4">Select all</span>
               </div>

--- a/front-end/src/renderer/pages/Files/Files.vue
+++ b/front-end/src/renderer/pages/Files/Files.vue
@@ -515,7 +515,7 @@ watch(files, newFiles => {
                 class="min-w-unset ms-auto"
                 color="danger"
                 :disabled="selectedFileIds.length < 1"
-                data-testid="button-remove-account-card"
+                data-testid="button-remove-multiple-files"
                 @click="isUnlinkFileModalShown = true"
                 ><span class="bi bi-trash"></span
               ></AppButton>

--- a/front-end/src/renderer/pages/Files/Files.vue
+++ b/front-end/src/renderer/pages/Files/Files.vue
@@ -283,9 +283,9 @@ const handleSortFiles = async (
   await fetchFiles();
 };
 
-const handleSelectAllAccounts = (isChecked: boolean) => {
-  selectAll.value = isChecked;
-  if (isChecked) {
+const handleSelectAllFiles = () => {
+  selectAll.value = !selectAll.value;
+  if (selectAll.value) {
     selectedFileIds.value = files.value.map(file => file.file_id);
   } else {
     selectedFileIds.value = [];
@@ -502,14 +502,15 @@ watch(files, newFiles => {
 
           <div class="fill-remaining pe-3">
             <div v-if="selectMany" class="d-flex flex-row align-items-center flex-nowrap mb-4">
-              <AppCheckBox
-                name="select-card"
-                class="cursor-pointer"
-                type="checkbox"
-                :checked="selectAll"
-                @update:checked="handleSelectAllAccounts"
-              />
-              <label class="ms-2">Select all</label>
+              <div class="d-flex cursor-pointer" @click="handleSelectAllFiles">
+                <AppCheckBox
+                  name="select-card"
+                  class="cursor-pointer"
+                  type="checkbox"
+                  :checked="selectAll"
+                />
+                <span class="ms-4">Select all</span>
+              </div>
               <AppButton
                 size="small"
                 class="min-w-unset ms-auto"

--- a/front-end/src/renderer/pages/Files/Files.vue
+++ b/front-end/src/renderer/pages/Files/Files.vue
@@ -138,7 +138,6 @@ const sorting = ref<{
   created_at: 'desc',
 });
 const selectMany = ref(false);
-const selectAll = ref(false);
 
 /* Computed */
 const selectedFileInfo = computed(() =>
@@ -153,6 +152,10 @@ const selectedFileIdWithChecksum = computed(
       .toStringWithChecksum(network.client as Client)
       .split('-'),
 );
+
+const selectAll = computed(() => {
+  return selectedFileIds.value.length > 0 && selectedFileIds.value.length === files.value.length;
+});
 
 /* Composables */
 const toast = useToast();
@@ -185,7 +188,6 @@ const handleCheckBoxUpdate = (isChecked: boolean, fileId: string) => {
           : files.value[0] || null;
     }
   }
-  selectAll.value = selectedFileIds.value.length === files.value.length;
 };
 
 const handleUnlinkFile = async () => {
@@ -205,7 +207,6 @@ const handleUnlinkFile = async () => {
   isUnlinkFileModalShown.value = false;
 
   selectedFileIds.value = [];
-  selectAll.value = false;
   toast.success('File Unlinked!');
 };
 
@@ -284,8 +285,7 @@ const handleSortFiles = async (
 };
 
 const handleSelectAllFiles = () => {
-  selectAll.value = !selectAll.value;
-  if (selectAll.value) {
+  if (selectedFileIds.value.length !== files.value.length) {
     selectedFileIds.value = files.value.map(file => file.file_id);
   } else {
     selectedFileIds.value = [];
@@ -294,7 +294,6 @@ const handleSelectAllFiles = () => {
 
 const handleToggleSelectMode = () => {
   selectMany.value = !selectMany.value;
-  selectAll.value = false;
   if (selectMany.value === false) {
     selectedFileIds.value = files.value.length > 0 ? [files.value[0].file_id] : [];
   } else {

--- a/front-end/src/renderer/pages/Files/Files.vue
+++ b/front-end/src/renderer/pages/Files/Files.vue
@@ -138,6 +138,7 @@ const sorting = ref<{
   created_at: 'desc',
 });
 const selectMany = ref(false);
+const selectAll = ref(false);
 
 /* Computed */
 const selectedFileInfo = computed(() =>
@@ -184,6 +185,7 @@ const handleCheckBoxUpdate = (isChecked: boolean, fileId: string) => {
           : files.value[0] || null;
     }
   }
+  selectAll.value = selectedFileIds.value.length === files.value.length;
 };
 
 const handleUnlinkFile = async () => {
@@ -202,6 +204,8 @@ const handleUnlinkFile = async () => {
 
   isUnlinkFileModalShown.value = false;
 
+  selectedFileIds.value = [];
+  selectAll.value = false;
   toast.success('File Unlinked!');
 };
 
@@ -277,6 +281,25 @@ const handleSortFiles = async (
   };
 
   await fetchFiles();
+};
+
+const handleSelectAllAccounts = (isChecked: boolean) => {
+  selectAll.value = isChecked;
+  if (isChecked) {
+    selectedFileIds.value = files.value.map(file => file.file_id);
+  } else {
+    selectedFileIds.value = [];
+  }
+};
+
+const handleToggleSelectMode = () => {
+  selectMany.value = !selectMany.value;
+  selectAll.value = false;
+  if (selectMany.value === false) {
+    selectedFileIds.value = files.value.length > 0 ? [files.value[0].file_id] : [];
+  } else {
+    selectedFileIds.value = [];
+  }
 };
 
 /* Functions */
@@ -467,25 +490,40 @@ watch(files, newFiles => {
             </div>
             <div class="transition-bg rounded px-3" :class="{ 'bg-secondary': selectMany }">
               <AppButton
-                class="d-flex align-items-center text-dark-emphasis min-w-unset border-0 p-0"
+                class="d-flex align-items-center text-dark-emphasis min-w-unset border-0 p-1"
                 data-testid="button-select-many-files"
-                @click="
-                  selectMany = !selectMany;
-                  selectedFileIds = [];
-                "
+                @click="handleToggleSelectMode"
               >
-                <i class="bi bi-check-all text-headline me-2"></i> Select many</AppButton
+                <i class="bi bi-check-all text-headline me-2"></i> Select</AppButton
               >
             </div>
           </div>
           <hr class="separator mb-5" />
 
           <div class="fill-remaining pe-3">
+            <div v-if="selectMany" class="d-flex flex-row align-items-center flex-nowrap mb-4">
+              <AppCheckBox
+                name="select-card"
+                class="cursor-pointer"
+                type="checkbox"
+                :checked="selectAll"
+                @update:checked="handleSelectAllAccounts"
+              />
+              <label class="ms-2">Select all</label>
+              <AppButton
+                size="small"
+                class="min-w-unset ms-auto"
+                color="danger"
+                :disabled="selectedFileIds.length < 1"
+                data-testid="button-remove-account-card"
+                @click="isUnlinkFileModalShown = true"
+                ><span class="bi bi-trash"></span
+              ></AppButton>
+            </div>
             <template v-for="(file, index) in files" :key="file.fileId">
               <div class="d-flex align-items-center mt-3">
                 <div
                   v-if="selectMany"
-                  class="visible-on-hover activate-on-sibling-hover"
                   :selected="selectedFileIds.includes(file.file_id) ? true : undefined"
                 >
                   <AppCheckBox
@@ -497,11 +535,9 @@ watch(files, newFiles => {
                   />
                 </div>
                 <div
-                  class="container-multiple-select activate-on-sibling-hover overflow-hidden w-100 p-4 mt-3"
+                  class="container-multiple-select activate-on-sibling-hover overflow-hidden w-100 p-4"
                   :class="{
-                    'is-selected':
-                      selectedFile?.file_id === file.file_id ||
-                      selectedFileIds.includes(file.file_id),
+                    'is-selected': selectedFileIds.includes(file.file_id),
                   }"
                   @click="handleSelectFile(file.file_id)"
                 >
@@ -550,7 +586,7 @@ watch(files, newFiles => {
                     ></span>
                   </p>
                 </div>
-                <div v-if="selectedFile" class="d-flex gap-3">
+                <div v-if="selectedFile && !selectMany" class="d-flex gap-3">
                   <AppButton
                     class="min-w-unset"
                     color="danger"
@@ -558,7 +594,7 @@ watch(files, newFiles => {
                     data-testid="button-remove-file-card"
                     ><span class="bi bi-trash"></span> Remove</AppButton
                   >
-                  <div v-if="!selectMany" class="border-start ps-3">
+                  <div class="border-start ps-3">
                     <AppButton
                       class="min-w-unset"
                       color="borderless"
@@ -573,7 +609,7 @@ watch(files, newFiles => {
                       ><span class="bi bi-arrow-repeat"></span> Update</AppButton
                     >
                   </div>
-                  <div v-if="!selectMany" class="border-start ps-3">
+                  <div class="border-start ps-3">
                     <AppButton
                       class="min-w-unset"
                       color="borderless"
@@ -588,7 +624,7 @@ watch(files, newFiles => {
                       ><span class="bi bi-plus-square-dotted"></span> Append</AppButton
                     >
                   </div>
-                  <div v-if="!selectMany" class="border-start ps-3">
+                  <div class="border-start ps-3">
                     <AppButton
                       class="min-w-unset"
                       color="borderless"

--- a/front-end/src/renderer/pages/Migrate/Migrate.vue
+++ b/front-end/src/renderer/pages/Migrate/Migrate.vue
@@ -163,7 +163,9 @@ onMounted(async () => {
       <h4 class="text-title text-semi-bold text-center">{{ heading }}</h4>
 
       <h5 v-if="step === 'selectKeys'" class="text-title fs-6 mt-4 text-normal text-center">
-        You can import either one of the decrypted keys or just select all of them.
+        <span>You can import a single/multiple decrypted key(s)</span>
+        <br />
+        <span>or select all of them.</span>
       </h5>
 
       <div class="fill-remaining mt-4">


### PR DESCRIPTION

**Description**:

- Remove Button Visibility:
The "Remove" (for a single item) buttons in Accounts and Files pages are now only visible when the "Select" button is not active.
If the "Select" button is active, the "Remove" button is relocated underneath the "Select" button.

- Files Page:
Code improvement and matching logic with that in Accounts page.

**Related issue(s)**:
#1379 

