### PR TITLE
Update README.md for working link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and is at your own risk.
 
 ## Documentation
 
-The user guide for this application can be found [here](https://docs.hedera.com/hedera-transactions-tool).
+The user guide for this application can be found [here](https://docs.hedera.com/hedera-transaction-tool-v2).
 
 ## Contributing
 


### PR DESCRIPTION
The current link https://docs.hedera.com/hedera-transactions-tool listed in the README is no longer working. This is the updated link https://docs.hedera.com/hedera-transaction-tool-v2