### PR TITLE
fix: update outdated documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and is at your own risk.
 
 ## Documentation
 
-The user guide for this application can be found [here](https://docs.hedera.com/hedera-transactions-tool).
+The user guide for this application can be found [here](https://docs.hedera.com/hedera-transaction-tool-v2).
 
 ## Contributing
 


### PR DESCRIPTION
**Description**: This commit updates the outdated Hedera Transaction Tool documentation link in the README.md file.

Previous link:
https://docs.hedera.com/hedera-transaction-tool

Updated to:
https://docs.hedera.com/hedera-transaction-tool-v2
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**: 

Fixes #hashgraph/node-operator-docs/issues/31

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
