### PR TITLE
feat: filter canceled transactions in a group

### DIFF
--- a/back-end/apps/chain/src/execute/execute.service.ts
+++ b/back-end/apps/chain/src/execute/execute.service.ts
@@ -53,7 +53,8 @@ export class ExecuteService {
       groupItems: transactionGroup.groupItems.filter(
         tx =>
           tx.transaction.status !== TransactionStatus.CANCELED &&
-          tx.transaction.status !== TransactionStatus.EXPIRED,
+          tx.transaction.status !== TransactionStatus.EXPIRED &&
+          tx.transaction.status !== TransactionStatus.WAITING_FOR_SIGNATURES,
       ),
     };
     const transactions: { sdkTransaction: SDKTransaction; transaction: ExecuteTransactionDto }[] =

--- a/back-end/apps/chain/src/execute/execute.service.ts
+++ b/back-end/apps/chain/src/execute/execute.service.ts
@@ -51,7 +51,9 @@ export class ExecuteService {
     const filteredTransactionGroup: ExecuteTransactionGroupDto = {
       ...transactionGroup,
       groupItems: transactionGroup.groupItems.filter(
-        tx => tx.transaction.status !== TransactionStatus.CANCELED,
+        tx =>
+          tx.transaction.status !== TransactionStatus.CANCELED &&
+          tx.transaction.status !== TransactionStatus.EXPIRED,
       ),
     };
     const transactions: { sdkTransaction: SDKTransaction; transaction: ExecuteTransactionDto }[] =

--- a/back-end/apps/chain/src/execute/execute.service.ts
+++ b/back-end/apps/chain/src/execute/execute.service.ts
@@ -48,10 +48,16 @@ export class ExecuteService {
 
   @MurLock(15000, 'transactionGroup.id + "_group"')
   async executeTransactionGroup(transactionGroup: ExecuteTransactionGroupDto) {
+    const filteredTransactionGroup: ExecuteTransactionGroupDto = {
+      ...transactionGroup,
+      groupItems: transactionGroup.groupItems.filter(
+        tx => tx.transaction.status !== TransactionStatus.CANCELED,
+      ),
+    };
     const transactions: { sdkTransaction: SDKTransaction; transaction: ExecuteTransactionDto }[] =
       [];
     // first we need to validate all the transactions, as they all need to be valid before we can execute any of them
-    for (const groupItemDto of transactionGroup.groupItems) {
+    for (const groupItemDto of filteredTransactionGroup.groupItems) {
       const transaction = groupItemDto.transaction;
       try {
         const sdkTransaction = await this.getValidatedSDKTransaction(transaction);

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -140,10 +140,6 @@ const isCreator = computed(() => {
   return creator.value.user.id === user.selectedOrganization.userId;
 });
 
-const isAdmin = computed(() => {
-  return user.selectedOrganization.role === 'admin';
-});
-
 const transactionIsInProgress = computed(
   () =>
     props.organizationTransaction &&
@@ -187,16 +183,12 @@ const canRemind = computed(() => {
     isCreator.value &&
     transactionIsInProgress.value
   );
-})
+});
 
 const canArchive = computed(() => {
   const isManual = props.organizationTransaction?.isManual;
 
-  return (
-    isManual &&
-    isCreator.value &&
-    transactionIsInProgress.value
-  );
+  return isManual && isCreator.value && transactionIsInProgress.value;
 });
 
 const visibleButtons = computed(() => {


### PR DESCRIPTION
**Description**:
Added a filter in the backend's execute service to exclude canceled transactions within a group. Since executeTransactionGroup validates all submitted transactions, this ensures that any transaction canceled in the meantime is properly filtered out.

**Related issue(s)**:
#1376 