### PR TITLE
fix: Migration reuse username if applicable

### DIFF
--- a/back-end/apps/api/package.json
+++ b/back-end/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/api",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/chain/package.json
+++ b/back-end/apps/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/chain",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/notifications/package.json
+++ b/back-end/apps/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/notifications",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "back-end",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "",
   "author": "",
   "private": true,

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-transaction-tool",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Transaction tool application",
   "author": {
     "name": "Hedera",

--- a/front-end/src/main/shared/constants/index.ts
+++ b/front-end/src/main/shared/constants/index.ts
@@ -37,6 +37,7 @@ export const historyTitle = 'History';
 
 /* Local Storage */
 export const LOCAL_STORAGE_IMPORTANT_NOTE_ACCEPTED = 'important-note-accepted';
+export const HTX_USER = 'htx_user';
 
 /* Session Storage */
 export const SESSION_STORAGE_AUTH_TOKEN_PREFIX = 'auth-token-';

--- a/front-end/src/renderer/composables/useAutoLogin.ts
+++ b/front-end/src/renderer/composables/useAutoLogin.ts
@@ -1,5 +1,7 @@
 import { onMounted } from 'vue';
 
+import { HTX_USER } from '@main/shared/constants';
+
 import useUserStore from '@renderer/stores/storeUser';
 
 import { getStaticUser, getUseKeychain } from '@renderer/services/safeStorageService';
@@ -30,7 +32,7 @@ export default function useAutoLogin() {
 
   return async () => {
     const { data: useKeychain } = await safeAwait(getUseKeychain());
-    const loggedUser = localStorage.getItem('htx_user');
+    const loggedUser = localStorage.getItem(HTX_USER);
 
     if (useKeychain) {
       await keychainLogin();

--- a/front-end/src/renderer/pages/Migrate/Migrate.vue
+++ b/front-end/src/renderer/pages/Migrate/Migrate.vue
@@ -96,8 +96,7 @@ const handleSetRecoveryPhrase = async (value: {
 
   step.value = 'personal';
 };
-//this should make sure that if user logs in with username/password, then log out, then log in, it won't require mnemonic
-//org setup doesn't have username IF i create personal user with username/password. it would be better to preset it instead of hide it
+
 const handleSetPersonalUser = async (value: PersonalUser) => {
   personalUser.value = value;
   await user.setAccountSetupStarted(true);

--- a/front-end/src/renderer/pages/Migrate/Migrate.vue
+++ b/front-end/src/renderer/pages/Migrate/Migrate.vue
@@ -118,7 +118,6 @@ const handleSetOrganizationId = async (value: string | null) => {
 
 const handleKeysImported = async (value: number) => {
   if (!personalUser.value) throw new Error('(BUG) Personal User not set');
-  await user.setAccountSetupStarted(false);
   if (!value) {
     await handleSkipSetupAfterMigration();
   }

--- a/front-end/src/renderer/pages/Migrate/components/SetupOrganizationForm.vue
+++ b/front-end/src/renderer/pages/Migrate/components/SetupOrganizationForm.vue
@@ -96,6 +96,13 @@ watch(inputNewOrganizationPassword, pass => {
   if (isPasswordStrong(pass).result && pass !== inputTemporaryOrganizationPassword.value)
     inputOrganizationURLInvalid.value = false;
 });
+watch(
+  () => props.personalUser.email,
+  email => {
+    if (email) inputOrganizationEmail.value = email;
+  },
+  { immediate: true }
+);
 </script>
 <template>
   <form @submit.prevent="handleOnFormSubmit" class="flex-column-100" v-focus-first-input>
@@ -137,7 +144,7 @@ watch(inputNewOrganizationPassword, pass => {
       </div>
 
       <!-- Organization Email -->
-      <div v-if="personalUser.useKeychain" class="mt-4">
+      <div class="mt-4">
         <label data-testid="label-organization-email" class="form-label">Organization Email</label>
         <AppInput
           data-testid="input-organization-email"

--- a/front-end/src/renderer/pages/Migrate/components/Summary.vue
+++ b/front-end/src/renderer/pages/Migrate/components/Summary.vue
@@ -32,7 +32,6 @@ const recoveryPhraseItemRef = ref<HTMLElement | null>(null);
 
 /* Handlers */
 const handleFinishMigration = () => {
-  user.setAccountSetupStarted(false);
   router.push({ name: 'settingsKeys' });
 };
 
@@ -41,10 +40,6 @@ const handleCopy = (event: ClipboardEvent) => {
   if (!selection) return;
 
   const selectedText = selection.toString();
-
-  //This is the label that is the lead anchor. so the first item in the list for example. this still isnt' working
-  //also, what if hte user selects the whole page? maybe we just also filter out the numbers?
-  console.log('selection.node', selection.anchorNode);
 
   if (recoveryPhraseItemRef.value instanceof HTMLElement && selection.rangeCount > 0) {
     const range = selection.getRangeAt(0);
@@ -69,6 +64,8 @@ const copyRecoveryPhrase = () => {
 /* Hooks */
 onMounted(() => {
   document.addEventListener('copy', handleCopy);
+  // whether the user 'finishes' or not, they have finished account setup.
+  user.setAccountSetupStarted(false);
 });
 
 onBeforeUnmount(() => {
@@ -120,7 +117,7 @@ onBeforeUnmount(() => {
         <SummaryItem
           class="mt-4"
           label="Imported Public Keys"
-          :value="importedUserData.publicKeysImported"
+          :value="importedUserData.publicKeysImported.toString()"
           data-testid="p-migration-summary-imported-personal-id"
         />
       </template>

--- a/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
@@ -5,6 +5,9 @@ import useUserStore from '@renderer/stores/storeUser';
 
 import { useToast } from 'vue-toast-notification';
 import { useRouter } from 'vue-router';
+
+import { HTX_USER } from '@main/shared/constants';
+
 import usePersonalPassword from '@renderer/composables/usePersonalPassword';
 import useLoader from '@renderer/composables/useLoader';
 
@@ -129,7 +132,7 @@ const handleLogout = async () => {
     toggleAuthTokenInSessionStorage(serverUrl, '', true);
     await user.selectOrganization({ id, nickname, serverUrl, key });
   } else {
-    localStorage.removeItem('htx_user');
+    localStorage.removeItem(HTX_USER);
     user.logout();
     await router.push({ name: 'login' });
   }

--- a/front-end/src/renderer/services/userService.ts
+++ b/front-end/src/renderer/services/userService.ts
@@ -1,4 +1,4 @@
-import { LOCAL_STORAGE_IMPORTANT_NOTE_ACCEPTED } from '@main/shared/constants';
+import { HTX_USER, LOCAL_STORAGE_IMPORTANT_NOTE_ACCEPTED } from '@main/shared/constants';
 
 import { commonIPCHandler } from '@renderer/utils';
 
@@ -19,9 +19,9 @@ export const loginLocal = async (
     );
 
     if (keepLoggedIn) {
-      localStorage.setItem('htx_user', JSON.stringify({ userId: id, email: userEmail }));
+      localStorage.setItem(HTX_USER, JSON.stringify({ userId: id, email: userEmail }));
     } else {
-      localStorage.removeItem('htx_user');
+      localStorage.removeItem(HTX_USER);
     }
     return { id, email: userEmail };
   }, 'Login failed');
@@ -35,7 +35,7 @@ export const registerLocal = async (email: string, password: string, keepLoggedI
     );
 
     if (keepLoggedIn) {
-      localStorage.setItem('htx_user', JSON.stringify({ userId: id, email: userEmail }));
+      localStorage.setItem(HTX_USER, JSON.stringify({ userId: id, email: userEmail }));
     }
 
     return { id: id, email: userEmail };


### PR DESCRIPTION
**Description**:
If the user chooses to create the personal account using an email/password during the migration process, the org setup process didn't allow the user to use a different email for the org. 