### PR TITLE
feat: track changes in draft transactions from a group

### DIFF
--- a/front-end/src/renderer/utils/sdk/getData.ts
+++ b/front-end/src/renderer/utils/sdk/getData.ts
@@ -46,26 +46,7 @@ import type {
 import { getMaximumExpirationTime, getMinimumExpirationTime } from '.';
 import { uint8ToHex } from '..';
 
-export type ExtendedTransactionData = Transaction &
-  TransactionCommonData &
-  (
-    | AccountCreateData
-    | AccountUpdateData
-    | AccountDeleteData
-    | ApproveHbarAllowanceData
-    | FileCreateData
-    | FileUpdateData
-    | FileAppendData
-    | FreezeData
-    | TransferHbarData
-    | NodeData
-    | NodeUpdateData
-    | NodeDeleteData
-    | SystemDeleteData
-    | SystemUndeleteData
-  );
-
-export type Test = TransactionCommonData &
+export type ExtendedTransactionData = TransactionCommonData &
   (
     | AccountCreateData
     | AccountUpdateData
@@ -440,7 +421,7 @@ const transactionHandlers = new Map<
 
 export function getAllData(transaction: Transaction) {
   const handler = transactionHandlers.get(
-    transaction.constructor as new (...args: any[]) => ExtendedTransactionData,
+    transaction.constructor as new (...args: any[]) => ExtendedTransactionData & Transaction,
   );
   if (!handler) {
     throw new Error('Unsupported transaction type');

--- a/front-end/src/renderer/utils/sdk/getData.ts
+++ b/front-end/src/renderer/utils/sdk/getData.ts
@@ -46,6 +46,43 @@ import type {
 import { getMaximumExpirationTime, getMinimumExpirationTime } from '.';
 import { uint8ToHex } from '..';
 
+export type ExtendedTransactionData = Transaction &
+  TransactionCommonData &
+  (
+    | AccountCreateData
+    | AccountUpdateData
+    | AccountDeleteData
+    | ApproveHbarAllowanceData
+    | FileCreateData
+    | FileUpdateData
+    | FileAppendData
+    | FreezeData
+    | TransferHbarData
+    | NodeData
+    | NodeUpdateData
+    | NodeDeleteData
+    | SystemDeleteData
+    | SystemUndeleteData
+  );
+
+export type Test = TransactionCommonData &
+  (
+    | AccountCreateData
+    | AccountUpdateData
+    | AccountDeleteData
+    | ApproveHbarAllowanceData
+    | FileCreateData
+    | FileUpdateData
+    | FileAppendData
+    | FreezeData
+    | TransferHbarData
+    | NodeData
+    | NodeUpdateData
+    | NodeDeleteData
+    | SystemDeleteData
+    | SystemUndeleteData
+  );
+
 export const getTransactionCommonData = (transaction: Transaction): TransactionCommonData => {
   const transactionId = transaction.transactionId;
   const payerId = transactionId?.accountId?.toString()?.trim();
@@ -278,4 +315,135 @@ export function getSystemDeleteData(transaction: Transaction): SystemDeleteData 
 export function getSystemUndeleteData(transaction: Transaction): SystemUndeleteData {
   assertTransactionType(transaction, SystemUndeleteTransaction);
   return getSystemData(transaction);
+}
+
+const transactionHandlers = new Map<
+  new (...args: any[]) => Transaction,
+  (transaction: Transaction) => Record<string, any>
+>([
+  [
+    AccountCreateTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getAccountData(tx),
+      ...getAccountCreateData(tx),
+    }),
+  ],
+
+  [
+    AccountUpdateTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getAccountUpdateData(tx),
+    }),
+  ],
+
+  [
+    AccountAllowanceApproveTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getApproveHbarAllowanceTransactionData(tx),
+    }),
+  ],
+
+  [
+    AccountDeleteTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getAccountDeleteData(tx),
+    }),
+  ],
+
+  [
+    FileCreateTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getFileInfoTransactionData(tx),
+      ...getFileCreateTransactionData(tx),
+    }),
+  ],
+
+  [
+    FileUpdateTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getFileInfoTransactionData(tx),
+      ...getFileUpdateTransactionData(tx),
+    }),
+  ],
+
+  [
+    FileAppendTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getFileAppendTransactionData(tx),
+    }),
+  ],
+
+  [
+    FreezeTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getFreezeData(tx),
+    }),
+  ],
+
+  [
+    TransferTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getTransferHbarData(tx),
+    }),
+  ],
+
+  [
+    NodeCreateTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getNodeData(tx),
+    }),
+  ],
+
+  [
+    NodeUpdateTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getNodeData(tx),
+      ...getNodeUpdateData(tx),
+    }),
+  ],
+
+  [
+    NodeDeleteTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getNodeDeleteData(tx),
+    }),
+  ],
+
+  [
+    SystemDeleteTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getSystemDeleteData(tx),
+    }),
+  ],
+
+  [
+    SystemUndeleteTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getSystemUndeleteData(tx),
+    }),
+  ],
+]);
+
+export function getAllData(transaction: Transaction) {
+  const handler = transactionHandlers.get(
+    transaction.constructor as new (...args: any[]) => ExtendedTransactionData,
+  );
+  if (!handler) {
+    throw new Error('Unsupported transaction type');
+  }
+  return handler(transaction);
 }


### PR DESCRIPTION
**Description**:
This code change implements a system to track changes in transaction drafts, ensuring both transaction-specific data, transaction common data and description are monitored. This includes dynamically extracting transaction details based on type, storing initial values, and using computed properties to detect modifications so the modal is triggered only when changes are detected.

PS: Please keep in mind that if you don't change the date/time and save the transaction with the current time then you return to edit it, it will still ask you if you want to keep the changes and that's an expected behaviour.

**Related issue(s)**:
#1445 
