### PR TITLE
1284 copy pasting in all places of the recovery phrase should copy and paste the same format

### DIFF
--- a/front-end/src/renderer/pages/Migrate/Migrate.vue
+++ b/front-end/src/renderer/pages/Migrate/Migrate.vue
@@ -87,13 +87,12 @@ const handleSetRecoveryPhrase = async (value: {
 
   const keysPath = await getDataMigrationKeysPath();
   const encryptedKeyPaths = await searchEncryptedKeys([keysPath]);
-  const keyNames = encryptedKeyPaths.map(path => {
+  allUserKeysToRecover.value = encryptedKeyPaths.map(path => {
     return new KeyPathWithName(
       path.split('/').pop()?.split('.').slice(0, -1).join('.') || '',
       path,
     );
   });
-  allUserKeysToRecover.value = keyNames;
 
   step.value = 'personal';
 };
@@ -159,7 +158,10 @@ onMounted(async () => {
   <div class="flex-column flex-centered flex-1 overflow-hidden p-6">
     <div
       class="container-dark-border bg-modal-surface glow-dark-bg p-5"
-      :class="step === 'selectKeys' ? 'custom-key-modal' : null"
+      :class="{
+        'custom-key-modal': stepIs('selectKeys'),
+        'col-12 col-md-10 col-lg-8': stepIs('summary')
+      }"
     >
       <h4 class="text-title text-semi-bold text-center">{{ heading }}</h4>
 

--- a/front-end/src/renderer/pages/Migrate/components/SummaryItem.vue
+++ b/front-end/src/renderer/pages/Migrate/components/SummaryItem.vue
@@ -8,10 +8,10 @@ defineProps<{
 </script>
 <template>
   <div class="row">
-    <div class="col-5">
+    <div class="col-4 d-flex align-items-center">
       <p class="text-small text-semi-bold">{{ label }}</p>
     </div>
-    <div class="col-7">
+    <div class="col-8">
       <p class="text-small text-secondary overflow-hidden" :data-testid="['data-testid']">
         {{ value }}
         <slot></slot>


### PR DESCRIPTION
**Description**:
Summary step of the migration flow now shows the recovery phrase in a more familiar way. Copying the phrase also is done in the 'standard' format used throughout the app.

**Related issue(s)**:

Fixes #1284 

**Checklist**

- [x] Tested (unit, integration, etc.)
