### PR TITLE
fix: routing when hitting Back button on altered draft

### DIFF
--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransactionModal.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransactionModal.vue
@@ -154,7 +154,7 @@ async function handleSubmit() {
 
 /* Hooks */
 onBeforeRouteLeave(async to => {
-  redirectPath.value = to.path;
+  redirectPath.value = to.fullPath;
   if (to.name?.toString().toLocaleLowerCase().includes('login')) return true;
   if (shouldWarnForUnsaved.value && wantToDeleteModalShown.value === false) {
     wantToDeleteModalShown.value = true;


### PR DESCRIPTION
…TransactionModal

**Description**:

One-line fix to make sure the full route path is saved before displaying the Discard/Save modal dialog, such that we can route appropriately when the user dismisses the dialog.

**Related issue(s)**:

Fixes #1793
