### PR TITLE
fix: do not ask to save new transactions without any alteration

### DIFF
--- a/front-end/src/renderer/components/RunningClockDatePicker.vue
+++ b/front-end/src/renderer/components/RunningClockDatePicker.vue
@@ -16,10 +16,17 @@ const props = defineProps<
 /* Emits */
 const emit = defineEmits<{
   (event: 'update:modelValue', value: Date): void;
+  (event: 'userEdit'): void;
 }>();
 
 /* State */
 const intervalId = ref<ReturnType<typeof setInterval> | null>(null);
+
+/* Handlers */
+const handleUpdateValue = (v: Date) => {
+  emit('update:modelValue', v);
+  emit('userEdit');
+}
 
 /* Functions */
 function startInterval() {
@@ -47,7 +54,7 @@ onUnmounted(() => {
 <template>
   <AppDatePicker
     :model-value="modelValue"
-    @update:model-value="emit('update:modelValue', $event)"
+    @update:model-value="handleUpdateValue"
     :minDate="minDate"
     :maxDate="maxDate"
     :clearable="false"

--- a/front-end/src/renderer/components/Transaction/Create/AccountCreate/AccountCreate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/AccountCreate/AccountCreate.vue
@@ -45,6 +45,8 @@ const data = reactive<AccountCreateData>({
 });
 const nickname = ref('');
 
+const gotUserEdit = ref(false)
+
 /* Computed */
 const createTransaction = computed<CreateTransactionFunc>(() => {
   return common =>
@@ -64,10 +66,13 @@ const createDisabled = computed(() => {
 
 /* Handlers */
 const handleDraftLoaded = (transaction: Transaction) => {
-  handleUpdateData(getAccountCreateData(transaction));
+  handleUpdateData(getAccountCreateData(transaction), false);
 };
 
-const handleUpdateData = (newData: AccountCreateData) => {
+const handleUpdateData = (newData: AccountCreateData, userEdit = true) => {
+  if (userEdit ) {
+    gotUserEdit.value = true
+  }
   Object.assign(data, newData);
 };
 
@@ -132,6 +137,7 @@ watch(
     :create-transaction="createTransaction"
     :pre-create-assert="preCreateAssert"
     :create-disabled="createDisabled"
+    :got-user-edit="gotUserEdit"
     @executed:success="handleExecutedSuccess"
     @draft-loaded="handleDraftLoaded"
   >
@@ -142,6 +148,7 @@ watch(
           <div>
             <AppInput
               v-model="nickname"
+              @update:model-value="gotUserEdit = true"
               :filled="true"
               data-testid="input-nickname"
               placeholder="Enter Account Nickname"

--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransactionModal.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransactionModal.vue
@@ -167,12 +167,7 @@ onBeforeRouteLeave(async to => {
     return true;
   }
 
-  if (isFromScratchGroup.value) {
-    isActionModalShown.value = true;
-    return false;
-  }
-
-  if (!props.skip && isFromScratch.value && !(await draftExists(transactionBytes))) {
+  if (isFromScratchGroup.value && props.hasDataChanged) {
     isActionModalShown.value = true;
     return false;
   }

--- a/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
@@ -27,7 +27,12 @@ const props = defineProps<{
 }>();
 
 /* Emits */
-const emit = defineEmits(['update:payerId', 'update:validStart', 'update:maxTransactionFee']);
+const emit = defineEmits([
+  'update:payerId',
+  'update:validStart',
+  'update:maxTransactionFee',
+  'userEdit',
+]);
 
 /* Stores */
 const user = useUserStore();
@@ -43,10 +48,16 @@ const localValidStart = ref<Date>(props.validStart);
 const handlePayerChange = (payerId: string) => {
   emit('update:payerId', payerId || '');
   account.accountId.value = payerId || '';
+  emit('userEdit');
 };
 
 function handleUpdateValidStart(v: Date) {
   emit('update:validStart', v);
+}
+
+function handleUpdateMaxTransactionFee(v: Hbar) {
+  emit('update:maxTransactionFee', v);
+  emit('userEdit');
 }
 
 /* Hooks */
@@ -135,6 +146,7 @@ const columnClass = 'col-4 col-xxxl-3';
       <RunningClockDatePicker
         :model-value="validStart"
         @update:model-value="handleUpdateValidStart"
+        @user-edit="emit('userEdit')"
         :now-button-visible="true"
         data-testid="date-picker-valid-start"
       />
@@ -143,7 +155,7 @@ const columnClass = 'col-4 col-xxxl-3';
       <label class="form-label">Max Transaction Fee {{ HbarUnit.Hbar._symbol }}</label>
       <AppHbarInput
         :model-value="maxTransactionFee"
-        @update:model-value="v => $emit('update:maxTransactionFee', v)"
+        @update:model-value="handleUpdateMaxTransactionFee"
         :filled="true"
         placeholder="Enter Max Transaction Fee"
         data-testid="input-max-transaction-fee"


### PR DESCRIPTION
**Description**:

Track various possible user edits to be able to assess that a new transaction has not been touched by the user, and hence does not require to display the Discard/Save modal dialog.

**Related issue(s)**:

Fixes #1794

**Notes for reviewer**:
