### PR TITLE
fix: remove drag tooltip on menu page buttons

### DIFF
--- a/front-end/src/renderer/components/Menu.vue
+++ b/front-end/src/renderer/components/Menu.vue
@@ -96,8 +96,12 @@ const organizationOnly = ['/contact-list'];
         )"
         :key="_index"
       >
-        <RouterLink class="link-menu mt-2" :to="item.link" :data-testid="item.testid">
-          <i :class="item.icon"></i>
+        <RouterLink
+          class="link-menu mt-2"
+          :to="item.link"
+          draggable="false"
+          :data-testid="item.testid"
+          ><i :class="item.icon"></i>
           <span>{{ item.title }}</span>
           <span
             v-if="item.notifications"
@@ -111,10 +115,11 @@ const organizationOnly = ['/contact-list'];
 
     <div>
       <RouterLink
-        data-testid="button-menu-settings"
         class="link-menu mt-2"
         to="/settings/general"
         :class="{ active: $route.path.startsWith('/settings') }"
+        draggable="false"
+        data-testid="button-menu-settings"
         ><i class="bi bi-gear"></i><span>Settings</span></RouterLink
       >
     </div>


### PR DESCRIPTION
**Description**:
The page/tab buttons in the menu on the left hand side have now been set to not-draggable.

**Related issue(s)**:

Fixes #1446 
