### PR TITLE
fix: required public keys

### DIFF
--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -132,7 +132,12 @@ async function handleFetchGroup(id: string | number) {
             }
           }
 
-          publicKeysRequiredToSign.value = publicKeysRequiredToSign.value!.concat(usersUnsigned);
+          if (
+            item.transaction.status !== TransactionStatus.CANCELED &&
+            item.transaction.status !== TransactionStatus.EXPIRED
+          ) {
+            publicKeysRequiredToSign.value = publicKeysRequiredToSign.value!.concat(usersUnsigned);
+          }
         }
       }
     } catch (error) {


### PR DESCRIPTION
Fix for excluding canceled/expired transactions within a group, which resolves the issue of the 'Sign All' button persisting on the screen.

**Related issue(s)**:
#1559 