### PR TITLE
fix: scrolling to auto-suggested  in AppAutoComplete, fix: handler function

### DIFF
--- a/front-end/src/renderer/components/ui/AppAutoComplete.vue
+++ b/front-end/src/renderer/components/ui/AppAutoComplete.vue
@@ -26,6 +26,7 @@ const inputRef = ref<InstanceType<typeof AppInput> | null>(null);
 const suggestionRef = ref<HTMLSpanElement | null>(null);
 const dropdownRef = ref<HTMLDivElement | null>(null);
 const itemRefs = ref<HTMLElement[]>([]);
+const lastKeyPressed = ref<string | null>(null);
 
 /* Computed */
 const modelValue = computed({
@@ -73,14 +74,16 @@ const handleKeyDown = (e: KeyboardEvent) => {
       });
     }
   } else if (e.key === 'Tab' && props.modelValue.toString().length > 0) {
-    if (filteredItems.value[selectedIndex.value]) {
+    if (filteredItems.value[selectedIndex.value] && lastKeyPressed.value !== 'Escape') {
       setValue(filteredItems.value[selectedIndex.value]);
     }
     toggleDropdown(false);
   } else if (e.key === 'Enter') {
     e.preventDefault();
+    if (lastKeyPressed.value !== 'Escape') {
+      setValue((modelValue.value + autocompleteSuggestion.value).trim());
+    }
     toggleDropdown(false);
-    setValue((modelValue.value + autocompleteSuggestion.value).trim());
     focusNextElement();
   } else if (e.key === 'Escape') {
     toggleDropdown(false);
@@ -88,6 +91,7 @@ const handleKeyDown = (e: KeyboardEvent) => {
     e.preventDefault();
   }
 
+  lastKeyPressed.value = e.key;
   handleResize();
 };
 
@@ -224,6 +228,7 @@ function setItemRef(el: HTMLElement | null, index: number) {
   }
 }
 
+/* Watchers */
 watch(
   () => selectedIndex.value,
   newValue => {

--- a/front-end/src/renderer/components/ui/AppAutoComplete.vue
+++ b/front-end/src/renderer/components/ui/AppAutoComplete.vue
@@ -148,9 +148,9 @@ function setValue(value: string) {
 }
 
 function scrollToItem(index: number) {
-  if (index < 0) return;
+  const indexToScrollTo = index >= 0 ? index : 0;
   nextTick(() => {
-    itemRefs.value[index]?.scrollIntoView({
+    itemRefs.value[indexToScrollTo]?.scrollIntoView({
       block: 'nearest',
     });
     handleResize();

--- a/front-end/src/renderer/components/ui/AppAutoComplete.vue
+++ b/front-end/src/renderer/components/ui/AppAutoComplete.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watchEffect } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch, watchEffect } from 'vue';
 
 import AppInput from '@renderer/components/ui/AppInput.vue';
 
@@ -50,19 +50,15 @@ const handleKeyDown = (e: KeyboardEvent) => {
     e.preventDefault();
     if (selectedIndex.value > 0) {
       setValue(filteredItems.value[selectedIndex.value - 1]);
-      scrollToItem(selectedIndex.value - 1);
     } else {
       setValue(filteredItems.value[filteredItems.value.length - 1]);
-      scrollToItem(filteredItems.value.length - 1);
     }
   } else if (e.key === 'ArrowDown') {
     e.preventDefault();
     if (selectedIndex.value < filteredItems.value.length - 1) {
       setValue(filteredItems.value[selectedIndex.value + 1]);
-      scrollToItem(selectedIndex.value + 1);
     } else {
       setValue(filteredItems.value[0]);
-      scrollToItem(0);
     }
   } else if (e.key === 'ArrowRight') {
     const inputElement = inputRef.value?.inputRef as HTMLInputElement;
@@ -148,6 +144,7 @@ function setValue(value: string) {
 }
 
 function scrollToItem(index: number) {
+  if (index < 0) return;
   nextTick(() => {
     itemRefs.value[index]?.scrollIntoView({
       block: 'nearest',
@@ -226,6 +223,13 @@ function setItemRef(el: HTMLElement | null, index: number) {
     itemRefs.value[index] = el;
   }
 }
+
+watch(
+  () => selectedIndex.value,
+  newValue => {
+    scrollToItem(newValue);
+  },
+);
 
 /* Hooks */
 onMounted(() => {


### PR DESCRIPTION
**Description**:
This PR includes two fixes for the AppAutoComplete reusable component: ensuring correct scrolling to the auto-suggested account in the dropdown while typing and modifying the handler function logic for the keydown event.

**Related issue(s)**:
#1534 #1536 
