### PR TITLE
feat: unsaved group modal, fix: route leave logic

### DIFF
--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseGroupHandler.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseGroupHandler.vue
@@ -75,11 +75,12 @@ const addGroupItem = (
   validStart: Date,
   observers: number[],
   approvers: TransactionApproverDto[],
+  path?: string,
 ) => {
   transactionGroup.addGroupItem(
     buildActionData('add', description, payerId, validStart, observers, approvers),
   );
-  router.push({ name: 'createTransactionGroup' });
+  path ? router.push(path) : router.push({ name: 'createTransactionGroup' });
 };
 
 const editGroupItem = (
@@ -88,11 +89,12 @@ const editGroupItem = (
   validStart: Date,
   observers: number[],
   approvers: TransactionApproverDto[],
+  path?: string,
 ) => {
   transactionGroup.editGroupItem(
     buildActionData('edit', description, payerId, validStart, observers, approvers),
   );
-  router.push({ name: 'createTransactionGroup' });
+  path ? router.push(path) : router.push({ name: 'createTransactionGroup' });
 };
 
 /* Exposes */

--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
@@ -166,7 +166,7 @@ const handleLocalStored = (id: string) => {
   redirectToDetails(router, id);
 };
 
-const handleGroupAction = (action: 'add' | 'edit') => {
+const handleGroupAction = (action: 'add' | 'edit', path?: string) => {
   groupActionTaken.value = true;
   const handle =
     action === 'add'
@@ -178,6 +178,7 @@ const handleGroupAction = (action: 'add' | 'edit') => {
     data.validStart,
     observers.value,
     approvers.value,
+    path,
   );
 };
 
@@ -307,8 +308,8 @@ defineExpose({
 
     <BaseTransactionModal
       :skip="groupActionTaken || isDraftSaved || isProcessed"
-      @addToGroup="handleGroupAction('add')"
-      @editGroupItem="handleGroupAction('edit')"
+      @addToGroup="handleGroupAction('add', $event)"
+      @editGroupItem="handleGroupAction('edit', $event)"
       :get-transaction="() => createTransaction({ ...data } as TransactionCommonData)"
       :description="description || ''"
       :has-data-changed="hasDataChanged"


### PR DESCRIPTION
**Description**:
This PR improves 'on route leave' logic, adds a new modal to warn users when leaving a 'create transaction' page during the process of group creating/editing, and includes a minor refactor of the components used in the flow.

**Related issue(s)**:
none

Fixes #
BaseTransactionModal, BaseTransaction, BaseGroupHandler
