### PR TITLE
fix: 1699 during migration the option to create a new recovery phrase use existing or importing existing recovery phrase still displays

### DIFF
--- a/back-end/apps/api/package.json
+++ b/back-end/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/api",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/chain/package.json
+++ b/back-end/apps/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/chain",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/notifications/package.json
+++ b/back-end/apps/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/notifications",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "back-end",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "",
   "author": "",
   "private": true,

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-transaction-tool",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Transaction tool application",
   "author": {
     "name": "Hedera",

--- a/front-end/src/renderer/composables/user/useAfterOrganizationSelection.ts
+++ b/front-end/src/renderer/composables/user/useAfterOrganizationSelection.ts
@@ -82,7 +82,10 @@ export default function useAfterOrganizationSelection() {
       return;
     }
 
-    await router.push({ name: 'transactions' });
+    // only automatically redirect the user to transactions if an account setup is not in progress.
+    if (!user.accountSetupStarted) {
+      await router.push({ name: 'transactions' });
+    }
   };
 
   const afterOrganizationSelection = async () => {


### PR DESCRIPTION
**Description**:
A specific flow used during migration was causing the wrong steps to appear. This has been resolved by further assuring that the normal routing rules are bypassed or ignored during migration.

**Related issue(s)**:

Fixes #1699 

