### PR TITLE
fix: force inherited the is-invalid class

### DIFF
--- a/front-end/src/renderer/components/ui/AppPasswordInput.vue
+++ b/front-end/src/renderer/components/ui/AppPasswordInput.vue
@@ -11,7 +11,6 @@ defineOptions({
 /* Props */
 const props = withDefaults(
   defineProps<{
-    modelValue?: string | number;
     filled?: boolean;
     size?: 'small' | 'large' | undefined;
     autoTrim?: boolean;
@@ -43,6 +42,7 @@ const togglePasswordVisibility = () => {
 <template>
   <div
     class="password-input-wrapper d-flex align-items-center position-relative"
+    :class="$attrs.class"
   >
     <AppInput
       class="pe-7"

--- a/front-end/src/renderer/pages/UserLogin/components/EmailLoginForm.vue
+++ b/front-end/src/renderer/pages/UserLogin/components/EmailLoginForm.vue
@@ -260,7 +260,6 @@ watch(inputEmail, pass => {
     <AppPasswordInput
       v-model="inputPassword"
       :filled="true"
-      :show-icon="!shouldRegister"
       :class="{ 'is-invalid': inputPasswordInvalid }"
       placeholder="Enter password"
       :data-bs-toggle="shouldRegister ? 'tooltip' : ''"


### PR DESCRIPTION
**Description**:
Force inherited the is-invalid class to the div wrapper in AppPasswordInput.

Bootstrap's is-invalid and invalid-feedback don't behave as expected when the is-invalid component is a compound component that does not bind the attrs to the root component. In this case, the invalid-feedback component looks for the nearest component that has is-invalid and binds to it.

**Related issue(s)**:

Fixes #1378 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
