### PR TITLE
feat: 1736 create transfer transactions even if not enough available balance

### DIFF
--- a/front-end/src/renderer/components/TransferCard.vue
+++ b/front-end/src/renderer/components/TransferCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, ref, watch } from 'vue';
+import { ref, watch } from 'vue';
 
 import { Hbar, HbarUnit } from '@hashgraph/sdk';
 
@@ -47,6 +47,7 @@ const accountData = useAccountId();
 /* State */
 const amount = ref<Hbar>(new Hbar(0));
 const isApprovedTransfer = ref(false);
+const amountExceedsBalance = ref(false);
 
 /* Handlers */
 const handleSubmit = () => {
@@ -96,8 +97,9 @@ watch([amount, accountData.isValid], async ([newAmount]) => {
     accountData.isValid.value &&
     accountData.accountInfo.value?.balance.toBigNumber().isLessThan(newAmount.toBigNumber())
   ) {
-    await nextTick();
-    amount.value = accountData.accountInfo.value?.balance as Hbar;
+    amountExceedsBalance.value = true;
+  } else {
+    amountExceedsBalance.value = false;
   }
 });
 </script>
@@ -128,6 +130,10 @@ watch([amount, accountData.isValid], async ([newAmount]) => {
       </div>
       <div class="form-group mt-4">
         <label class="form-label me-3">Amount {{ HbarUnit.Hbar._symbol }}</label>
+        <label v-if="amountExceedsBalance" class="form-label text-danger me-3"
+          ><span class="bi bi-exclamation-triangle-fill me-1"></span> Amount exceeds current
+          balance</label
+        >
         <label v-if="spender?.trim() && isApprovedTransfer" class="form-label text-secondary"
           >Allowance: {{ stringifyHbar(accountData.getSpenderAllowance(spender)) }}</label
         >


### PR DESCRIPTION
**Description**:

Allow the user to enter debit amounts which exceed the corresponding account balance -- by displaying a warning instead of replacing the user input with the current balance.
Flag such amounts in the Transaction details.
Prevent from executing the transaction when in Personnal mode
Allow to export or create and share the transaction when in Organization mode

**Related issue(s)**:

Fixes #1736 

**Notes for reviewer**:
<img width="549" height="293" alt="Screenshot 2025-08-29 at 13 09 59" src="https://github.com/user-attachments/assets/c2115e8b-b130-44c8-91ee-c43f89a9abef" />
<img width="1727" height="1102" alt="Screenshot 2025-08-29 at 13 11 11" src="https://github.com/user-attachments/assets/60cc4f4f-e899-4c7c-81fb-7f3e7c9c8f9f" />
<img width="1727" height="1102" alt="Screenshot 2025-08-29 at 13 12 25" src="https://github.com/user-attachments/assets/2a6b49d4-6ec3-474e-8fdf-ee7a1a88a470" />

