### PR TITLE
CSV import fixes

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -466,7 +466,7 @@ The Initial Developer of @pkgr/core@0.1.1,
 is JounQin (https://github.com/un-ts/pkgr).
 Copyright JounQin. All Rights Reserved.
 
-The Initial Developer of @playwright/test@1.49.1,
+The Initial Developer of @playwright/test@1.50.0,
 is Microsoft Corporation (https://github.com/microsoft/playwright).
 Copyright Microsoft Corporation. All Rights Reserved.
 
@@ -2413,11 +2413,11 @@ The Initial Developer of pino@8.21.0,
 is Matteo Collina (https://github.com/pinojs/pino).
 Copyright Matteo Collina. All Rights Reserved.
 
-The Initial Developer of playwright-core@1.49.1,
+The Initial Developer of playwright-core@1.50.0,
 is Microsoft Corporation (https://github.com/microsoft/playwright).
 Copyright Microsoft Corporation. All Rights Reserved.
 
-The Initial Developer of playwright@1.49.1,
+The Initial Developer of playwright@1.50.0,
 is Microsoft Corporation (https://github.com/microsoft/playwright).
 Copyright Microsoft Corporation. All Rights Reserved.
 

--- a/back-end/apps/api/package.json
+++ b/back-end/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/api",
-  "version": "0.8.3",
+  "version": "0.9.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/api/package.json
+++ b/back-end/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/api",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/chain/package.json
+++ b/back-end/apps/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/chain",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/chain/package.json
+++ b/back-end/apps/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/chain",
-  "version": "0.8.3",
+  "version": "0.9.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/notifications/package.json
+++ b/back-end/apps/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/notifications",
-  "version": "0.8.3",
+  "version": "0.9.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/notifications/package.json
+++ b/back-end/apps/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/notifications",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "back-end",
-  "version": "0.8.3",
+  "version": "0.9.1",
   "description": "",
   "author": "",
   "private": true,

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "back-end",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "",
   "author": "",
   "private": true,

--- a/front-end/electron-builder.yml
+++ b/front-end/electron-builder.yml
@@ -22,10 +22,10 @@ nsis:
 mac:
   notarize: false
   target:
-#    - target: 'default'
-#      arch:
-#        - x64
-#        - arm64
+    - target: 'default'
+      arch:
+        - x64
+        - arm64
     - target: 'pkg'
       arch:
         - x64

--- a/front-end/electron-builder.yml
+++ b/front-end/electron-builder.yml
@@ -22,10 +22,10 @@ nsis:
 mac:
   notarize: false
   target:
-    - target: 'default'
-      arch:
-        - x64
-        - arm64
+#    - target: 'default'
+#      arch:
+#        - x64
+#        - arm64
     - target: 'pkg'
       arch:
         - x64

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-transaction-tool",
-  "version": "0.8.3",
+  "version": "0.9.1",
   "description": "Transaction tool application",
   "author": {
     "name": "Hedera",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-transaction-tool",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Transaction tool application",
   "author": {
     "name": "Hedera",

--- a/front-end/src/main/modules/ipcHandlers/utils.ts
+++ b/front-end/src/main/modules/ipcHandlers/utils.ts
@@ -53,8 +53,12 @@ export default () => {
 
       const content = Buffer.from(getNumberArrayFromString(uint8ArrayString));
       await fs.promises.writeFile(filePath, Uint8Array.from(content));
-    } catch (error: any) {
-      dialog.showErrorBox('Failed to save file', error?.message || 'Unknown error');
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        dialog.showErrorBox('Failed to save file', error.message);
+      } else {
+        dialog.showErrorBox('Failed to save file', 'Unknown error');
+      }
     }
   });
 
@@ -85,8 +89,12 @@ export default () => {
         if (!filePath) throw new Error('File path is undefined');
 
         await fs.promises.writeFile(filePath, data);
-      } catch (error: any) {
-        dialog.showErrorBox('Failed to save file', error?.message || 'Unknown error');
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          dialog.showErrorBox('Failed to save file', error.message);
+        } else {
+          dialog.showErrorBox('Failed to save file', 'Unknown error');
+        }
       }
     },
   );
@@ -114,11 +122,11 @@ export default () => {
     },
   );
 
-  ipcMain.handle(createChannelName('sha384'), (_e, str: string): Promise<string> => {
-    return createHash('sha384').update(str).digest('hex');
+  ipcMain.handle(createChannelName('sha384'), async (_e, str: string): Promise<string> => {
+    return await createHash('sha384').update(str).digest('hex');
   });
 
-  ipcMain.handle(createChannelName('x509BytesFromPem'), (_e, pem: string | Uint8Array) => {
+  ipcMain.handle(createChannelName('x509BytesFromPem'), async (_e, pem: string | Uint8Array) => {
     const PEM_HEADER = '-----BEGIN CERTIFICATE-----';
 
     if (
@@ -157,7 +165,7 @@ export default () => {
     };
   });
 
-  ipcMain.handle(createChannelName('quit'), () => {
+  ipcMain.handle(createChannelName('quit'), async () => {
     app.quit();
   });
 };

--- a/front-end/src/preload/localUser/utils.ts
+++ b/front-end/src/preload/localUser/utils.ts
@@ -27,7 +27,6 @@ export default {
       title: string,
       buttonLabel: string,
       filters: FileFilter[],
-      properties: ('openFile' | 'openDirectory' | 'multiSelections')[],
       message: string,
     ): Promise<void> =>
       ipcRenderer.invoke(
@@ -37,7 +36,6 @@ export default {
         title,
         buttonLabel,
         filters,
-        properties,
         message,
       ),
     sha384: (str: string): Promise<string> => ipcRenderer.invoke('utils:sha384', str),

--- a/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
+++ b/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
@@ -15,6 +15,7 @@ import { deleteGroup } from '@renderer/services/transactionGroupsService';
 
 import {
   assertUserLoggedIn,
+  formatHbarTransfers,
   getErrorMessage,
   getPropagationButtonLabel,
   isLoggedInOrganization,
@@ -327,43 +328,7 @@ function makeTransfer(index: number) {
     ) as TransferTransaction
   ).hbarTransfersList;
 
-  if (transfers.length === 0) {
-    return 'No transfers';
-  }
-
-  if (transfers.length === 1) {
-    const amount = transfers[0].amount;
-    if (amount.isNegative()) {
-      return 'Missing receiver';
-    } else {
-      return 'Missing sender';
-    }
-  }
-
-  if (transfers.length === 2) {
-    // if the amount is at least 1 hbar, show the amount as hbar, otherwise show it as tinybar
-    const formatAmount = (amount: Hbar) => {
-      const tinybars = Math.abs(amount.toTinybars());
-      const isHbar = tinybars >= Hbar.from(1).toTinybars();
-      const symbol = isHbar ? HbarUnit.Hbar._symbol : HbarUnit.Tinybar._symbol;
-      const amountString = isHbar ? amount.to(HbarUnit.Hbar).toString() : amount.to(HbarUnit.Tinybar).toString();
-
-      return `${amountString} <span class="text-semi-bold text-pink">${symbol}</span>`;
-    };
-
-    // the JS SDK sorts the order of the transfers by account ID. We don't want this. We want the sender to be on the
-    // left and the receiver to be on the right. So we need to check if the amount is negative or positive and then
-    // arrange the transfers accordingly
-    let sender = transfers[0];
-    let receiver = transfers[1];
-    if (receiver.amount.isNegative()) {
-      sender = transfers[1];
-      receiver = transfers[0];
-    }
-    return `${sender.accountId} --> ${formatAmount(receiver.amount)} --> ${receiver.accountId}`;
-  }
-
-  return 'Multiple transfers';
+  return formatHbarTransfers(transfers);
 }
 
 /* Hooks */

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -482,11 +482,10 @@ const handleExport = async () => {
   const transactionId = props.sdkTransaction.transactionId?.toString();
   await saveFileNamed(
     bytes,
-    `${transactionId || 'transaction'}.tx`,
+    `${transactionId || 'transaction'}.txsig`,
     'Export transaction',
     'Export',
-    [],
-    ['openDirectory'],
+    [{ name: 'Transaction Files', extensions: ['txsig'] }],
     'Export transaction',
   );
 };

--- a/front-end/src/renderer/services/electronUtilsService.ts
+++ b/front-end/src/renderer/services/electronUtilsService.ts
@@ -63,7 +63,6 @@ export const saveFileNamed = async (
   title: string,
   buttonLabel: string,
   filters: FileFilter[],
-  properties: ('openFile' | 'openDirectory' | 'multiSelections')[],
   message: string,
 ): Promise<void> => {
   try {
@@ -73,7 +72,6 @@ export const saveFileNamed = async (
       title,
       buttonLabel,
       filters,
-      properties,
       message,
     );
   } catch {
@@ -97,7 +95,7 @@ export async function x509BytesFromPem(pem: string | Uint8Array) {
 }
 
 /* Quits the application */
-export const quit = async () =>
-  commonIPCHandler(async () => {
-    return await window.electronAPI.local.utils.quit();
+export const quit = () =>
+  commonIPCHandler(() => {
+    return window.electronAPI.local.utils.quit();
   }, 'Failed quit the application');

--- a/front-end/src/renderer/services/electronUtilsService.ts
+++ b/front-end/src/renderer/services/electronUtilsService.ts
@@ -95,7 +95,7 @@ export async function x509BytesFromPem(pem: string | Uint8Array) {
 }
 
 /* Quits the application */
-export const quit = () =>
-  commonIPCHandler(() => {
-    return window.electronAPI.local.utils.quit();
+export const quit = async () =>
+  commonIPCHandler(async () => {
+    return await window.electronAPI.local.utils.quit();
   }, 'Failed quit the application');

--- a/front-end/src/renderer/utils/index.ts
+++ b/front-end/src/renderer/utils/index.ts
@@ -1,6 +1,6 @@
 import type { AccountInfo } from '@main/shared/interfaces';
 import type { HederaAccount } from '@prisma/client';
-import { AccountId, Client } from '@hashgraph/sdk';
+import { AccountId, Client, Hbar, HbarUnit } from '@hashgraph/sdk';
 import { isUserLoggedIn } from './userStoreHelpers';
 import useUserStore from '@renderer/stores/storeUser';
 import { getOne } from '@renderer/services/accountsService';
@@ -9,6 +9,7 @@ import useNetworkStore from '@renderer/stores/storeNetwork';
 export * from './dom';
 export * from './sdk';
 export * from './transactions';
+export * from './transferTransactions';
 export * from './validator';
 export * from './axios';
 export * from './ipc';
@@ -179,3 +180,12 @@ export const getAccountIdWithChecksum = (accountId: string): string => {
     return accountId;
   }
 };
+
+export function stringifyHbarWithFont(hbar: Hbar, fontClass: string): string {
+  const tinybars = Math.abs(hbar.toTinybars());
+  const isHbar = tinybars >= Hbar.fromTinybars(1_000_000).toTinybars();
+  const symbol = isHbar ? HbarUnit.Hbar._symbol : HbarUnit.Tinybar._symbol;
+  const amountString = isHbar ? hbar.to(HbarUnit.Hbar).toString() : hbar.to(HbarUnit.Tinybar).toString();
+
+  return `${amountString} <span class="${fontClass}">${symbol}</span>`;
+}

--- a/front-end/src/renderer/utils/transferTransactions.ts
+++ b/front-end/src/renderer/utils/transferTransactions.ts
@@ -1,0 +1,33 @@
+import { stringifyHbarWithFont } from './index';
+
+export function formatHbarTransfers(transfers): string {
+  if (transfers.length === 0) {
+    return 'No transfers';
+  }
+
+  if (transfers.length === 1) {
+    const amount = transfers[0].amount;
+    if (amount.isNegative()) {
+      return 'Missing receiver';
+    } else {
+      return 'Missing sender';
+    }
+  }
+
+  if (transfers.length === 2) {
+    // the JS SDK sorts the order of the transfers by account ID. We don't want this. We want the sender to be on the
+    // left and the receiver to be on the right. So we need to check if the amount is negative or positive and then
+    // arrange the transfers accordingly
+    let sender = transfers[0];
+    let receiver = transfers[1];
+    if (receiver.amount.isNegative()) {
+      sender = transfers[1];
+      receiver = transfers[0];
+    }
+    return `${sender.accountId} --> ${stringifyHbarWithFont(
+      receiver.amount, "text-semi-bold text-pink"
+    )} --> ${receiver.accountId}`;
+  }
+
+  return 'Multiple transfers';
+}

--- a/front-end/src/tests/main/modules/ipcHandlers/utils.spec.ts
+++ b/front-end/src/tests/main/modules/ipcHandlers/utils.spec.ts
@@ -349,6 +349,47 @@ describe('registerUtilsListeners', () => {
     expect(fs.promises.writeFile).not.toHaveBeenCalled();
   });
 
+  test('Should show error in dialog if fail to write in util:saveFileNamed', async () => {
+    const windows = [{}];
+    const data = new Uint8Array([1, 2, 3, 4]);
+    const name = 'test.txt';
+    const title = 'Save File';
+    const buttonLabel = 'Save';
+    const filters = [{ name: 'Text Files', extensions: ['txt'] }];
+    const message = 'Select a file to save';
+    const filePath = 'testPath';
+    const canceled = false;
+
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue(windows as unknown as BrowserWindow[]);
+    vi.mocked(dialog.showSaveDialog).mockResolvedValue({ filePath, canceled });
+    vi.mocked(fs.promises.writeFile).mockRejectedValueOnce(new Error('An error'));
+    vi.mocked(fs.promises.writeFile).mockRejectedValueOnce(undefined);
+
+    await invokeIPCHandler('utils:saveFileNamed', data, name, title, buttonLabel, filters, message);
+    expect(dialog.showErrorBox).toHaveBeenCalledWith('Failed to save file', 'An error');
+    await invokeIPCHandler('utils:saveFileNamed', data, name, title, buttonLabel, filters, message);
+    expect(dialog.showErrorBox).toHaveBeenCalledWith('Failed to save file', 'Unknown error');
+  });
+
+  test('Should show error in dialog if error in util:saveFileNamed', async () => {
+    const windows = [{}];
+    const data = new Uint8Array([1, 2, 3, 4]);
+    const name = 'test.txt';
+    const title = 'Save File';
+    const buttonLabel = 'Save';
+    const filters = [{ name: 'Text Files', extensions: ['txt'] }];
+    const message = 'Select a file to save';
+
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue(windows as unknown as BrowserWindow[]);
+    vi.mocked(dialog.showSaveDialog).mockRejectedValueOnce(new Error('An error'));
+    vi.mocked(dialog.showSaveDialog).mockRejectedValueOnce(undefined);
+
+    await invokeIPCHandler('utils:saveFileNamed', data, name, title, buttonLabel, filters, message);
+    expect(dialog.showErrorBox).toHaveBeenCalledWith('Failed to save file', 'An error');
+    await invokeIPCHandler('utils:saveFileNamed', data, name, title, buttonLabel, filters, message);
+    expect(dialog.showErrorBox).toHaveBeenCalledWith('Failed to save file', 'Unknown error');
+  });
+
   test('Should invoke app.quit in util:quit', async () => {
     await invokeIPCHandler('utils:quit');
     expect(app.quit).toHaveBeenCalled();


### PR DESCRIPTION
**Description**:
CSV importing is a feature brought over from the old tool. The flow for importing is slightly different. 

As such, the CSV template will be slightly altered. Some additional features will be added. Each transfer transaction can override the global memo with a transaction specific memo. The CSV will have a 'Transaction Description' that will set the Transaction Group Description field. 

The hbar transfers now have a new format: <sender account> -> amount -> <receiver account>. The SDK enforces the order of the transfers to be based on accountId, so this needed to be circumvented.  

**Related issue(s)**:

Fixes # 1569,1570,1571