### PR TITLE
866 rename delete missing key to something that will let the user know to re upload their key

### DIFF
--- a/front-end/src/renderer/router/index.ts
+++ b/front-end/src/renderer/router/index.ts
@@ -63,9 +63,10 @@ const routes: RouteRecordRaw[] = [
     component: MatchRecoveryPhrase,
   },
   {
-    path: '/restore-missing-keys',
+    path: '/restore-missing-keys/:index?/:publicKey?',
     name: constants.RESTORE_MISSING_KEYS,
     component: RestoreMissingKeys,
+    props: true,
   },
   {
     path: '/create-transaction/:type/:seq?',

--- a/front-end/src/renderer/types/index.ts
+++ b/front-end/src/renderer/types/index.ts
@@ -1,1 +1,6 @@
 export * from './userStore';
+
+export enum KeyType {
+  ED25519 = 'ED25519',
+  ECDSA = 'ECDSA'
+}

--- a/front-end/src/renderer/utils/sdk/index.ts
+++ b/front-end/src/renderer/utils/sdk/index.ts
@@ -20,11 +20,13 @@ import {
   Timestamp,
   Transaction,
 } from '@hashgraph/sdk';
+import { KeyType } from '../../types';
+
 import { proto } from '@hashgraph/proto';
 
 import { getNetworkNodes } from '@renderer/services/mirrorNodeDataService';
 
-import { uint8ToHex, hexToUint8Array, isContractId, isAccountId } from '..';
+import { hexToUint8Array, isAccountId, isContractId, uint8ToHex } from '..';
 import { getNodeAddressBook } from '@renderer/services/sdkService';
 
 export * from './createTransactions';
@@ -70,6 +72,25 @@ export const createFileInfo = (props: {
   };
 
   return proto.FileGetInfoResponse.FileInfo.encode(protoBuf).finish();
+};
+
+/**
+ * Gets the public key and its type.
+ * @param key - The key to get the public key from.
+ * @returns {object} - An object containing the public key and the key type.
+ */
+export const getPublicKeyAndType = (key: string | PublicKey): { publicKey: PublicKey, keyType: KeyType } => {
+  let publicKey: PublicKey;
+
+  if (key instanceof PublicKey) {
+    publicKey = key;
+  } else {
+    publicKey = PublicKey.fromString(key)
+  }
+
+  const keyType = publicKey._toProtobufKey().ed25519 ? KeyType.ED25519 : KeyType.ECDSA;
+
+  return { publicKey, keyType };
 };
 
 export const normalizePublicKey = (key: Key) => {


### PR DESCRIPTION
**Description**:
Added button and modified flows to allow the user to recover keys after reconnecting to an organization. Previously, the user was directed to delete keys. Now they have both options

**Related issue(s)**:

Fixes #866 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
