### PR TITLE
feat: importing signatures from TTv1 for backend storage

### DIFF
--- a/back-end/apps/api/src/transactions/dto/index.ts
+++ b/back-end/apps/api/src/transactions/dto/index.ts
@@ -5,6 +5,7 @@ export * from './create-transaction-approver.dto';
 export * from './create-transaction-group.dto';
 export * from './create-transaction-group-item.dto';
 export * from './create-transaction-observers.dto';
+export * from './signature-import-result.dto';
 export * from './transaction.dto';
 export * from './transaction-approver.dto';
 export * from './transaction-group.dto';

--- a/back-end/apps/api/src/transactions/dto/signature-import-result.dto.ts
+++ b/back-end/apps/api/src/transactions/dto/signature-import-result.dto.ts
@@ -1,0 +1,9 @@
+import { Expose } from 'class-transformer';
+
+export class SignatureImportResultDto {
+  @Expose()
+  transactionId: number;
+
+  @Expose()
+  error?: string;
+}

--- a/back-end/apps/api/src/transactions/signers/signers.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.controller.spec.ts
@@ -117,21 +117,6 @@ describe('SignaturesController', () => {
   });
 
   describe('uploadSignatureMap', () => {
-    it('should return an array of signatures', async () => {
-      const result = [signer];
-      const body = {
-        transactionId: 1,
-        signatureMap: new SignatureMap(),
-      };
-
-      signersService.uploadSignatureMaps.mockResolvedValue(result);
-
-      expect(await controller.uploadSignatureMap(body, user)).toEqual(result);
-    });
-  });
-
-
-  describe('uploadSignatureMap', () => {
     it('should transform, validate and upload signature map for a single object', async () => {
       const dtoInput = {
         transactionId: 1,

--- a/back-end/apps/api/src/transactions/signers/signers.controller.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.controller.ts
@@ -15,6 +15,7 @@ import {
   Pagination,
   PaginationParams,
   Serialize,
+  transformAndValidateDto,
   withPaginatedResponse,
 } from '@app/common';
 import { TransactionSigner, User } from '@entities';
@@ -30,8 +31,6 @@ import {
 } from '../dto';
 
 import { SignersService } from './signers.service';
-import { validateOrReject } from 'class-validator';
-import { plainToInstance } from 'class-transformer';
 
 @ApiTags('Transaction Signers')
 @Controller('transactions/:transactionId?/signers')
@@ -96,16 +95,7 @@ export class SignersController {
     @Body() body: UploadSignatureMapDto | UploadSignatureMapDto[],
     @GetUser() user: User,
   ): Promise<TransactionSigner[]> {
-    const signatureMaps = Array.isArray(body) ? body : [body];
-
-    // Transform and validate each item in the array
-    const transformedSignatureMaps = signatureMaps.map((map) =>
-      plainToInstance(UploadSignatureMapDto, map)
-    );
-
-    await Promise.all(
-      transformedSignatureMaps.map((map) => validateOrReject(map))
-    );
+    const transformedSignatureMaps = await transformAndValidateDto(UploadSignatureMapDto, body);
 
     return this.signaturesService.uploadSignatureMaps(transformedSignatureMaps, user);
   }

--- a/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
@@ -241,6 +241,164 @@ describe('SignaturesService', () => {
       user.keys[0].publicKey = originalPublicKey;
     });
 
+    it('should upload signature, but not update transaction bytes if no change', async () => {
+      const transactionId = 3;
+      const originalPublicKey = user.keys[0].publicKey;
+      const publicKeyId = user.keys[0].id;
+      const privateKey = PrivateKey.generateECDSA();
+      user.keys[0].publicKey = privateKey.publicKey.toStringRaw();
+
+      const sdkTransaction = new AccountCreateTransaction()
+        .setTransactionId(TransactionId.generate('0.0.2'))
+        .setNodeAccountIds([AccountId.fromString('0.0.3')])
+        .freeze();
+      await sdkTransaction.sign(privateKey);
+      const transaction = {
+        id: transactionId,
+        transactionBytes: sdkTransaction.toBytes(),
+        status: TransactionStatus.WAITING_FOR_EXECUTION,
+        mirrorNetwork: 'testnet',
+      };
+
+      dataSource.manager.findOneBy
+        .mockResolvedValueOnce(transaction);
+      jest.mocked(isExpired).mockReturnValue(false);
+      jest.mocked(safe).mockReturnValue({ data: [privateKey.publicKey] });
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([publicKeyId]);
+
+      const queryRunner = mockDeep<QueryRunner>();
+      dataSource.createQueryRunner.mockReturnValueOnce(queryRunner);
+
+      await service.uploadSignatureMaps(
+        [{ transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        user,
+      );
+
+      expect(dataSource.manager.update).not.toHaveBeenCalled();
+      expect(signersRepo.create).toHaveBeenCalledWith({
+        user,
+        transaction,
+        userKey: user.keys[0],
+      });
+
+      expect(emitUpdateTransactionStatus).toHaveBeenCalledWith(chainService, transactionId);
+      expect(notifyTransactionAction).toHaveBeenCalledWith(notificationService);
+      expect(notifySyncIndicators).toHaveBeenCalledWith(
+        notificationService,
+        transactionId,
+        transaction.status,
+        { network: transaction.mirrorNetwork },
+      );
+
+      user.keys[0].publicKey = originalPublicKey;
+    });
+
+    it('should update transaction bytes, but not upload signature if it already exists', async () => {
+      const transactionId = 3;
+      const originalPublicKey = user.keys[0].publicKey;
+      const publicKeyId = user.keys[0].id;
+      const privateKey = PrivateKey.generateECDSA();
+      user.keys[0].publicKey = privateKey.publicKey.toStringRaw();
+
+      const sdkTransaction = new AccountCreateTransaction()
+        .setTransactionId(TransactionId.generate('0.0.2'))
+        .setNodeAccountIds([AccountId.fromString('0.0.3')])
+        .freeze();
+      const transaction = {
+        id: transactionId,
+        transactionBytes: sdkTransaction.toBytes(),
+        status: TransactionStatus.WAITING_FOR_EXECUTION,
+        mirrorNetwork: 'testnet',
+      };
+      await sdkTransaction.sign(privateKey);
+      const signer = {
+        id: 1,
+        transactionId,
+        userKeyId: publicKeyId,
+      }
+
+      dataSource.manager.findOneBy
+        .mockResolvedValueOnce(transaction)
+        .mockResolvedValueOnce(signer);
+      jest.mocked(isExpired).mockReturnValue(false);
+      jest.mocked(safe).mockReturnValue({ data: [privateKey.publicKey] });
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([publicKeyId]);
+
+      const queryRunner = mockDeep<QueryRunner>();
+      dataSource.createQueryRunner.mockReturnValueOnce(queryRunner);
+
+      await service.uploadSignatureMaps(
+        [{ transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        user,
+      );
+
+      expect(dataSource.manager.update).toHaveBeenCalledWith(
+        Transaction,
+        { id: transactionId },
+        expect.anything(),
+      );
+
+      expect(signersRepo.create).not.toHaveBeenCalled();
+      expect(emitUpdateTransactionStatus).toHaveBeenCalledWith(chainService, transactionId);
+      expect(notifyTransactionAction).toHaveBeenCalledWith(notificationService);
+      expect(notifySyncIndicators).toHaveBeenCalledWith(
+        notificationService,
+        transactionId,
+        transaction.status,
+        { network: transaction.mirrorNetwork },
+      );
+
+      user.keys[0].publicKey = originalPublicKey;
+    });
+
+    it('should ignore signature if it already exists', async () => {
+      const transactionId = 3;
+      const originalPublicKey = user.keys[0].publicKey;
+      const publicKeyId = user.keys[0].id;
+      const privateKey = PrivateKey.generateECDSA();
+      user.keys[0].publicKey = privateKey.publicKey.toStringRaw();
+
+      const sdkTransaction = new AccountCreateTransaction()
+        .setTransactionId(TransactionId.generate('0.0.2'))
+        .setNodeAccountIds([AccountId.fromString('0.0.3')])
+        .freeze();
+      await sdkTransaction.sign(privateKey);
+      const transaction = {
+        id: transactionId,
+        transactionBytes: sdkTransaction.toBytes(),
+        status: TransactionStatus.WAITING_FOR_EXECUTION,
+        mirrorNetwork: 'testnet',
+      };
+      const signer = {
+        id: 1,
+        transactionId,
+        userKeyId: publicKeyId,
+      }
+
+      dataSource.manager.findOneBy
+        .mockResolvedValueOnce(transaction)
+        .mockResolvedValueOnce(signer);
+      jest.mocked(isExpired).mockReturnValue(false);
+      jest.mocked(safe).mockReturnValue({ data: [privateKey.publicKey] });
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([publicKeyId]);
+
+      const queryRunner = mockDeep<QueryRunner>();
+      dataSource.createQueryRunner.mockReturnValueOnce(queryRunner);
+
+      await service.uploadSignatureMaps(
+        [{ transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        user,
+      );
+
+      expect(dataSource.manager.update).not.toHaveBeenCalled();
+      expect(signersRepo.create).not.toHaveBeenCalled();
+      expect(emitUpdateTransactionStatus).not.toHaveBeenCalled();
+      expect(notifyTransactionAction).not.toHaveBeenCalled();
+      expect(notifySyncIndicators).not.toHaveBeenCalled();
+
+      user.keys[0].publicKey = originalPublicKey;
+    });
+
     it('should throw if signature public key does not belong to sender', async () => {
       const transactionId = 3;
       const publicKey = PrivateKey.generate().publicKey;

--- a/back-end/apps/api/src/transactions/transactions.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.controller.spec.ts
@@ -2,6 +2,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { mockDeep } from 'jest-mock-extended';
 import { EntityManager } from 'typeorm';
+import { plainToInstance } from 'class-transformer';
+import { validateOrReject } from 'class-validator';
+
+import { SignatureMap } from '@hashgraph/sdk';
 
 import { BlacklistService, guardMock, Pagination } from '@app/common';
 import { Transaction, TransactionStatus, TransactionType, User, UserStatus } from '@entities';
@@ -10,6 +14,22 @@ import { HasKeyGuard, VerifiedUserGuard } from '../guards';
 
 import { TransactionsController } from './transactions.controller';
 import { TransactionsService } from './transactions.service';
+import { UploadSignatureMapDto } from './dto';
+
+jest.mock('class-transformer', () => {
+  const actualModule = jest.requireActual('class-transformer');
+  return {
+    ...actualModule,
+    plainToInstance: jest.fn(),
+  };
+});
+jest.mock('class-validator', () => {
+  const actualModule = jest.requireActual('class-validator');
+  return {
+    ...actualModule,
+    validateOrReject: jest.fn(),
+  };
+});
 
 describe('TransactionsController', () => {
   let controller: TransactionsController;
@@ -114,6 +134,10 @@ describe('TransactionsController', () => {
     };
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('createTransaction', () => {
     it('should return a transaction', async () => {
       const dto = { ...transaction, creatorKeyId: 1 };
@@ -121,6 +145,61 @@ describe('TransactionsController', () => {
       transactionService.createTransaction.mockResolvedValue(transaction);
 
       expect(await controller.createTransaction(dto, user)).toBe(transaction);
+    });
+  });
+
+  describe('importSignatures', () => {
+    it('should transform, validate and import signature map for a single object', async () => {
+      const dtoInput = {
+        transactionId: 1,
+        signatureMap: new SignatureMap(),
+      };
+      const transformedDto = { transformed: 'value' };
+
+      // Mock plainToInstance to return a transformed object
+      (plainToInstance as jest.Mock).mockReturnValueOnce(transformedDto);
+      // Stub validateOrReject to resolve
+      (validateOrReject as jest.Mock).mockResolvedValue(undefined);
+      const expectedResult = [{ id: 1 }];
+      (transactionService.importSignatures as jest.Mock).mockResolvedValue(expectedResult);
+
+      const result = await controller.importSignatures(dtoInput, user);
+
+      expect(plainToInstance).toHaveBeenCalledWith(UploadSignatureMapDto, dtoInput);
+      expect(validateOrReject).toHaveBeenCalledWith(transformedDto);
+      expect(transactionService.importSignatures).toHaveBeenCalledWith([transformedDto], user);
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should transform, validate and import signature maps for an array of objects', async () => {
+      const dtoInput = [
+        {
+          transactionId: 1,
+          signatureMap: new SignatureMap(),
+        },
+        {
+          transactionId: 2,
+          signatureMap: new SignatureMap(),
+        }
+      ];
+      const transformedDtos = [{ transformed: 'value1' }, { transformed: 'value2' }];
+
+      // For each call, return the corresponding transformed object
+      (plainToInstance as jest.Mock)
+        .mockReturnValueOnce(transformedDtos[0])
+        .mockReturnValueOnce(transformedDtos[1]);
+      (validateOrReject as jest.Mock).mockResolvedValue(undefined);
+      const expectedResult = [{ id: 1 }, { id: 2 }];
+      (transactionService.importSignatures as jest.Mock).mockResolvedValue(expectedResult);
+
+      const result = await controller.importSignatures(dtoInput, user);
+
+      expect(plainToInstance).toHaveBeenCalledTimes(2);
+      expect((plainToInstance as jest.Mock).mock.calls[0]).toEqual([UploadSignatureMapDto, dtoInput[0]]);
+      expect((plainToInstance as jest.Mock).mock.calls[1]).toEqual([UploadSignatureMapDto, dtoInput[1]]);
+      expect(validateOrReject).toHaveBeenCalledTimes(2);
+      expect(transactionService.importSignatures).toHaveBeenCalledWith(transformedDtos, user);
+      expect(result).toEqual(expectedResult);
     });
   });
 

--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -18,6 +18,8 @@ import {
   TransactionId,
   Timestamp,
   Client,
+  PrivateKey,
+  SignatureMap,
 } from '@hashgraph/sdk';
 
 import {
@@ -26,6 +28,8 @@ import {
   ErrorCodes,
   CHAIN_SERVICE,
   SchedulerService,
+  safe,
+  emitUpdateTransactionStatus,
 } from '@app/common';
 import {
   attachKeys,
@@ -620,6 +624,165 @@ describe('TransactionsService', () => {
       await expect(service.createTransaction(dto, user as User)).rejects.toThrow(ErrorCodes.TOS);
 
       client.close();
+    });
+  });
+
+  describe('importSignatures', () => {
+    let sdkTransaction: AccountCreateTransaction;
+
+    const transactionId = 3;
+    const privateKey = PrivateKey.generateECDSA();
+
+    const userWithKeys = {
+      ...user,
+      keys: [
+        { id: 1, publicKey: privateKey.publicKey.toStringRaw(), mnemonicHash: 'hash' },
+      ],
+    } as User;
+
+    beforeEach(async () => {
+      sdkTransaction = new AccountCreateTransaction()
+        .setTransactionId(TransactionId.generate('0.0.2'))
+        .setNodeAccountIds([AccountId.fromString('0.0.3')])
+        .freeze();
+
+      jest.resetAllMocks();
+    });
+
+    it('should import signatures successfully', async () => {
+      const transaction = {
+        id: transactionId,
+        transactionId: sdkTransaction.transactionId.toString(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      await sdkTransaction.sign(privateKey);
+
+      entityManager.findOneBy.mockResolvedValue(transaction);
+
+      jest.mocked(safe).mockReturnValue({
+        data: [privateKey.publicKey],
+      });
+
+      entityManager.update.mockResolvedValue(undefined);
+
+      const result = await service.importSignatures(
+        [{ transactionId: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys
+      );
+      expect(result).toEqual([{ transactionId: transactionId }]);
+      expect(emitUpdateTransactionStatus).toHaveBeenCalledWith(chainService, transactionId);
+      expect(notifyTransactionAction).toHaveBeenCalledWith(notificationsService);
+      expect(notifySyncIndicators).toHaveBeenCalledWith(
+        notificationsService,
+        transactionId,
+        transaction.status,
+        {
+          transactionId: sdkTransaction.transactionId.toString(),
+          network: transaction.mirrorNetwork,
+        }
+      );
+    });
+
+    it('should return error if transaction not found', async () => {
+      entityManager.findOneBy.mockResolvedValue(null);
+
+      const result = await service.importSignatures(
+        [{ transactionId: transactionId, signatureMap: new SignatureMap() }],
+        userWithKeys
+      );
+      expect(result[0].error).toContain(ErrorCodes.TNF);
+    });
+
+    it('should return error if transaction status is not valid', async () => {
+      const transaction = {
+        id: transactionId,
+        status: TransactionStatus.CANCELED,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      await sdkTransaction.sign(privateKey);
+
+      entityManager.findOneBy.mockResolvedValue(transaction);
+
+      const result = await service.importSignatures(
+        [{ transactionId: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys
+      );
+      expect(result[0].error).toContain(ErrorCodes.TNRS);
+    });
+
+    it('should return error if transaction is expired', async () => {
+      const transaction = {
+        id: transactionId,
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      await sdkTransaction.sign(privateKey);
+
+      entityManager.findOneBy.mockResolvedValue(transaction);
+      jest.mocked(isExpired).mockReturnValue(true);
+
+      const result = await service.importSignatures(
+        [{ transactionId: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys
+      );
+      expect(result[0]).toMatchObject({
+        transactionId: transactionId,
+        error: ErrorCodes.TE,
+      });
+    });
+
+    it('should return error if signature validation fails', async () => {
+      const transaction = {
+        id: transactionId,
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      await sdkTransaction.sign(privateKey);
+      entityManager.findOneBy.mockResolvedValue(transaction);
+
+      jest.mocked(safe).mockImplementationOnce(() => {
+        return { error: 'error' };
+      });
+
+      const result = await service.importSignatures(
+        [{ transactionId: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys
+      );
+      expect(result[0]).toMatchObject({
+        transactionId: transactionId,
+        error: ErrorCodes.ISNMPN,
+      });
+    });
+
+    it('should return error if entityManager.update throws', async () => {
+      const transaction = {
+        id: transactionId,
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      await sdkTransaction.sign(privateKey);
+      entityManager.findOneBy.mockResolvedValue(transaction);
+
+      jest.mocked(safe).mockReturnValue({
+        data: [privateKey.publicKey],
+      });
+
+      entityManager.update.mockRejectedValue(new Error('fail'));
+
+      const result = await service.importSignatures(
+        [{ transactionId: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys
+      );
+      expect(result[0]).toMatchObject({
+        transactionId: transactionId,
+        error: 'An unexpected error occurred while importing the signatures',
+      });
     });
   });
 

--- a/back-end/libs/common/src/dtos/index.ts
+++ b/back-end/libs/common/src/dtos/index.ts
@@ -1,3 +1,6 @@
+import { plainToInstance } from 'class-transformer';
+import { validateOrReject } from 'class-validator';
+
 export * from './chain-update-transaction-status.dto';
 export * from './execute-transaction-group.dto';
 export * from './execute-transaction.dto';
@@ -9,3 +12,13 @@ export * from './notifications-sync-indicators.dto';
 export * from './paginated-resource.dto';
 export * from './transaction-executed.dto';
 export * from './transaction-group-executed.dto';
+
+export async function transformAndValidateDto<T extends object>(
+  dtoClass: new (...args: any[]) => T,
+  payload: T | T[],
+): Promise<T[]> {
+  const items = Array.isArray(payload) ? payload : [payload];
+  const instances = items.map(item => plainToInstance(dtoClass, item));
+  await Promise.all(instances.map(instance => validateOrReject(instance)));
+  return instances;
+}

--- a/front-end/src/renderer/services/organization/transaction.ts
+++ b/front-end/src/renderer/services/organization/transaction.ts
@@ -5,10 +5,11 @@ import type {
   ITransactionFull,
   Network,
   PaginatedResourceDto,
+  SignatureImportResultDto,
 } from '@shared/interfaces';
 import type { ITransactionApprover, TransactionApproverDto } from '@shared/interfaces';
 
-import { Transaction } from '@hashgraph/sdk';
+import { Transaction as SDKTransaction } from '@hashgraph/sdk';
 
 import { ObserverRole, TransactionStatus } from '@shared/interfaces';
 
@@ -81,7 +82,7 @@ export const uploadSignatures = async (
   userPassword: string | null,
   organization: LoggedInOrganization & Organization,
   publicKeys?: string[],
-  transaction?: Transaction,
+  transaction?: SDKTransaction,
   transactionId?: number,
   items?: SignatureItem[],
 ) => {
@@ -122,6 +123,26 @@ export const uploadSignatures = async (
     );
   }, 'Failed upload signatures');
 };
+
+export const importSignatures = async (
+  organization: LoggedInOrganization & Organization,
+  transaction: SDKTransaction[] | SDKTransaction,
+): Promise<SignatureImportResultDto[]> => {
+  const formattedMaps = [];
+  const transactions = Array.isArray(transaction) ? transaction : [transaction];
+  for (const tx of transactions) {
+    formattedMaps.push({
+      transactionId: tx.transactionId,
+      signatureMap: formatSignatureMap(tx.getSignatures()),
+    });
+  }
+  return commonRequestHandler(async () => {
+    await axiosWithCredentials.post(
+      `${organization.serverUrl}/${controller}/signatures/import`,
+      formattedMaps,
+    );
+  }, 'Failed to import signatures');
+}
 
 /* Get transactions to sign */
 export const getTransactionsToSign = async (

--- a/front-end/src/shared/interfaces/organization/transactions/index.ts
+++ b/front-end/src/shared/interfaces/organization/transactions/index.ts
@@ -97,3 +97,8 @@ export interface IGroup {
 }
 
 export type IDefaultNetworks = 'mainnet' | 'testnet' | 'previewnet' | 'local-node';
+
+export interface SignatureImportResultDto {
+  transactionId: number;
+  error?: string;
+}


### PR DESCRIPTION
**Description**:
Signatures from the Java Transaction Tool (TTv1) need to be supported by the latest Transaction Tool. An endpoint for the backend has been added to allow for importing signatures, in the form of a SignatureMap. The front end has been updated with the necessary code to call this endpoint, only. 

**Related issue(s)**:

Fixes #1825 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
