### PR TITLE
fix: bypass the need for the transaction parameter.

### DIFF
--- a/front-end/src/renderer/services/organization/transaction.ts
+++ b/front-end/src/renderer/services/organization/transaction.ts
@@ -1,13 +1,15 @@
 import type { Organization } from '@prisma/client';
 import type { LoggedInOrganization, SignatureItem } from '@renderer/types';
 import type {
+  ISignatureImport,
   ITransaction,
+  ITransactionApprover,
+  TransactionApproverDto,
   ITransactionFull,
   Network,
   PaginatedResourceDto,
   SignatureImportResultDto,
 } from '@shared/interfaces';
-import type { ITransactionApprover, TransactionApproverDto } from '@shared/interfaces';
 
 import { Transaction as SDKTransaction } from '@hashgraph/sdk';
 
@@ -124,16 +126,22 @@ export const uploadSignatures = async (
   }, 'Failed upload signatures');
 };
 
+/**
+ * Imports signatures for a transaction.
+ *
+ * @param organization
+ * @param signatureImport
+ */
 export const importSignatures = async (
   organization: LoggedInOrganization & Organization,
-  transaction: SDKTransaction[] | SDKTransaction,
+  signatureImport: ISignatureImport[] | ISignatureImport,
 ): Promise<SignatureImportResultDto[]> => {
   const formattedMaps = [];
-  const transactions = Array.isArray(transaction) ? transaction : [transaction];
-  for (const tx of transactions) {
+  const imports = Array.isArray(signatureImport) ? signatureImport : [signatureImport];
+  for (const signatureImport of imports) {
     formattedMaps.push({
-      transactionId: tx.transactionId,
-      signatureMap: formatSignatureMap(tx.getSignatures()),
+      transactionId: signatureImport.transactionId,
+      signatureMap: formatSignatureMap(signatureImport.signatureMap),
     });
   }
   return commonRequestHandler(async () => {

--- a/front-end/src/shared/interfaces/organization/transactions/index.ts
+++ b/front-end/src/shared/interfaces/organization/transactions/index.ts
@@ -1,3 +1,5 @@
+import { SignatureMap } from '@hashgraph/sdk';
+
 import type { ITransactionApprover } from '../approvers';
 import type { ITransactionObserverUserId } from '../observers';
 import type { ITransactionSignerUserKey } from '../signers';
@@ -97,6 +99,12 @@ export interface IGroup {
 }
 
 export type IDefaultNetworks = 'mainnet' | 'testnet' | 'previewnet' | 'local-node';
+
+/** Request/Response DTOs */
+export interface ISignatureImport {
+  transactionId: number; // ID of the transaction to which the signatures belong. In a bulk transaction (File Append with multiple transactions inside), this ID refers to the parent transaction.
+  signatureMap: SignatureMap;
+}
 
 export interface SignatureImportResultDto {
   transactionId: number;


### PR DESCRIPTION
**Description**:
When importing from TTv1, the entire signatureMap is serialized. Now, the signatureMap can be deserialized and sent directly to the backend, it does not need to first be added to the transaction. 

Either solution would work, but this approach allows the developer more control over which signatures will be uploaded instead of having to manipulate the transaction directly, in some cases. 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
