### PR TITLE
fix(#1651): Update password field label to 'Temporary Password' for clarity.

### DIFF
--- a/front-end/src/renderer/pages/AccountSetup/components/NewPassword.vue
+++ b/front-end/src/renderer/pages/AccountSetup/components/NewPassword.vue
@@ -139,7 +139,7 @@ watch(newPassword, pass => {
           v-model="currentPassword"
           :filled="true"
           :class="{ 'is-invalid': currentPasswordInvalid }"
-          placeholder="Current Password"
+          placeholder="Enter Temporary Password"
           @blur="handleBlur('currentPassword', $event.target.value)"
         />
         <div v-if="currentPasswordInvalid" class="invalid-feedback">


### PR DESCRIPTION
**Description**:

This PR updates the password field label when adding a new organisation.
Previously, the field was labelled “Current Password”, which created confusion.
It is now labelled “Temporary Password” to better reflect the expected input.

**Related issue(s)**:

Fixes #1651 

**Notes for reviewer**:
Only the label text has been updated.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
