### PR TITLE
fix: explanatory text & icon in modal, fix: skip modal on logout

### DIFF
--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransactionModal.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransactionModal.vue
@@ -22,6 +22,7 @@ import { getTransactionFromBytes, isUserLoggedIn } from '@renderer/utils';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppModal from '@renderer/components/ui/AppModal.vue';
+import AppCustomIcon from '@renderer/components/ui/AppCustomIcon.vue';
 
 /* Props */
 const props = defineProps<{
@@ -133,7 +134,8 @@ async function handleSubmit() {
 }
 
 /* Hooks */
-onBeforeRouteLeave(async () => {
+onBeforeRouteLeave(async to => {
+  if (to.name?.toString().toLocaleLowerCase().includes('login')) return true;
   if (isDiscardFromScratch.value) return true;
   const transactionBytes = getTransactionBytes();
   if (!transactionBytes) return true;
@@ -175,6 +177,9 @@ onBeforeRouteLeave(async () => {
       <div class="text-start">
         <i class="bi bi-x-lg cursor-pointer" @click="isGroupActionModalShown = false"></i>
       </div>
+      <div>
+        <AppCustomIcon :name="'lock'" style="height: 160px" />
+      </div>
       <h2
         v-if="!route.params.seq && !route.query.draftId && !isFromScratch"
         class="text-title text-semi-bold mt-3"
@@ -182,6 +187,9 @@ onBeforeRouteLeave(async () => {
         Add To Group?
       </h2>
       <h2 v-else class="text-title text-semi-bold mt-3">Save Edits?</h2>
+      <p class="text-small text-secondary mt-3">
+        Pick up exactly where you left off, without compromising your flow or losing valuable time.
+      </p>
 
       <hr class="separator my-5" />
 

--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransactionModal.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransactionModal.vue
@@ -209,7 +209,7 @@ onBeforeRouteLeave(async to => {
           >Add To Group</AppButton
         >
         <AppButton v-else color="primary" data-testid="button-save-draft-modal" type="submit"
-          >Save Edits</AppButton
+          >Save</AppButton
         >
       </div>
     </form>


### PR DESCRIPTION
**Description**:
This PR adds the missing explanatory text and icon in modals, along with a missed conditional logic for route leave when the user is logging out. These were not included in the previous bug fix for tracking changes in drafts.

**Related issue(s)**:
#1547 
