### PR TITLE
fix: accountId color in KeysTab, fix: AccountIdsSelect

### DIFF
--- a/automation/tests/transactionTests.test.js
+++ b/automation/tests/transactionTests.test.js
@@ -603,7 +603,7 @@ test.describe('Transaction tests', () => {
     expect(transactionMemoFromField).toBe(transactionMemoText);
 
     const allowanceOwnerAccountIdFromPage = await transactionPage.getAllowanceOwnerAccountId();
-    expect(allowanceOwnerAccountIdFromPage).toBe(ownerId);
+    expect(ownerId).toContain(allowanceOwnerAccountIdFromPage);
 
     const allowanceAmountFromField = await transactionPage.getAllowanceAmount();
     expect(allowanceAmountFromField).toBe(amount);

--- a/front-end/src/renderer/components/AccountIdsSelect.vue
+++ b/front-end/src/renderer/components/AccountIdsSelect.vue
@@ -7,6 +7,7 @@ import useUserStore from '@renderer/stores/storeUser';
 import useNetworkStore from '@renderer/stores/storeNetwork';
 
 import { getAll } from '@renderer/services/accountsService';
+import useAccountId from '@renderer/composables/useAccountId';
 
 import { flattenAccountIds, isUserLoggedIn } from '@renderer/utils';
 
@@ -27,6 +28,9 @@ const network = useNetworkStore();
 
 /* State */
 const linkedAccounts = ref<HederaAccount[]>([]);
+
+/* Composables */
+const accountData = useAccountId();
 
 /* Computed */
 const accoundIds = computed(() => flattenAccountIds(user.publicKeyToAccounts));
@@ -78,7 +82,7 @@ watch(
   >
     <template v-for="accountId in accoundIds" :key="accountId">
       <option :value="accountId">
-        {{ accountId }}
+        {{ accountData.getAccountIdWithChecksum(accountId) }}
         {{
           (linkedAccounts.find(la => la.account_id === accountId)?.nickname?.trim() || '').length >
           0

--- a/front-end/src/renderer/pages/Settings/components/KeysTab/KeysTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/KeysTab/KeysTab.vue
@@ -180,15 +180,12 @@ const handleMissingKeyDeleteModal = (id: number) => {
 
 const handleDeleteSelectedClick = () => (isDeleteModalShown.value = true);
 
-const handleAccountString = (returnedData: 'id' | 'checksum', publicKey: string) => {
+const handleAccountString = (publicKey: string) => {
   const account = user.publicKeyToAccounts.find(acc => acc.publicKey === publicKey)?.accounts[0]
     ?.account;
   if (account) {
-    const idWithChecksum = accountData.getAccountIdWithChecksum(account).split('-');
-    if (returnedData !== 'id') {
-      return idWithChecksum[1];
-    }
-    return idWithChecksum[0];
+    const idWithChecksum = accountData.getAccountIdWithChecksum(account);
+    return idWithChecksum;
   }
 };
 
@@ -278,22 +275,18 @@ watch([selectedTab, selectedRecoveryPhrase], () => {
                     user.publicKeyToAccounts.find(acc => acc.publicKey === keyPair.public_key)
                       ?.accounts[0]?.account
                   "
+                  :class="{
+                    'text-mainnet': network.network === CommonNetwork.MAINNET,
+                    'text-testnet': network.network === CommonNetwork.TESTNET,
+                    'text-previewnet': network.network === CommonNetwork.PREVIEWNET,
+                    'text-info': ![
+                      CommonNetwork.MAINNET,
+                      CommonNetwork.TESTNET,
+                      CommonNetwork.PREVIEWNET,
+                    ].includes(network.network),
+                  }"
                 >
-                  <span
-                    :class="{
-                      'text-mainnet': network.network === CommonNetwork.MAINNET,
-                      'text-testnet': network.network === CommonNetwork.TESTNET,
-                      'text-previewnet': network.network === CommonNetwork.PREVIEWNET,
-                      'text-info': ![
-                        CommonNetwork.MAINNET,
-                        CommonNetwork.TESTNET,
-                        CommonNetwork.PREVIEWNET,
-                      ].includes(network.network),
-                    }"
-                  >
-                    {{ handleAccountString('id', keyPair.public_key) }}</span
-                  >
-                  <span>-{{ handleAccountString('checksum', keyPair.public_key) }}</span>
+                  {{ handleAccountString(keyPair.public_key) }}
                 </span>
                 <span v-else>N/A</span>
               </td>
@@ -397,23 +390,19 @@ watch([selectedTab, selectedRecoveryPhrase], () => {
                       user.publicKeyToAccounts.find(acc => acc.publicKey === keyPair.publicKey)
                         ?.accounts[0]?.account
                     "
+                    :class="{
+                      'text-mainnet': network.network === CommonNetwork.MAINNET,
+                      'text-testnet': network.network === CommonNetwork.TESTNET,
+                      'text-previewnet': network.network === CommonNetwork.PREVIEWNET,
+                      'text-info': ![
+                        CommonNetwork.MAINNET,
+                        CommonNetwork.TESTNET,
+                        CommonNetwork.PREVIEWNET,
+                      ].includes(network.network),
+                    }"
                   >
-                    <span
-                      :class="{
-                        'text-mainnet': network.network === CommonNetwork.MAINNET,
-                        'text-testnet': network.network === CommonNetwork.TESTNET,
-                        'text-previewnet': network.network === CommonNetwork.PREVIEWNET,
-                        'text-info': ![
-                          CommonNetwork.MAINNET,
-                          CommonNetwork.TESTNET,
-                          CommonNetwork.PREVIEWNET,
-                        ].includes(network.network),
-                      }"
-                    >
-                      {{ handleAccountString('id', keyPair.publicKey) }}</span
-                    >
-                    <span>-{{ handleAccountString('checksum', keyPair.publicKey) }}</span>
-                  </span>
+                    {{ handleAccountString(keyPair.publicKey) }}</span
+                  >
                   <span v-else>N/A</span>
                 </td>
                 <td :data-testid="`cell-key-type-missing-${index}`">


### PR DESCRIPTION
**Description**:
Color fix of account id in settings -> keys. The account id and it's checksum is now with the color of the user's current network.
AccountIdsSelect (used for selecting account ids in personal mode) is now showing the checksum too.
