### PR TITLE
fix: do not ask to save new unaltered transaction drafts

### DIFF
--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransactionModal.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransactionModal.vue
@@ -172,11 +172,6 @@ onBeforeRouteLeave(async to => {
     return false;
   }
 
-  if (!props.skip && isFromScratch.value && !(await draftExists(transactionBytes))) {
-    isActionModalShown.value = true;
-    return false;
-  }
-
   if (!props.skip && isActionModalShown.value === false && props.hasDataChanged) {
     isActionModalShown.value = true;
     return false;


### PR DESCRIPTION
**Description**:

When leaving draft editing, we compare the transaction data (excluding the validStart) with a snapshot taken before the edit to determine whether we need to show the discard/save modal.

When creating a draft from scratch, we set a 500ms timer after the view is mounted to make sure the transaction is fully initialized before we can snapshot it.

**Related issue(s)**:

Fixes #1794

**Notes for reviewer**:

This obsoletes the draft PR #1806, which I am going to close.
