### PR TITLE
1716 signatures gathered from different versions of the tool can be incorrect

### DIFF
--- a/front-end/src/main/modules/ipcHandlers/utils.ts
+++ b/front-end/src/main/modules/ipcHandlers/utils.ts
@@ -14,7 +14,7 @@ export default () => {
   ipcMain.on(createChannelName('setDockBounce'), (_e, bounce: boolean) => {
     if (bounce) {
       const windows = BrowserWindow.getAllWindows();
-      const isAppFocused = windows.some((win) => win.isFocused());
+      const isAppFocused = windows.some(win => win.isFocused());
 
       if (!isAppFocused && app.dock) {
         bounceId = app.dock.bounce('critical');
@@ -94,7 +94,7 @@ export default () => {
       if (windows.length === 0) return;
 
       try {
-        const {canceled, filePath} = await dialog.showSaveDialog(windows[0], {
+        const { canceled, filePath } = await dialog.showSaveDialog(windows[0], {
           title,
           defaultPath: name,
           buttonLabel,

--- a/front-end/src/main/services/localUser/dataMigration.ts
+++ b/front-end/src/main/services/localUser/dataMigration.ts
@@ -300,10 +300,12 @@ export async function migrateUserData(userId: string): Promise<MigrateUserDataRe
     if (fs.existsSync(keysPath)) {
       const files = await fs.promises.readdir(keysPath);
       const pemFiles = new Set(
-        files.filter(file => file.endsWith('.pem')).map(file => path.parse(file).name)
+        files.filter(file => file.endsWith('.pem')).map(file => path.parse(file).name),
       );
 
-      for (const file of files.filter(file => file.endsWith('.pub') && !pemFiles.has(path.parse(file).name))) {
+      for (const file of files.filter(
+        file => file.endsWith('.pub') && !pemFiles.has(path.parse(file).name),
+      )) {
         const filePath = path.join(keysPath, file);
         const publicKeyContent = await fs.promises.readFile(filePath, 'utf-8');
         const nickname = path.basename(filePath, '.pub');

--- a/front-end/src/preload/localUser/utils.ts
+++ b/front-end/src/preload/localUser/utils.ts
@@ -30,15 +30,7 @@ export default {
       filters: FileFilter[],
       message: string,
     ): Promise<void> =>
-      ipcRenderer.invoke(
-        'utils:saveFileNamed',
-        data,
-        name,
-        title,
-        buttonLabel,
-        filters,
-        message,
-      ),
+      ipcRenderer.invoke('utils:saveFileNamed', data, name, title, buttonLabel, filters, message),
     sha384: (str: string): Promise<string> => ipcRenderer.invoke('utils:sha384', str),
     x509BytesFromPem: (
       pem: string | Uint8Array,

--- a/front-end/src/renderer/components/Header.vue
+++ b/front-end/src/renderer/components/Header.vue
@@ -22,7 +22,7 @@ const createTooltips = useCreateTooltips();
 
 /* Computed */
 const isAccountSetupComplete = computed(() => {
-  return user.personal && user.personal.isLoggedIn && !user.accountSetupStarted ;
+  return user.personal && user.personal.isLoggedIn && !user.accountSetupStarted;
 });
 
 /* Hooks */
@@ -35,10 +35,7 @@ onUpdated(createTooltips);
       <Logo class="me-2" />
       <LogoText />
     </div>
-    <div
-      v-if="isAccountSetupComplete"
-      class="flex-centered justify-content-end"
-    >
+    <div v-if="isAccountSetupComplete" class="flex-centered justify-content-end">
       <!-- <span class="container-icon">
         <i class="text-icon-main bi bi-search"></i>
       </span>

--- a/front-end/src/renderer/components/ImportExternalPrivateKeyModal.vue
+++ b/front-end/src/renderer/components/ImportExternalPrivateKeyModal.vue
@@ -9,7 +9,10 @@ import useContactsStore from '@renderer/stores/storeContacts';
 import { useToast } from 'vue-toast-notification';
 import usePersonalPassword from '@renderer/composables/usePersonalPassword';
 
-import { generateExternalKeyPairFromString, verifyKeyPair } from '@renderer/services/keyPairService';
+import {
+  generateExternalKeyPairFromString,
+  verifyKeyPair,
+} from '@renderer/services/keyPairService';
 
 import {
   assertUserLoggedIn,
@@ -127,8 +130,9 @@ watch(
           <p
             :data-testid="`label-${keyType.toLocaleLowerCase()}-public-key`"
             class="d-inline-block text-truncate w-100"
-            >{{ props.publicKey }}</p
           >
+            {{ props.publicKey }}
+          </p>
         </div>
         <div class="form-group mt-4">
           <label class="form-label">Enter {{ keyType }} Private key</label>

--- a/front-end/src/renderer/components/Notifications/NotificationsDropDown.vue
+++ b/front-end/src/renderer/components/Notifications/NotificationsDropDown.vue
@@ -24,7 +24,7 @@ const triggerRingAnimation = () => {
 
 /* Watchers */
 let previousTotalCount = totalCount.value;
-watch(totalCount, (newCount) => {
+watch(totalCount, newCount => {
   if (newCount > previousTotalCount) {
     triggerRingAnimation();
   }
@@ -53,9 +53,7 @@ watch(totalCount, (newCount) => {
     <div class="dropdown-menu overflow-hidden" :style="{ width: '300px' }">
       <ul class="overflow-auto" :style="{ maxHeight: '45vh' }">
         <template v-if="totalCount === 0">
-          <li class="dropdown-item text-small text-center user-select-none">
-            No notifications
-          </li>
+          <li class="dropdown-item text-small text-center user-select-none">No notifications</li>
         </template>
         <template v-else>
           <template
@@ -70,7 +68,10 @@ watch(totalCount, (newCount) => {
                 v-for="notification of notifications"
                 :key="`${notification.content}${notification.network}`"
               >
-                <li class="dropdown-item text-small cursor-pointer user-select-none" @click="notification.action()">
+                <li
+                  class="dropdown-item text-small cursor-pointer user-select-none"
+                  @click="notification.action()"
+                >
                   <div class="row">
                     <div class="col-8" :class="{ 'col-12': notification.network === 'Unknown' }">
                       <p class="text-truncate">

--- a/front-end/src/renderer/components/Notifications/composables/useGroupedNotifications.ts
+++ b/front-end/src/renderer/components/Notifications/composables/useGroupedNotifications.ts
@@ -187,10 +187,10 @@ export function useGroupedNotifications() {
   /* Watch */
   watch(
     () => notificationsStore.notifications,
-    (newNotifications) => {
+    newNotifications => {
       previousNotifications.value = { ...newNotifications };
     },
-    { immediate: true }
+    { immediate: true },
   );
 
   return {

--- a/front-end/src/renderer/components/SignatureStatus.vue
+++ b/front-end/src/renderer/components/SignatureStatus.vue
@@ -30,13 +30,9 @@ const props = defineProps<{
 }>();
 
 /* Computed */
-const hasMultiplePublicKeys = computed(() =>
-  props.signatureKeyObject.signatureKeys.length > 1
-);
+const hasMultiplePublicKeys = computed(() => props.signatureKeyObject.signatureKeys.length > 1);
 const isSignatureKeySatisfied = computed(() =>
-  props.signatureKeyObject.signatureKeys.every(key =>
-    ableToSign(props.publicKeysSigned, key)
-  )
+  props.signatureKeyObject.signatureKeys.every(key => ableToSign(props.publicKeysSigned, key)),
 );
 </script>
 <template>
@@ -48,10 +44,9 @@ const isSignatureKeySatisfied = computed(() =>
           class="bi bi-check-lg text-success position-absolute"
           :style="{ left: '-15px' }"
         ></span>
-        <p
-          class="text-nowrap"
-          :class="{ 'text-success': isSignatureKeySatisfied }"
-        >Required Keys</p>
+        <p class="text-nowrap" :class="{ 'text-success': isSignatureKeySatisfied }">
+          Required Keys
+        </p>
       </div>
     </template>
     <template v-if="signatureKeyObject.payerKey">

--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
@@ -234,16 +234,12 @@ function basePreCreateAssert() {
 }
 
 async function updateTransactionKey() {
-  const computedKeys =  await computeSignatureKey(transaction.value, network.mirrorNodeBaseURL);
+  const computedKeys = await computeSignatureKey(transaction.value, network.mirrorNodeBaseURL);
   transactionKey.value = new KeyList(computedKeys.signatureKeys);
 }
 
 /* Watches */
-watch(
-  [() => payerData.key.value],
-  updateTransactionKey,
-  { immediate: true }
-);
+watch([() => payerData.key.value], updateTransactionKey, { immediate: true });
 
 /* Exposes */
 defineExpose({

--- a/front-end/src/renderer/components/Transaction/Create/FileData/FileDataFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileData/FileDataFormData.vue
@@ -3,10 +3,7 @@ import type { FileData } from '@renderer/utils';
 
 import { isHederaSpecialFileId } from '@shared/hederaSpecialFiles';
 
-import {
-  getMinimumExpirationTime,
-  getMaximumExpirationTime,
-} from '@renderer/utils';
+import { getMinimumExpirationTime, getMaximumExpirationTime } from '@renderer/utils';
 
 import AppInput from '@renderer/components/ui/AppInput.vue';
 import AppDatePicker from '@renderer/components/ui/AppDatePicker.vue';

--- a/front-end/src/renderer/components/Transaction/Create/FileUpdate/FileUpdate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileUpdate/FileUpdate.vue
@@ -85,7 +85,7 @@ watch(
   () => [data.fileId, data.ownerKey],
   () => {
     baseTransactionRef.value?.updateTransactionKey();
-  }
+  },
 );
 </script>
 <template>

--- a/front-end/src/renderer/components/Transaction/Create/NodeCreate/NodeCreate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/NodeCreate/NodeCreate.vue
@@ -102,7 +102,7 @@ watch(
   () => [data.nodeAccountId, data.adminKey],
   () => {
     baseTransactionRef.value?.updateTransactionKey();
-  }
+  },
 );
 </script>
 <template>

--- a/front-end/src/renderer/components/Transaction/Create/NodeCreate/NodeFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/NodeCreate/NodeFormData.vue
@@ -436,30 +436,30 @@ watch(
     </div>
   </div>
   <!-- gRPC Web Endpoint -->
-    <div class="form-group mt-6">
-      <label class="form-label">gRPC Web Proxy Endpoint</label>
-      <div class="text-micro mb-3 text-muted">Fully Qualified Domain Name (FQDN) is required</div>
-      <div class="row align-items-end">
-        <div class="col-4 col-xxxl-3">
-          <label class="form-label">Domain</label>
-          <AppInput
-            :model-value="data.grpcWebProxyEndpoint?.domainName"
-            @update:model-value="getGrpcWebProxyEndpoint('domainName', $event)"
-            placeholder="Enter FQDN"
-            :filled="true"
-          />
-        </div>
-        <div class="col-4 col-xxxl-3">
-          <label class="form-label">Port</label>
-          <AppInput
-            :model-value="data.grpcWebProxyEndpoint?.port"
-            @update:model-value="getGrpcWebProxyEndpoint('port', $event)"
-            placeholder="Enter Port"
-            :filled="true"
-          />
-        </div>
+  <div class="form-group mt-6">
+    <label class="form-label">gRPC Web Proxy Endpoint</label>
+    <div class="text-micro mb-3 text-muted">Fully Qualified Domain Name (FQDN) is required</div>
+    <div class="row align-items-end">
+      <div class="col-4 col-xxxl-3">
+        <label class="form-label">Domain</label>
+        <AppInput
+          :model-value="data.grpcWebProxyEndpoint?.domainName"
+          @update:model-value="getGrpcWebProxyEndpoint('domainName', $event)"
+          placeholder="Enter FQDN"
+          :filled="true"
+        />
+      </div>
+      <div class="col-4 col-xxxl-3">
+        <label class="form-label">Port</label>
+        <AppInput
+          :model-value="data.grpcWebProxyEndpoint?.port"
+          @update:model-value="getGrpcWebProxyEndpoint('port', $event)"
+          placeholder="Enter Port"
+          :filled="true"
+        />
       </div>
     </div>
+  </div>
 
   <hr class="separator my-5" />
 

--- a/front-end/src/renderer/components/Transaction/Create/NodeUpdate/NodeUpdate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/NodeUpdate/NodeUpdate.vue
@@ -12,7 +12,7 @@ import useAccountId from '@renderer/composables/useAccountId';
 import useNodeId from '@renderer/composables/useNodeId';
 
 import { createNodeUpdateTransaction } from '@renderer/utils/sdk/createTransactions';
-import {getComponentServiceEndpoint, getNodeUpdateData, isAccountId} from '@renderer/utils';
+import { getComponentServiceEndpoint, getNodeUpdateData, isAccountId } from '@renderer/utils';
 
 import BaseTransaction from '@renderer/components/Transaction/Create/BaseTransaction';
 import NodeUpdateFormData from '@renderer/components/Transaction/Create/NodeUpdate/NodeUpdateFormData.vue';
@@ -126,7 +126,7 @@ watch(
   () => [data.nodeAccountId, data.adminKey, data.nodeId],
   () => {
     baseTransactionRef.value?.updateTransactionKey();
-  }
+  },
 );
 </script>
 <template>

--- a/front-end/src/renderer/components/Transaction/Create/TransferHbar/TransferHbar.vue
+++ b/front-end/src/renderer/components/Transaction/Create/TransferHbar/TransferHbar.vue
@@ -117,7 +117,7 @@ watch(
   () => data,
   () => {
     baseTransactionRef.value?.updateTransactionKey();
-  }
+  },
 );
 </script>
 <template>

--- a/front-end/src/renderer/components/Transaction/Details/NodeDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/NodeDetails.vue
@@ -12,8 +12,11 @@ import {
   PublicKey,
 } from '@hashgraph/sdk';
 
-import { getComponentServiceEndpoint, getComponentServiceEndpoints,  uint8ToHex } from '@renderer/utils';
-
+import {
+  getComponentServiceEndpoint,
+  getComponentServiceEndpoints,
+  uint8ToHex,
+} from '@renderer/utils';
 
 import KeyStructureModal from '@renderer/components/KeyStructureModal.vue';
 
@@ -29,8 +32,8 @@ const isKeyStructureModalShown = ref(false);
 /* Computed */
 const grpcWebProxyEndpoint = computed(() => {
   if (
-    (props.transaction instanceof NodeCreateTransaction ||
-      props.transaction instanceof NodeUpdateTransaction)
+    props.transaction instanceof NodeCreateTransaction ||
+    props.transaction instanceof NodeUpdateTransaction
   ) {
     return getComponentServiceEndpoint(props.transaction.grpcWebProxyEndpoint);
   }
@@ -121,10 +124,7 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
 
       <!-- Decline Reward - Displayed in the reverse -->
       <div
-        v-if="
-          transaction instanceof NodeCreateTransaction ||
-          transaction.declineReward !== null
-        "
+        v-if="transaction instanceof NodeCreateTransaction || transaction.declineReward !== null"
         class="col-12 my-3"
       >
         <h4 :class="detailItemLabelClass">Accept Node Rewards</h4>
@@ -176,7 +176,9 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
           </thead>
           <tbody class="thin">
             <tr
-              v-for="(endpoint, index) of getComponentServiceEndpoints(transaction.serviceEndpoints)"
+              v-for="(endpoint, index) of getComponentServiceEndpoints(
+                transaction.serviceEndpoints,
+              )"
               :key="index"
             >
               <td class="col text-start">{{ endpoint.ipAddressV4 }}</td>
@@ -188,14 +190,9 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
       </div>
 
       <!-- gRPC Web Proxy Endpoint -->
-      <div
-        v-if="grpcWebProxyEndpoint"
-        class="col-12 my-3"
-      >
+      <div v-if="grpcWebProxyEndpoint" class="col-12 my-3">
         <h4 :class="detailItemLabelClass">gRPC Web Proxy Endpoint</h4>
-        <p>
-          {{ grpcWebProxyEndpoint.domainName }}:{{ grpcWebProxyEndpoint.port }}
-        </p>
+        <p>{{ grpcWebProxyEndpoint.domainName }}:{{ grpcWebProxyEndpoint.port }}</p>
       </div>
 
       <!-- Gossip CA Certificate -->

--- a/front-end/src/renderer/components/Transaction/TransactionProcessor/components/ValidateRequestHandler.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionProcessor/components/ValidateRequestHandler.vue
@@ -9,11 +9,7 @@ import { TRANSACTION_MAX_SIZE } from '@shared/constants';
 import useUserStore from '@renderer/stores/storeUser';
 import useNetworkStore from '@renderer/stores/storeNetwork';
 
-import {
-  assertUserLoggedIn,
-  ableToSign,
-  validateFileUpdateTransaction,
-} from '@renderer/utils';
+import { assertUserLoggedIn, ableToSign, validateFileUpdateTransaction } from '@renderer/utils';
 import { getTransactionType } from '@renderer/utils/sdk/transactions';
 
 /* Constants */

--- a/front-end/src/renderer/components/modals/ResetDataModal.vue
+++ b/front-end/src/renderer/components/modals/ResetDataModal.vue
@@ -49,7 +49,8 @@ const handleResetData = async () => {
       </div>
       <h3 class="text-center text-title text-bold">Reset Data</h3>
       <p class="text-center text-small text-secondary mt-4">
-        Resetting the application will remove all personal data, including keys and organization credentials.
+        Resetting the application will remove all personal data, including keys and organization
+        credentials.
       </p>
       <p class="text-center text-small text-secondary mt-2">
         You will need to import all of your keys and reconnect to each organization.

--- a/front-end/src/renderer/components/ui/AppAutoComplete.vue
+++ b/front-end/src/renderer/components/ui/AppAutoComplete.vue
@@ -53,7 +53,7 @@ const selectedIndex = computed(() => {
 
   // Partial match
   const partialMatchIndex = props.items.findIndex(item =>
-    item.split('.').some(part => part.startsWith(input))
+    item.split('.').some(part => part.startsWith(input)),
   );
   if (partialMatchIndex !== -1) return partialMatchIndex;
 
@@ -97,7 +97,13 @@ const handleKeyDown = (e: KeyboardEvent) => {
   } else if (e.key === 'Enter') {
     e.preventDefault();
     if (lastKeyPressed.value !== 'Escape') {
-      setValue((autocompletePrefixSuggestion.value + modelValue.value + autocompletePostfixSuggestion.value).trim());
+      setValue(
+        (
+          autocompletePrefixSuggestion.value +
+          modelValue.value +
+          autocompletePostfixSuggestion.value
+        ).trim(),
+      );
     }
     toggleDropdown(false);
     focusNextElement();
@@ -115,7 +121,7 @@ const handleKeyDown = (e: KeyboardEvent) => {
 const handleUpdate = (value: string) => {
   value = sanitizeAccountId(value);
 
-  setValue(value)
+  setValue(value);
 
   // Update the input field value
   if (inputRef.value?.inputRef) {
@@ -213,7 +219,8 @@ function measureTextWidth(text: string, input: HTMLInputElement): number {
 }
 
 async function positionSuggestion() {
-  if (!inputRef.value?.inputRef || !prefixSuggestionRef.value || !postfixSuggestionRef.value) return;
+  if (!inputRef.value?.inputRef || !prefixSuggestionRef.value || !postfixSuggestionRef.value)
+    return;
 
   const input = inputRef.value.inputRef;
   const prefixSuggestion = prefixSuggestionRef.value;
@@ -321,7 +328,9 @@ watchEffect(() => {
 <template>
   <div @blur="toggleDropdown(false)" class="w-100 autocomplete-container">
     <div @click="toggleDropdown(true)" class="input-wrapper">
-      <span ref="prefixSuggestionRef" class="autocomplete-suggestion">{{ autocompletePrefixSuggestion }}</span>
+      <span ref="prefixSuggestionRef" class="autocomplete-suggestion">{{
+        autocompletePrefixSuggestion
+      }}</span>
       <AppInput
         ref="inputRef"
         :model-value="modelValue"
@@ -330,7 +339,9 @@ watchEffect(() => {
         :data-testid="dataTestid"
         v-bind="$attrs"
       />
-      <span ref="postfixSuggestionRef" class="autocomplete-suggestion">{{ autocompletePostfixSuggestion }}</span>
+      <span ref="postfixSuggestionRef" class="autocomplete-suggestion">{{
+        autocompletePostfixSuggestion
+      }}</span>
     </div>
 
     <div

--- a/front-end/src/renderer/components/ui/AppButton.vue
+++ b/front-end/src/renderer/components/ui/AppButton.vue
@@ -36,8 +36,7 @@ const colorMapping = {
     :class="['btn', color ? colorMapping[color] : '', sizeMapping[size || 'default']]"
   >
     <template v-if="loading">
-      <span class="spinner-border spinner-border-sm me-2" role="status" inert></span
-      >{{ ' ' }}
+      <span class="spinner-border spinner-border-sm me-2" role="status" inert></span>{{ ' ' }}
       <span v-if="loadingText">{{ loadingText }}</span>
       <span v-else>Loading...</span>
     </template>

--- a/front-end/src/renderer/components/ui/AppStepper.vue
+++ b/front-end/src/renderer/components/ui/AppStepper.vue
@@ -19,8 +19,9 @@ const isActive = (index: number) => {
 };
 
 const isCompleted = (index: number) => {
-  return index < props.activeIndex ||
-    (props.activeIndex === index && index === props.items.length - 1);
+  return (
+    index < props.activeIndex || (props.activeIndex === index && index === props.items.length - 1)
+  );
 };
 
 const getBubbleContent = (index: number, item: { bubbleIcon?: string; bubbleLabel?: string }) => {

--- a/front-end/src/renderer/composables/useMarkNotifications.ts
+++ b/front-end/src/renderer/composables/useMarkNotifications.ts
@@ -34,16 +34,16 @@ export default function useMarkNotifications(notificationTypes: NotificationType
   /* Functions */
   async function markAsRead() {
     if (isLoggedInOrganization(user.selectedOrganization)) {
-      const typesToMark = [...new Set(
-        networkFilteredNotifications.value
-          .filter(nr => notificationTypes.includes(nr.notification.type))
-          .map(nr => nr.notification.type)
-      )];
+      const typesToMark = [
+        ...new Set(
+          networkFilteredNotifications.value
+            .filter(nr => notificationTypes.includes(nr.notification.type))
+            .map(nr => nr.notification.type),
+        ),
+      ];
 
       if (typesToMark.length > 0) {
-        await Promise.allSettled(
-          typesToMark.map(type => notifications.markAsRead(type)),
-        );
+        await Promise.allSettled(typesToMark.map(type => notifications.markAsRead(type)));
       }
     }
   }

--- a/front-end/src/renderer/composables/user/useAfterOrganizationSelection.ts
+++ b/front-end/src/renderer/composables/user/useAfterOrganizationSelection.ts
@@ -75,7 +75,8 @@ export default function useAfterOrganizationSelection() {
 
     const shouldSetup = accountSetupRequired(organization, user.keyPairs);
     const shouldNavigateToSetup =
-      shouldSetup && ((organization && !isLoggedInOrganization(organization)) || !user.skippedSetup);
+      shouldSetup &&
+      ((organization && !isLoggedInOrganization(organization)) || !user.skippedSetup);
 
     if (shouldNavigateToSetup) {
       await router.push({ name: 'accountSetup' });

--- a/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
+++ b/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
@@ -255,7 +255,9 @@ async function handleOnFileChanged(e: Event) {
           try {
             await getAccountInfo(senderAccount, network.mirrorNodeBaseURL);
           } catch (error) {
-            toast.error(`Sender account ${senderAccount} does not exist on network. Review the CSV file.`);
+            toast.error(
+              `Sender account ${senderAccount} does not exist on network. Review the CSV file.`,
+            );
             console.log(error);
             return;
           }
@@ -265,7 +267,9 @@ async function handleOnFileChanged(e: Event) {
           try {
             await getAccountInfo(feePayer, network.mirrorNodeBaseURL);
           } catch (error) {
-            toast.error(`Fee payer account ${feePayer} does not exist on network. Review the CSV file.`);
+            toast.error(
+              `Fee payer account ${feePayer} does not exist on network. Review the CSV file.`,
+            );
             console.log(error);
             return;
           }
@@ -306,7 +310,9 @@ async function handleOnFileChanged(e: Event) {
           try {
             await getAccountInfo(receiverAccount, network.mirrorNodeBaseURL);
           } catch (error) {
-            toast.error(`Receiver account ${receiverAccount} does not exist on network. Review the CSV file.`);
+            toast.error(
+              `Receiver account ${receiverAccount} does not exist on network. Review the CSV file.`,
+            );
             console.log(error);
             transactionGroup.clearGroup();
             return;
@@ -320,9 +326,7 @@ async function handleOnFileChanged(e: Event) {
                 : maxTransactionFee.value) as Hbar,
             );
 
-          transaction.setTransactionId(
-            createTransactionId(feePayer, validStart),
-          );
+          transaction.setTransactionId(createTransactionId(feePayer, validStart));
           const transferAmount = rowInfo[1].replace(/,/g, '');
           transaction.addHbarTransfer(receiverAccount, new Hbar(transferAmount, HbarUnit.Tinybar));
           transaction.addHbarTransfer(senderAccount, new Hbar(-transferAmount, HbarUnit.Tinybar));

--- a/front-end/src/renderer/pages/Migrate/Migrate.vue
+++ b/front-end/src/renderer/pages/Migrate/Migrate.vue
@@ -164,15 +164,14 @@ const handleSkipSetupAfterMigration = async () => {
   // in order to set the skip setup BEFORE org is selected, user the user.organization[0]
   const org = user.selectedOrganization || user.organizations[0];
   if (!org) {
-    const { data } = await safeAwait(getStoredClaim(personalUser.value.personalId, SKIPPED_PERSONAL_SETUP));
+    const { data } = await safeAwait(
+      getStoredClaim(personalUser.value.personalId, SKIPPED_PERSONAL_SETUP),
+    );
     const addOrUpdate = data !== undefined ? update : add;
     await addOrUpdate(personalUser.value.personalId, SKIPPED_PERSONAL_SETUP, 'true');
     user.skippedSetup = true;
   } else if (isLoggedInOrganization(org)) {
-    const claimKey = buildSkipClaimKey(
-      org.serverUrl,
-      org.userId,
-    );
+    const claimKey = buildSkipClaimKey(org.serverUrl, org.userId);
     const { data } = await safeAwait(getStoredClaim(user.personal.id, claimKey));
     const addOrUpdate = data !== undefined ? update : add;
     await addOrUpdate(user.personal.id, claimKey, 'true');
@@ -186,7 +185,7 @@ const handleSkipSetupAfterMigration = async () => {
       class="container-dark-border bg-modal-surface glow-dark-bg p-5"
       :class="{
         'custom-key-modal': stepIs('selectKeys'),
-        'col-12 col-md-10 col-lg-8': stepIs('summary')
+        'col-12 col-md-10 col-lg-8': stepIs('summary'),
       }"
     >
       <h4 class="text-title text-semi-bold text-center">{{ heading }}</h4>
@@ -216,9 +215,7 @@ const handleSkipSetupAfterMigration = async () => {
         </template>
 
         <!-- Setup Organization Step -->
-        <template
-          v-if="stepIs('organization') && personalUser"
-        >
+        <template v-if="stepIs('organization') && personalUser">
           <SetupOrganization
             :personal-user="personalUser"
             @set-organization-id="handleSetOrganizationId"
@@ -232,13 +229,7 @@ const handleSkipSetupAfterMigration = async () => {
         </template>
 
         <!-- Select Keys Step -->
-        <template
-          v-if="
-            stepIs('selectKeys') &&
-            personalUser &&
-            allUserKeysToRecover.length > 0
-          "
-        >
+        <template v-if="stepIs('selectKeys') && personalUser && allUserKeysToRecover.length > 0">
           <SelectKeys
             v-if="userInitialized"
             :keys-to-recover="allUserKeysToRecover"

--- a/front-end/src/renderer/pages/Migrate/components/DecryptRecoveryPhraseForm.vue
+++ b/front-end/src/renderer/pages/Migrate/components/DecryptRecoveryPhraseForm.vue
@@ -47,7 +47,8 @@ watch(inputRecoveryPhrasePassword, () => (inputRecoveryPhrasePasswordError.value
     <div class="fill-remaining">
       <p class="text-secondary text-small lh-base text-center">
         Enter your recovery phrase password from the old tool. <br />
-        This is the password used when first installing the old tool, or when creating a new key. <br />
+        This is the password used when first installing the old tool, or when creating a new key.
+        <br />
         This is likely the same password used when signing a transaction in the old tool.
       </p>
 

--- a/front-end/src/renderer/pages/Migrate/components/SetupOrganizationForm.vue
+++ b/front-end/src/renderer/pages/Migrate/components/SetupOrganizationForm.vue
@@ -101,7 +101,7 @@ watch(
   email => {
     if (email) inputOrganizationEmail.value = email;
   },
-  { immediate: true }
+  { immediate: true },
 );
 </script>
 <template>
@@ -208,12 +208,12 @@ watch(
           :loading="loading"
           :loading-text="loadingText"
           :disabled="
-          inputTemporaryOrganizationPassword.trim().length === 0 ||
-          inputOrganizationURL.trim().length === 0 ||
-          (personalUser.useKeychain ? inputOrganizationEmail.length === 0 : false) ||
-          inputNewOrganizationPassword.trim().length === 0 ||
-          inputNewOrganizationPassword.trim() === inputTemporaryOrganizationPassword.trim()
-        "
+            inputTemporaryOrganizationPassword.trim().length === 0 ||
+            inputOrganizationURL.trim().length === 0 ||
+            (personalUser.useKeychain ? inputOrganizationEmail.length === 0 : false) ||
+            inputNewOrganizationPassword.trim().length === 0 ||
+            inputNewOrganizationPassword.trim() === inputTemporaryOrganizationPassword.trim()
+          "
           data-testid="button-migration-setup-organization"
         >Continue</AppButton>
       </div>

--- a/front-end/src/renderer/pages/MigrateRecoveryPhraseHash/MigrateRecoveryPhraseHash.vue
+++ b/front-end/src/renderer/pages/MigrateRecoveryPhraseHash/MigrateRecoveryPhraseHash.vue
@@ -115,8 +115,8 @@ watch(() => user.recoveryPhrase, handleVerify);
         <h4 class="text-title text-semi-bold text-center">Recovery Phrase</h4>
         <p class="text-main text-center mt-3">
           All previously created private keys need to be rematched to a mnemonic. This process is
-          required before the application will be fully usable. Enter your recovery phrase to rematch your
-          keys.
+          required before the application will be fully usable. Enter your recovery phrase to
+          rematch your keys.
         </p>
         <div class="mt-4">
           <Import />

--- a/front-end/src/renderer/pages/Settings/components/KeysTab/KeysTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/KeysTab/KeysTab.vue
@@ -170,7 +170,10 @@ const handleDeleteSelectedClick = () => (isDeleteModalShown.value = true);
 
 const handleRestoreMissingKey = (keyPair: { id: number; publicKey: string; index?: number }) => {
   if (keyPair.index !== undefined) {
-    router.push({ name: RESTORE_MISSING_KEYS, params: { index: keyPair.index, publicKey: keyPair.publicKey } });
+    router.push({
+      name: RESTORE_MISSING_KEYS,
+      params: { index: keyPair.index, publicKey: keyPair.publicKey },
+    });
   } else {
     keyType.value = getPublicKeyAndType(keyPair.publicKey).keyType;
     publicKey.value = keyPair.publicKey;

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsStatusStepper.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsStatusStepper.vue
@@ -22,9 +22,7 @@ const stepperItems = computed(() => {
     bubbleClass?: string;
     bubbleLabel?: string;
     bubbleIcon?: string;
-  }[] = [
-    { title: 'Transaction Created', name: 'Transaction Created' }
-  ];
+  }[] = [{ title: 'Transaction Created', name: 'Transaction Created' }];
 
   // If rejected, add rejected step and return
   if (props.transaction.status === TransactionStatus.REJECTED) {
@@ -78,7 +76,7 @@ const stepperActiveIndex = computed(() => {
     case TransactionStatus.NEW:
       return 0;
     case TransactionStatus.REJECTED:
-    // case TransactionStatus.WAITING_FOR_APPROVAL:
+      // case TransactionStatus.WAITING_FOR_APPROVAL:
       return 1;
     case TransactionStatus.WAITING_FOR_SIGNATURES:
       return hasApproveStep.value ? 2 : 1;
@@ -89,7 +87,7 @@ const stepperActiveIndex = computed(() => {
       return hasApproveStep.value ? 3 : 2;
     case TransactionStatus.EXECUTED:
     case TransactionStatus.FAILED:
-      return hasApproveStep.value? 4 : 3;
+      return hasApproveStep.value ? 4 : 3;
     default:
       return -1;
   }
@@ -118,8 +116,5 @@ const detailItemLabelClass = 'text-micro text-semi-bold text-dark-blue';
 </script>
 <template>
   <h2 class="text-title text-bold">Transaction Status</h2>
-  <AppStepper
-    :items="stepperItems"
-    :active-index="stepperActiveIndex"
-  />
+  <AppStepper :items="stepperItems" :active-index="stepperActiveIndex" />
 </template>

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -489,7 +489,7 @@ watchEffect(() => {
                   (isLoggedInOrganization(user.selectedOrganization) &&
                     publicKeysRequiredToSign &&
                     publicKeysRequiredToSign.length > 0 &&
-                    !showSignAll)
+                    showSignAll)
                 "
               >
                 <div class="d-flex gap-4 mt-5">
@@ -521,7 +521,7 @@ watchEffect(() => {
                       isLoggedInOrganization(user.selectedOrganization) &&
                       publicKeysRequiredToSign &&
                       publicKeysRequiredToSign.length > 0 &&
-                      !showSignAll
+                      showSignAll
                     "
                   >
                     <AppButton

--- a/front-end/src/renderer/services/electronUtilsService.ts
+++ b/front-end/src/renderer/services/electronUtilsService.ts
@@ -3,7 +3,8 @@ import type { FileFilter, OpenDialogReturnValue } from 'electron';
 import { commonIPCHandler } from '@renderer/utils';
 
 /* Set dock bounce */
-export const setDockBounce = (bounce: boolean = true) => window.electronAPI.local.utils.setDockBounce(bounce);
+export const setDockBounce = (bounce: boolean = true) =>
+  window.electronAPI.local.utils.setDockBounce(bounce);
 
 /* Open external URL */
 export const openExternal = (url: string) => window.electronAPI.local.utils.openExternal(url);

--- a/front-end/src/renderer/services/organization/notifications.ts
+++ b/front-end/src/renderer/services/organization/notifications.ts
@@ -1,7 +1,4 @@
-import type {
-  INotificationReceiver,
-  IUpdateNotificationReceiver,
-} from '@shared/interfaces';
+import type { INotificationReceiver, IUpdateNotificationReceiver } from '@shared/interfaces';
 
 import { axiosWithCredentials, commonRequestHandler } from '@renderer/utils';
 
@@ -54,10 +51,7 @@ export const updateNotifications = async (
       const batchSize = 500;
       for (let i = 0; i < notificationsToUpdate.length; i += batchSize) {
         const batch = notificationsToUpdate.slice(i, i + batchSize);
-        await axiosWithCredentials.patch(
-          `${organizationServerUrl}/${controller}`,
-          batch,
-        );
+        await axiosWithCredentials.patch(`${organizationServerUrl}/${controller}`, batch);
       }
     } catch (error) {
       console.log(error);

--- a/front-end/src/renderer/services/organization/transaction.ts
+++ b/front-end/src/renderer/services/organization/transaction.ts
@@ -6,10 +6,7 @@ import type {
   Network,
   PaginatedResourceDto,
 } from '@shared/interfaces';
-import type {
-  ITransactionApprover,
-  TransactionApproverDto,
-} from '@shared/interfaces';
+import type { ITransactionApprover, TransactionApproverDto } from '@shared/interfaces';
 
 import { Transaction } from '@hashgraph/sdk';
 

--- a/front-end/src/renderer/stores/storeNotifications.ts
+++ b/front-end/src/renderer/stores/storeNotifications.ts
@@ -124,7 +124,7 @@ const useNotificationsStore = defineStore('notifications', () => {
         const result = results[i];
         result.status === 'fulfilled' && (notifications.value[severUrls[i]] = result.value);
       }
-      notifications.value = {...notifications.value};
+      notifications.value = { ...notifications.value };
     });
 
     await notificationsQueue;
@@ -172,7 +172,7 @@ const useNotificationsStore = defineStore('notifications', () => {
     if (networkFilteredNotifications.length > 0) {
       const notificationIds = networkFilteredNotifications
         .filter(nr => nr.notification.type === type)
-        .map(nr => nr.id );
+        .map(nr => nr.id);
 
       await _updateNotifications(notificationsKey, notificationIds);
     }
@@ -203,7 +203,7 @@ const useNotificationsStore = defineStore('notifications', () => {
       notifications.value[notificationsKey] = notifications.value[notificationsKey].filter(
         nr => !notificationIds.includes(nr.id),
       );
-      notifications.value = {...notifications.value};
+      notifications.value = { ...notifications.value };
     });
 
     // Wait for the current update to complete

--- a/front-end/src/renderer/stores/storeTransactionGroup.ts
+++ b/front-end/src/renderer/stores/storeTransactionGroup.ts
@@ -208,15 +208,15 @@ const useTransactionGroupStore = defineStore('transactionGroup', () => {
   }
 
   function hasObservers(seq: number) {
-    return !(groupItems.value[seq].observers === undefined ||
-      groupItems.value[seq].observers.length === 0);
-
+    return !(
+      groupItems.value[seq].observers === undefined || groupItems.value[seq].observers.length === 0
+    );
   }
 
   function hasApprovers(seq: number) {
-    return !(groupItems.value[seq].approvers === undefined ||
-      groupItems.value[seq].approvers.length === 0);
-
+    return !(
+      groupItems.value[seq].approvers === undefined || groupItems.value[seq].approvers.length === 0
+    );
   }
 
   function setModified() {

--- a/front-end/src/renderer/types/index.ts
+++ b/front-end/src/renderer/types/index.ts
@@ -4,11 +4,11 @@ export * from './userStore';
 
 export enum KeyType {
   ED25519 = 'ED25519',
-  ECDSA = 'ECDSA'
+  ECDSA = 'ECDSA',
 }
 
 export type SignatureItem = {
   publicKeys: string[];
   transaction: Transaction;
   transactionId: number;
-}
+};

--- a/front-end/src/renderer/utils/sdk/createTransactions.ts
+++ b/front-end/src/renderer/utils/sdk/createTransactions.ts
@@ -449,9 +449,7 @@ export const getServiceEndpoints = (data: ComponentServiceEndpoint[]): ServiceEn
     .filter((endpoint): endpoint is ServiceEndpoint => endpoint !== null);
 };
 
-
-
-export const getServiceEndpoint= (serviceEndpoint: ComponentServiceEndpoint | null) => {
+export const getServiceEndpoint = (serviceEndpoint: ComponentServiceEndpoint | null) => {
   if (!serviceEndpoint) {
     return null;
   }
@@ -477,8 +475,7 @@ export const getServiceEndpoint= (serviceEndpoint: ComponentServiceEndpoint | nu
     }
     return serviceEndpoint;
   }
-}
-
+};
 
 const setNodeData = (
   transaction: NodeCreateTransaction | NodeUpdateTransaction,

--- a/front-end/src/renderer/utils/sdk/getData.ts
+++ b/front-end/src/renderer/utils/sdk/getData.ts
@@ -216,7 +216,9 @@ export const getTransferHbarData = (transaction: Transaction): TransferHbarData 
   };
 };
 
-export const getComponentServiceEndpoint = ( serviceEndpoint: ServiceEndpoint | null): ComponentServiceEndpoint | null => {
+export const getComponentServiceEndpoint = (
+  serviceEndpoint: ServiceEndpoint | null,
+): ComponentServiceEndpoint | null => {
   if (!serviceEndpoint) {
     return null;
   }
@@ -233,7 +235,7 @@ export const getComponentServiceEndpoint = ( serviceEndpoint: ServiceEndpoint | 
     port,
     domainName,
   };
-}
+};
 
 export const getComponentServiceEndpoints = (
   serviceEndpoints: ServiceEndpoint[],
@@ -251,7 +253,7 @@ export function getNodeData(transaction: Transaction): NodeData {
 
   const gossipEndpoints = getComponentServiceEndpoints(transaction.gossipEndpoints || []);
   const serviceEndpoints = getComponentServiceEndpoints(transaction.serviceEndpoints || []);
-  const grpcWebProxyEndpoint = getComponentServiceEndpoint(transaction.grpcWebProxyEndpoint)
+  const grpcWebProxyEndpoint = getComponentServiceEndpoint(transaction.grpcWebProxyEndpoint);
   return {
     nodeAccountId: transaction.accountId?.toString() || '',
     description: transaction.description || '',
@@ -262,7 +264,6 @@ export function getNodeData(transaction: Transaction): NodeData {
     certificateHash: transaction.certificateHash || Uint8Array.from([]),
     adminKey: transaction.adminKey,
     declineReward: transaction.declineReward || false,
-
   };
 }
 

--- a/front-end/src/renderer/utils/sdk/index.ts
+++ b/front-end/src/renderer/utils/sdk/index.ts
@@ -78,13 +78,15 @@ export const createFileInfo = (props: {
  * @param key - The key to get the public key from.
  * @returns {object} - An object containing the public key and the key type.
  */
-export const getPublicKeyAndType = (key: string | PublicKey): { publicKey: PublicKey, keyType: KeyType } => {
+export const getPublicKeyAndType = (
+  key: string | PublicKey,
+): { publicKey: PublicKey; keyType: KeyType } => {
   let publicKey: PublicKey;
 
   if (key instanceof PublicKey) {
     publicKey = key;
   } else {
-    publicKey = PublicKey.fromString(key)
+    publicKey = PublicKey.fromString(key);
   }
 
   const keyType = publicKey._toProtobufKey().ed25519 ? KeyType.ED25519 : KeyType.ECDSA;
@@ -138,7 +140,9 @@ export function getMaximumExpirationTime() {
 
 export function isPublicKeyInKeyList(publicKey: PublicKey | string, key: Key): boolean {
   if (key instanceof PublicKey) {
-    return key.toStringRaw() === (publicKey instanceof PublicKey ? publicKey.toStringRaw() : publicKey);
+    return (
+      key.toStringRaw() === (publicKey instanceof PublicKey ? publicKey.toStringRaw() : publicKey)
+    );
   }
 
   if (key instanceof KeyList) {

--- a/front-end/src/renderer/utils/sdk/transactions.ts
+++ b/front-end/src/renderer/utils/sdk/transactions.ts
@@ -16,7 +16,7 @@ import {
   SystemDeleteTransaction,
   SystemUndeleteTransaction,
   Transaction,
-  TransferTransaction
+  TransferTransaction,
 } from '@hashgraph/sdk';
 import { getDateStringExtended } from '..';
 
@@ -57,37 +57,37 @@ export const getTransactionType = (
   let transactionType = 'Unknown Transaction Type';
 
   if (transaction instanceof AccountCreateTransaction) {
-    transactionType = "Account Create Transaction";
+    transactionType = 'Account Create Transaction';
   } else if (transaction instanceof AccountUpdateTransaction) {
-    transactionType = "Account Update Transaction";
+    transactionType = 'Account Update Transaction';
   } else if (transaction instanceof AccountDeleteTransaction) {
-    transactionType = "Account Delete Transaction";
+    transactionType = 'Account Delete Transaction';
   } else if (transaction instanceof TransferTransaction) {
-    transactionType = "Transfer Transaction";
+    transactionType = 'Transfer Transaction';
   } else if (transaction instanceof AccountAllowanceApproveTransaction) {
-    transactionType = "Account Allowance Approve Transaction";
+    transactionType = 'Account Allowance Approve Transaction';
   } else if (transaction instanceof FileCreateTransaction) {
-    transactionType = "File Create Transaction";
+    transactionType = 'File Create Transaction';
   } else if (transaction instanceof FileUpdateTransaction) {
-    transactionType = "File Update Transaction";
+    transactionType = 'File Update Transaction';
   } else if (transaction instanceof FileAppendTransaction) {
-    transactionType = "File Append Transaction";
+    transactionType = 'File Append Transaction';
   } else if (transaction instanceof FileDeleteTransaction) {
-    transactionType = "File Delete Transaction";
+    transactionType = 'File Delete Transaction';
   } else if (transaction instanceof FileContentsQuery) {
-    transactionType = "Read File Query";
+    transactionType = 'Read File Query';
   } else if (transaction instanceof FreezeTransaction) {
-    transactionType = "Freeze Transaction";
+    transactionType = 'Freeze Transaction';
   } else if (transaction instanceof NodeCreateTransaction) {
-    transactionType = "Node Create Transaction";
+    transactionType = 'Node Create Transaction';
   } else if (transaction instanceof NodeUpdateTransaction) {
-    transactionType = "Node Update Transaction";
+    transactionType = 'Node Update Transaction';
   } else if (transaction instanceof NodeDeleteTransaction) {
-    transactionType = "Node Delete Transaction";
+    transactionType = 'Node Delete Transaction';
   } else if (transaction instanceof SystemDeleteTransaction) {
-    transactionType = "System Delete Transaction";
+    transactionType = 'System Delete Transaction';
   } else if (transaction instanceof SystemUndeleteTransaction) {
-    transactionType = "System Undelete Transaction";
+    transactionType = 'System Undelete Transaction';
     // } else if (transaction instanceof ContractCallTransaction) {
     //   transactionType = 'ContractCallTransaction';
     // } else if (transaction instanceof ContractCreateTransaction) {

--- a/front-end/src/renderer/utils/transactionSignatureModels/account-update-transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/account-update-transaction.model.ts
@@ -36,10 +36,7 @@ export default class AccountUpdateTransactionModel extends TransactionBaseModel<
 
   private shouldWaiveSigningRequirements(accountId: AccountId): boolean {
     const feePayer = this.getFeePayerAccountId();
-    return (
-      this.isSystemAccount(accountId) &&
-      this.isPrivilegedFeePayer(feePayer)
-    );
+    return this.isSystemAccount(accountId) && this.isPrivilegedFeePayer(feePayer);
   }
 
   private isSystemAccount(accountId: AccountId): boolean {

--- a/front-end/src/renderer/utils/transactionSignatureModels/index.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/index.ts
@@ -18,10 +18,7 @@ export * from './transaction-factory';
 export * from './transaction.model';
 export * from './transfer-transaction.model';
 
-export const computeSignatureKey = async (
-  transaction: SDKTransaction,
-  mirrorNodeLink: string,
-) => {
+export const computeSignatureKey = async (transaction: SDKTransaction, mirrorNodeLink: string) => {
   const transactionModel = TransactionFactory.fromTransaction(transaction);
 
   return await transactionModel.computeSignatureKey(mirrorNodeLink);

--- a/front-end/src/renderer/utils/transactionSignatureModels/transaction-factory.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/transaction-factory.ts
@@ -40,7 +40,10 @@ export default class TransactionFactory {
       NodeDeleteTransaction: NodeDeleteTransactionModel,
     };
 
-    const transactionType = getTransactionType(transaction, true) as keyof typeof transactionModelMap;
+    const transactionType = getTransactionType(
+      transaction,
+      true,
+    ) as keyof typeof transactionModelMap;
 
     if (transactionModelMap[transactionType]) {
       const Model = transactionModelMap[transactionType];

--- a/front-end/src/renderer/utils/transactionSignatureModels/transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/transaction.model.ts
@@ -43,9 +43,7 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
     return null;
   }
 
-  async computeSignatureKey(
-    mirrorNodeLink: string,
-  ) {
+  async computeSignatureKey(mirrorNodeLink: string) {
     const feePayerAccountId = this.getFeePayerAccountId();
     const accounts = this.getSigningAccounts();
     const receiverAccounts = this.getReceiverAccounts();
@@ -110,7 +108,7 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
         const adminKey = nodeInfo.adminKey;
         if (adminKey && !hasKey(adminKey)) {
           signatureKeys.push(adminKey);
-          nodeAdminKeys[nodeId] = adminKey
+          nodeAdminKeys[nodeId] = adminKey;
           currentKeyList.push(adminKey);
         }
 
@@ -125,7 +123,7 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
           const { key } = await getAccountInfo(nodeAccountId, mirrorNodeLink);
           if (key && !has(key)) {
             signatureKeys.push(key);
-            nodeAdminKeys[nodeId] = key
+            nodeAdminKeys[nodeId] = key;
             currentKeyList.push(key);
           }
         }

--- a/front-end/src/renderer/utils/transactions.ts
+++ b/front-end/src/renderer/utils/transactions.ts
@@ -125,7 +125,10 @@ const TransactionStatusName = {
   [TransactionStatus.ARCHIVED]: 'Archived',
 };
 
-export const getTransactionStatusName = (status: TransactionStatus, uppercase: boolean = false): string => {
+export const getTransactionStatusName = (
+  status: TransactionStatus,
+  uppercase: boolean = false,
+): string => {
   const statusName = TransactionStatusName[status];
   return uppercase ? statusName.toUpperCase() : statusName;
 };

--- a/front-end/src/shared/interfaces/HederaSchema.ts
+++ b/front-end/src/shared/interfaces/HederaSchema.ts
@@ -663,7 +663,6 @@ export interface NetworkNode {
   reward_rate_start: number | null;
   decline_reward: boolean | null;
   grpc_proxy_endpoint: ServiceEndPoint | null;
-
 }
 
 export interface ServiceEndPoint {

--- a/front-end/src/shared/utils/byteUtils.ts
+++ b/front-end/src/shared/utils/byteUtils.ts
@@ -1,0 +1,7 @@
+export function areByteArraysEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/front-end/src/tests/main/modules/ipcHandlers/utils.spec.ts
+++ b/front-end/src/tests/main/modules/ipcHandlers/utils.spec.ts
@@ -304,15 +304,7 @@ describe('registerUtilsListeners', () => {
     vi.mocked(BrowserWindow.getAllWindows).mockReturnValue(windows as unknown as BrowserWindow[]);
     vi.mocked(dialog.showSaveDialog).mockResolvedValue(dialogReturnValue);
 
-    await invokeIPCHandler(
-      'utils:saveFileNamed',
-      data,
-      name,
-      title,
-      buttonLabel,
-      filters,
-      message,
-    );
+    await invokeIPCHandler('utils:saveFileNamed', data, name, title, buttonLabel, filters, message);
 
     expect(BrowserWindow.getAllWindows).toHaveBeenCalled();
     expect(dialog.showSaveDialog).toHaveBeenCalledWith(windows[0], {
@@ -337,15 +329,7 @@ describe('registerUtilsListeners', () => {
     vi.mocked(BrowserWindow.getAllWindows).mockReturnValue(windows as unknown as BrowserWindow[]);
     vi.mocked(dialog.showSaveDialog).mockResolvedValueOnce({ filePath: '', canceled: true });
 
-    await invokeIPCHandler(
-      'utils:saveFileNamed',
-      data,
-      name,
-      title,
-      buttonLabel,
-      filters,
-      message,
-    );
+    await invokeIPCHandler('utils:saveFileNamed', data, name, title, buttonLabel, filters, message);
 
     expect(fs.promises.writeFile).not.toHaveBeenCalled();
   });
@@ -542,8 +526,12 @@ describe('setDockBounce listener', () => {
   });
 
   test('should bounce dock if not focused and bounce is true', () => {
-    const fakeWindow = { isFocused: vi.fn().mockReturnValue(false) } as unknown as Electron.BrowserWindow;
-    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([fakeWindow] as unknown as BrowserWindow[]);
+    const fakeWindow = {
+      isFocused: vi.fn().mockReturnValue(false),
+    } as unknown as Electron.BrowserWindow;
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
+      fakeWindow,
+    ] as unknown as BrowserWindow[]);
     const bounceId = 123;
     const bounceMock = vi.fn().mockReturnValue(bounceId);
     const cancelBounceMock = vi.fn();
@@ -554,8 +542,12 @@ describe('setDockBounce listener', () => {
   });
 
   test('should cancel bounce if bounce is false and bounceId is defined', () => {
-    const fakeWindow = { isFocused: vi.fn().mockReturnValue(false) } as unknown as Electron.BrowserWindow;
-    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([fakeWindow] as unknown as BrowserWindow[]);
+    const fakeWindow = {
+      isFocused: vi.fn().mockReturnValue(false),
+    } as unknown as Electron.BrowserWindow;
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
+      fakeWindow,
+    ] as unknown as BrowserWindow[]);
     const bounceMock = vi.fn();
     const cancelBounceMock = vi.fn();
     (app as any).dock = { bounce: bounceMock, cancelBounce: cancelBounceMock };

--- a/front-end/src/tests/main/services/localUser/dataMigration.spec.ts
+++ b/front-end/src/tests/main/services/localUser/dataMigration.spec.ts
@@ -251,9 +251,9 @@ describe('Data Migration', () => {
       vi.mocked(fs.existsSync).mockReturnValueOnce(true);
       vi.mocked(fs.promises.readdir).mockResolvedValueOnce(['publicKey1.pub'] as any);
       vi.mocked(fs.promises.readFile).mockResolvedValueOnce(
-          '302a300506032b6570032100a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90'
+        '302a300506032b6570032100a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90',
       );
-    }
+    };
 
     test('Should correctly migrate user', async () => {
       const mockUserId = 'userId';


### PR DESCRIPTION
**Description**:
When viewing a transaction's details, or a transaction group's details, the app will determine if the transaction was created using the same SDK. This is done by comparing the raw bytes with the deserialized transaction's bytes. If they are not the same, the app cannot sign the transaction.

**Related issue(s)**:

Fixes #1716 

**Notes for reviewer**:
The front-end needed a bunch of reformatting to follow the projects format rules.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
