### PR TITLE
feat: display failed code message banner and proper status step

### DIFF
--- a/front-end/src/renderer/components/ui/AppStepper.vue
+++ b/front-end/src/renderer/components/ui/AppStepper.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 /* Props */
-defineProps<{
+const props = defineProps<{
   items: {
     title: string;
     name: string;
@@ -12,6 +12,32 @@ defineProps<{
   itemClickable?: boolean;
   handleItemClick?: (item: { title: string; name: string }, index: number) => void;
 }>();
+
+/* Functions */
+const isActive = (index: number) => {
+  return index === props.activeIndex && index !== props.items.length - 1;
+};
+
+const isCompleted = (index: number) => {
+  return index < props.activeIndex ||
+    (props.activeIndex === index && index === props.items.length - 1);
+};
+
+const getBubbleContent = (index: number, item: { bubbleIcon?: string; bubbleLabel?: string }) => {
+  if (isActive(index) || props.activeIndex < index) {
+    return index + 1;
+  } else if (isCompleted(index)) {
+    if (item.bubbleIcon) {
+      return `<i class="bi bi-${item.bubbleIcon}"></i>`;
+    } else if (item.bubbleLabel) {
+      return item.bubbleLabel;
+    } else {
+      return '<i class="bi bi-check-lg"></i>';
+    }
+  } else {
+    return '<i class="bi bi-check-lg"></i>';
+  }
+};
 </script>
 <template>
   <div class="stepper">
@@ -21,29 +47,15 @@ defineProps<{
         <template v-for="(item, index) in items" :key="index">
           <div
             class="stepper-nav-item position-relative"
-            :class="{ 'stepper-active': activeIndex === index, 'cursor-pointer': itemClickable }"
+            :class="{ 'stepper-active': isActive(index), 'cursor-pointer': itemClickable }"
             @click="handleItemClick && handleItemClick(item, index)"
           >
             <div
               class="stepper-nav-item-bubble text-small rounded-circle border border-dark p-2"
-              :class="[item.bubbleClass && `${item.bubbleClass}`]"
+              :class="[isCompleted(index) ? item.bubbleClass : '']"
               :data-testid="`div-stepper-nav-item-bubble-${index}`"
-            >
-              <template v-if="activeIndex <= index">
-                <template v-if="item.bubbleIcon">
-                  <i class="bi" :class="[`bi-${item.bubbleIcon}`]"></i>
-                </template>
-                <template v-else-if="item.bubbleLabel">
-                  {{ item.bubbleLabel }}
-                </template>
-                <template v-else>
-                  {{ index + 1 }}
-                </template>
-              </template>
-              <template v-else>
-                <i class="bi bi-check-lg"></i>
-              </template>
-            </div>
+              v-html="getBubbleContent(index, item)"
+            ></div>
             <span
               :data-testid="`stepper-title-${index}`"
               class="stepper-nav-item-title text-micro position-absolute mt-3"

--- a/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
@@ -236,8 +236,6 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
           :local-transaction="localTransaction"
           :next-id="nextId"
           :previous-id="prevId"
-          :local-group-description="groupDescription"
-          :org-group-description="groupDescription"
         />
 
         <Transition name="fade" mode="out-in">
@@ -289,6 +287,21 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
               </div>
 
               <hr v-if="isLoggedInOrganization(user.selectedOrganization)" class="separator my-8" />
+
+              <!-- TRANSACTION GROUP DETAILS -->
+              <div v-if="groupDescription">
+                <h2 class="text-title text-bold mt-5">Transaction Group</h2>
+
+                <div class="row flex-wrap mt-5">
+                  <!-- Description -->
+                  <div class="col-18 col-lg-15 col-xl-12 col-xxl-9 overflow-hidden py-3">
+                    <h4 :class="detailItemLabelClass">Description</h4>
+                    <p :class="detailItemValueClass">{{ groupDescription }}</p>
+                  </div>
+                </div>
+
+                <hr class="separator my-5" />
+              </div>
 
               <!-- CREATION DETAILS -->
               <h2 class="text-title text-bold mt-5">Creation Details</h2>

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -34,6 +34,7 @@ import {
   assertUserLoggedIn,
   getErrorMessage,
   getPrivateKey,
+  getStatusFromCode,
   getTransactionBodySignatureWithoutNodeAccountId,
   hexToUint8Array,
   isLoggedInOrganization,
@@ -92,8 +93,6 @@ const props = defineProps<{
   sdkTransaction: SDKTransaction | null;
   nextId: number | string | null;
   previousId: number | string | null;
-  orgGroupDescription?: string | undefined;
-  localGroupDescription?: string | undefined;
 }>();
 
 /* Stores */
@@ -221,6 +220,10 @@ const visibleButtons = computed(() => {
 const dropDownItems = computed(() =>
   visibleButtons.value.slice(1).map(item => ({ label: item, value: item })),
 );
+
+const isTransactionFailed = computed(() => {
+  return props.organizationTransaction?.status === TransactionStatus.FAILED;
+});
 
 /* Handlers */
 const handleBack = () => {
@@ -579,18 +582,16 @@ watch(
         <i class="bi bi-arrow-left"></i>
       </AppButton>
 
-      <h2
-        class="text-title text-bold"
-        v-if="props.localGroupDescription || props.orgGroupDescription"
-      >
+      <h2 class="text-title text-bold">
         Transaction Details
-        <span class="text-secondary">
+        <span v-if="isTransactionFailed" class="badge bg-danger text-break ms-2">
           {{
-            props.localGroupDescription ? `(${localGroupDescription})` : `(${orgGroupDescription})`
+            getStatusFromCode(props.organizationTransaction?.statusCode)
+              ? getStatusFromCode(props.organizationTransaction?.statusCode)
+              : 'FAILED'
           }}
         </span>
       </h2>
-      <h2 v-else class="text-title text-bold">Transaction Details</h2>
     </div>
 
     <div class="flex-centered gap-4">

--- a/front-end/src/renderer/pages/UserLogin/components/KeychainOption.vue
+++ b/front-end/src/renderer/pages/UserLogin/components/KeychainOption.vue
@@ -46,6 +46,10 @@ onMounted(async () => {
 </script>
 <template>
   <div v-if="show" class="d-grid">
-    <AppButton color="secondary" @click="handleUseKeychain">Sign in with Keychain</AppButton>
+    <AppButton
+      color="secondary"
+      data-testid="button-keychain-login"
+      @click="handleUseKeychain"
+    >Sign in with Keychain</AppButton>
   </div>
 </template>

--- a/front-end/src/renderer/utils/transactions.ts
+++ b/front-end/src/renderer/utils/transactions.ts
@@ -11,6 +11,7 @@ import {
 } from '@hashgraph/sdk';
 
 import { CommonNetwork } from '@main/shared/enums';
+import { TransactionStatus } from '@main/shared/interfaces';
 
 import { openExternal } from '@renderer/services/electronUtilsService';
 import { flattenKeyList } from '@renderer/services/keyPairService';
@@ -116,10 +117,7 @@ export const getPropagationButtonLabel = (
     const publicKeysDer = publicKeys.map(pk => pk.toStringRaw());
 
     const userKeyRequired = userPublicKeys.some(userKey => {
-      if (publicKeysRaw.includes(userKey) || publicKeysDer.includes(userKey)) {
-        return true;
-      }
-      return false;
+      return publicKeysRaw.includes(userKey) || publicKeysDer.includes(userKey);
     });
 
     return userKeyRequired ? 'Create' : 'Create and Share';
@@ -135,4 +133,21 @@ export const normalizeNetworkName = (network: string): IDefaultNetworks | 'custo
   } else {
     return 'custom';
   }
+};
+
+const TransactionStatusName = {
+  [TransactionStatus.NEW]: 'New',
+  [TransactionStatus.CANCELED]: 'Canceled',
+  [TransactionStatus.REJECTED]: 'Rejected',
+  [TransactionStatus.WAITING_FOR_SIGNATURES]: 'Waiting for Signatures',
+  [TransactionStatus.WAITING_FOR_EXECUTION]: 'Waiting for Execution',
+  [TransactionStatus.EXECUTED]: 'Executed',
+  [TransactionStatus.FAILED]: 'Failed',
+  [TransactionStatus.EXPIRED]: 'Expired',
+  [TransactionStatus.ARCHIVED]: 'Archived',
+};
+
+export const getTransactionStatusName = (status: TransactionStatus, uppercase: boolean = false): string => {
+  const statusName = TransactionStatusName[status];
+  return uppercase ? statusName.toUpperCase() : statusName;
 };


### PR DESCRIPTION
**Description**:
Added a failed message banner and fixed the Transaction Status stepper to show the proper color, icon, and message for each status.

**Related issue(s)**:

Fixes #1562 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
