### PR TITLE
fix: private keys encryption and password hashing

### DIFF
--- a/back-end/apps/api/src/users/users.service.ts
+++ b/back-end/apps/api/src/users/users.service.ts
@@ -112,7 +112,8 @@ export class UsersService {
   // For the given password, create a salt and hash it with the password.
   // Return the result.
   async getSaltedHash(password: string): Promise<string> {
-    const salt = await bcrypt.genSalt();
+    const saltRounds = 12;
+    const salt = await bcrypt.genSalt(saltRounds);
     return await bcrypt.hash(password, salt);
   }
 }

--- a/front-end/src/main/services/localUser/dataMigration.ts
+++ b/front-end/src/main/services/localUser/dataMigration.ts
@@ -99,7 +99,7 @@ export async function decryptLegacyMnemonic(
   /* Read the encrypted data from the file */
   const data = await fs.promises.readFile(inputPath, { flag: 'r' });
 
-  const iterationCount = 65536;
+  const iterationCount = 1_000_000;
   const keyLength = 32; // 256 bits
   const salt = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
 

--- a/front-end/src/main/utils/crypto.ts
+++ b/front-end/src/main/utils/crypto.ts
@@ -3,7 +3,7 @@ import * as argon2 from 'argon2';
 import * as bcrypt from 'bcrypt';
 
 export function deriveKey(password: string, salt: Buffer) {
-  const iterations = 2560;
+  const iterations = 1_000_000;
   const keyLength = 32;
 
   return crypto.pbkdf2Sync(password, salt, iterations, keyLength, 'sha512');
@@ -49,6 +49,10 @@ export async function hash(data: string, usePseudoSalt = false): Promise<string>
     pseudoSalt = Buffer.from(paddedData.slice(0, 16));
   }
   return await argon2.hash(data, {
+    type: argon2.argon2id,
+    memoryCost: 2 ** 16,
+    timeCost: 3,
+    parallelism: 1,
     salt: pseudoSalt,
   });
 }


### PR DESCRIPTION
**Description**:
PBKDF2 iterations increased to 1,000,000 and those in bcrypt to 12.

Bcrypt is reliable and more 'battle-tested,' but if we need to migrate entirely to Argon2 for some reason, we will rework the branch.

**Related issue(s)**:
#1137 