### PR TITLE
Export Transaction as .txsig

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -466,7 +466,7 @@ The Initial Developer of @pkgr/core@0.1.1,
 is JounQin (https://github.com/un-ts/pkgr).
 Copyright JounQin. All Rights Reserved.
 
-The Initial Developer of @playwright/test@1.49.1,
+The Initial Developer of @playwright/test@1.50.0,
 is Microsoft Corporation (https://github.com/microsoft/playwright).
 Copyright Microsoft Corporation. All Rights Reserved.
 
@@ -2413,11 +2413,11 @@ The Initial Developer of pino@8.21.0,
 is Matteo Collina (https://github.com/pinojs/pino).
 Copyright Matteo Collina. All Rights Reserved.
 
-The Initial Developer of playwright-core@1.49.1,
+The Initial Developer of playwright-core@1.50.0,
 is Microsoft Corporation (https://github.com/microsoft/playwright).
 Copyright Microsoft Corporation. All Rights Reserved.
 
-The Initial Developer of playwright@1.49.1,
+The Initial Developer of playwright@1.50.0,
 is Microsoft Corporation (https://github.com/microsoft/playwright).
 Copyright Microsoft Corporation. All Rights Reserved.
 

--- a/back-end/apps/api/package.json
+++ b/back-end/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/api",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/chain/package.json
+++ b/back-end/apps/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/chain",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/notifications/package.json
+++ b/back-end/apps/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/notifications",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "back-end",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "",
   "author": "",
   "private": true,

--- a/front-end/electron-builder.yml
+++ b/front-end/electron-builder.yml
@@ -22,10 +22,10 @@ nsis:
 mac:
   notarize: false
   target:
-    - target: 'default'
-      arch:
-        - x64
-        - arm64
+#    - target: 'default'
+#      arch:
+#        - x64
+#        - arm64
     - target: 'pkg'
       arch:
         - x64

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-transaction-tool",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Transaction tool application",
   "author": {
     "name": "Hedera",

--- a/front-end/src/preload/localUser/utils.ts
+++ b/front-end/src/preload/localUser/utils.ts
@@ -27,7 +27,6 @@ export default {
       title: string,
       buttonLabel: string,
       filters: FileFilter[],
-      properties: ('openFile' | 'openDirectory' | 'multiSelections')[],
       message: string,
     ): Promise<void> =>
       ipcRenderer.invoke(
@@ -37,7 +36,6 @@ export default {
         title,
         buttonLabel,
         filters,
-        properties,
         message,
       ),
     sha384: (str: string): Promise<string> => ipcRenderer.invoke('utils:sha384', str),

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -474,11 +474,10 @@ const handleExport = async () => {
   const transactionId = props.sdkTransaction.transactionId?.toString();
   await saveFileNamed(
     bytes,
-    `${transactionId || 'transaction'}.tx`,
+    `${transactionId || 'transaction'}.txsig`,
     'Export transaction',
     'Export',
-    [],
-    ['openDirectory'],
+    [{ name: 'Transaction Files', extensions: ['txsig'] }],
     'Export transaction',
   );
 };

--- a/front-end/src/renderer/services/electronUtilsService.ts
+++ b/front-end/src/renderer/services/electronUtilsService.ts
@@ -63,7 +63,6 @@ export const saveFileNamed = async (
   title: string,
   buttonLabel: string,
   filters: FileFilter[],
-  properties: ('openFile' | 'openDirectory' | 'multiSelections')[],
   message: string,
 ): Promise<void> => {
   try {
@@ -73,7 +72,6 @@ export const saveFileNamed = async (
       title,
       buttonLabel,
       filters,
-      properties,
       message,
     );
   } catch {
@@ -97,7 +95,7 @@ export async function x509BytesFromPem(pem: string | Uint8Array) {
 }
 
 /* Quits the application */
-export const quit = async () =>
-  commonIPCHandler(async () => {
-    return await window.electronAPI.local.utils.quit();
+export const quit = () =>
+  commonIPCHandler(() => {
+    return window.electronAPI.local.utils.quit();
   }, 'Failed quit the application');


### PR DESCRIPTION
**Description**:
Patch 0.9.1 altered how exporting worked. The exported transaction will now have the extension of .txsig. 

This was done to ensure other work flows that use these exported files don't need to change how they work. Also, the concept behind .tx and .txsig was that .tx only contains the transaction, where as .txsig also contains the signatures. All exported transactions from this app will contain signatures, if applicable. 

**Checklist**

- [X] Tested (unit, integration, etc.)
