### PR TITLE
fix: 1764 display leading zeros in hbar amounts

### DIFF
--- a/front-end/src/renderer/utils/sdk/index.ts
+++ b/front-end/src/renderer/utils/sdk/index.ts
@@ -239,7 +239,7 @@ export function formatHbar(hbar: Hbar) {
 export function stringifyHbar(hbar: Hbar) {
   return hbar.toBigNumber().eq(0)
     ? `0 ${HbarUnit.Hbar._symbol}`
-    : `${hbar.to(HbarUnit.Hbar).toString()} ${HbarUnit.Hbar._symbol}`;
+    : `${formatHbar(hbar)} ${HbarUnit.Hbar._symbol}`;
 }
 
 // export function stringifyHbar(hbar: Hbar) {


### PR DESCRIPTION
**Description**:

Change stringifyHbar() such that it always displays the hbar amount in decimal notation -- and not using scientific notation -- in case of small amounts of tiny bars.

**Related issue(s)**:

Fixes #1764

**Notes for reviewer**:

Without fix:
<img width="772" height="169" alt="Screenshot 2025-08-26 at 16 30 33" src="https://github.com/user-attachments/assets/1555db27-648f-4b9c-8032-34352ffb9196" />

With fix:
<img width="772" height="207" alt="Screenshot 2025-08-26 at 16 29 02" src="https://github.com/user-attachments/assets/fabcf3a0-b14a-4613-ae59-e324c93b52b8" />
