### PR TITLE
feat: increase size of notification and display number of items

### DIFF
--- a/front-end/src/renderer/components/Notifications/NotificationsDropDown.vue
+++ b/front-end/src/renderer/components/Notifications/NotificationsDropDown.vue
@@ -50,7 +50,7 @@ watch(totalCount, newCount => {
       </template>
     </div>
 
-    <div class="dropdown-menu overflow-hidden" :style="{ width: '300px' }">
+    <div class="dropdown-menu overflow-hidden" :style="{ width: '320px' }">
       <ul class="overflow-auto" :style="{ maxHeight: '45vh' }">
         <template v-if="totalCount === 0">
           <li class="dropdown-item text-small text-center user-select-none">No notifications</li>

--- a/front-end/src/renderer/components/Notifications/NotificationsDropDown.vue
+++ b/front-end/src/renderer/components/Notifications/NotificationsDropDown.vue
@@ -43,10 +43,10 @@ watch(totalCount, newCount => {
       </span>
       <template v-if="totalCount > 0">
         <span
-          class="indicator-circle position-absolute absolute-centered"
+          class="position-absolute badge rounded-pill bg-danger"
           data-testid="notification-indicator"
-          :style="{ left: 'unset', right: '10%', top: '35%', width: '10px', height: '10px' }"
-        ></span>
+          :style="{ left: 'unset', right: '0%', top: '0%' }"
+          >{{ totalCount }}</span>
       </template>
     </div>
 

--- a/front-end/src/renderer/components/Notifications/NotificationsDropDown.vue
+++ b/front-end/src/renderer/components/Notifications/NotificationsDropDown.vue
@@ -39,7 +39,7 @@ watch(totalCount, newCount => {
         data-testid="button-notifications"
         :class="{ ringing: isRinging }"
       >
-        <i class="bi bi-bell-fill text-secondary text-subheader fs-4"></i>
+        <i class="bi bi-bell-fill text-secondary text-subheader fs-2"></i>
       </span>
       <template v-if="totalCount > 0">
         <span

--- a/front-end/src/renderer/components/Notifications/NotificationsDropDown.vue
+++ b/front-end/src/renderer/components/Notifications/NotificationsDropDown.vue
@@ -44,9 +44,10 @@ watch(totalCount, newCount => {
       <template v-if="totalCount > 0">
         <span
           class="position-absolute badge rounded-pill bg-danger"
+          :class="{ 'small-badge': totalCount > 9 }"
           data-testid="notification-indicator"
           :style="{ left: 'unset', right: '0%', top: '0%' }"
-          >{{ totalCount }}</span>
+          >{{ totalCount > 9 ? '9+' : totalCount }}</span>
       </template>
     </div>
 

--- a/front-end/src/renderer/styles/_ui-elements.scss
+++ b/front-end/src/renderer/styles/_ui-elements.scss
@@ -1113,6 +1113,11 @@
 }
 
 /* Misc */
+ .small-badge {
+   font-size: 0.7rem;
+   padding: 0.35em 0.45em;
+ }
+
 .key-threshhold-bg,
 .badge-bg {
   background-color: var(--#{$prefix}container-threshhold-key);


### PR DESCRIPTION
**Description**:

- Make the top right notification icon bigger
- Replace simple notification indicator by a badge indicating the number of notifications 
- Make the dropdown a bit larger 

**Related issue(s)**:

Fixes #1802

**Notes for reviewer**:

Before changes:
<img width="533" height="262" alt="Screenshot 2025-09-10 at 11 46 52" src="https://github.com/user-attachments/assets/c4405468-8379-4c0a-a81b-079f1f989c11" />

After changes:
<img width="533" height="262" alt="Screenshot 2025-09-10 at 11 47 56" src="https://github.com/user-attachments/assets/7de6a1c2-44ce-4135-b22b-55aaaa561120" />

With more than 9 notifications:
<img width="533" height="170" alt="Screenshot 2025-09-10 at 15 12 45" src="https://github.com/user-attachments/assets/6e6758de-6cc8-4e06-bfd8-673b70e8f5fc" />

