### PR TITLE
chore: rename transactionId to id for signature uploads

### DIFF
--- a/back-end/apps/api/src/transactions/dto/signature-import-result.dto.ts
+++ b/back-end/apps/api/src/transactions/dto/signature-import-result.dto.ts
@@ -1,8 +1,9 @@
 import { Expose } from 'class-transformer';
 
 export class SignatureImportResultDto {
+  // The database ID of the transaction
   @Expose()
-  transactionId: number;
+  id: number;
 
   @Expose()
   error?: string;

--- a/back-end/apps/api/src/transactions/dto/upload-signature.dto.ts
+++ b/back-end/apps/api/src/transactions/dto/upload-signature.dto.ts
@@ -10,7 +10,7 @@ export class UploadSignatureMapDto {
   })
   @IsDefined()
   @IsNumber()
-  transactionId: number;
+  id: number;
 
   @ApiProperty({
     type: 'object',

--- a/back-end/apps/api/src/transactions/signers/signers.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.controller.spec.ts
@@ -119,7 +119,7 @@ describe('SignaturesController', () => {
   describe('uploadSignatureMap', () => {
     it('should transform, validate and upload signature map for a single object', async () => {
       const dtoInput = {
-        transactionId: 1,
+        id: 1,
         signatureMap: new SignatureMap(),
       };
       const transformedDto = { transformed: 'value' };
@@ -142,11 +142,11 @@ describe('SignaturesController', () => {
     it('should transform, validate and upload signature maps for an array of objects', async () => {
       const dtoInput = [
         {
-          transactionId: 1,
+          id: 1,
           signatureMap: new SignatureMap(),
         },
         {
-          transactionId: 2,
+          id: 2,
           signatureMap: new SignatureMap(),
         }
       ];

--- a/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
@@ -214,7 +214,7 @@ describe('SignaturesService', () => {
       dataSource.createQueryRunner.mockReturnValueOnce(queryRunner);
 
       await service.uploadSignatureMaps(
-        [{ transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
         user,
       );
 
@@ -270,7 +270,7 @@ describe('SignaturesService', () => {
       dataSource.createQueryRunner.mockReturnValueOnce(queryRunner);
 
       await service.uploadSignatureMaps(
-        [{ transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
         user,
       );
 
@@ -328,7 +328,7 @@ describe('SignaturesService', () => {
       dataSource.createQueryRunner.mockReturnValueOnce(queryRunner);
 
       await service.uploadSignatureMaps(
-        [{ transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
         user,
       );
 
@@ -386,7 +386,7 @@ describe('SignaturesService', () => {
       dataSource.createQueryRunner.mockReturnValueOnce(queryRunner);
 
       await service.uploadSignatureMaps(
-        [{ transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
         user,
       );
 
@@ -419,7 +419,7 @@ describe('SignaturesService', () => {
       jest.mocked(userKeysRequiredToSign).mockResolvedValue([2]);
 
       await expect(
-        service.uploadSignatureMaps([{ transactionId, signatureMap }], user),
+        service.uploadSignatureMaps([{ id: transactionId, signatureMap }], user),
       ).rejects.toThrow(ErrorCodes.PNY);
       expectNotifyNotCalled();
     });
@@ -430,7 +430,7 @@ describe('SignaturesService', () => {
       dataSource.manager.findOneBy.mockResolvedValueOnce(null);
 
       await expect(
-        service.uploadSignatureMaps([{ transactionId, signatureMap }], user),
+        service.uploadSignatureMaps([{ id: transactionId, signatureMap }], user),
       ).rejects.toThrow(ErrorCodes.TNF);
       expectNotifyNotCalled();
     });
@@ -449,7 +449,7 @@ describe('SignaturesService', () => {
       jest.mocked(isExpired).mockReturnValue(true);
 
       await expect(
-        service.uploadSignatureMaps([{ transactionId, signatureMap }], user),
+        service.uploadSignatureMaps([{ id: transactionId, signatureMap }], user),
       ).rejects.toThrow(ErrorCodes.TE);
       expectNotifyNotCalled();
     });
@@ -468,7 +468,7 @@ describe('SignaturesService', () => {
       jest.mocked(isExpired).mockReturnValue(false);
 
       await expect(
-        service.uploadSignatureMaps([{ transactionId, signatureMap }], user),
+        service.uploadSignatureMaps([{ id: transactionId, signatureMap }], user),
       ).rejects.toThrow(ErrorCodes.TNRS);
       expectNotifyNotCalled();
     });
@@ -490,7 +490,7 @@ describe('SignaturesService', () => {
       });
 
       await expect(
-        service.uploadSignatureMaps([{ transactionId, signatureMap }], user),
+        service.uploadSignatureMaps([{ id: transactionId, signatureMap }], user),
       ).rejects.toThrow(ErrorCodes.ISNMPN);
       expectNotifyNotCalled();
     });
@@ -526,7 +526,7 @@ describe('SignaturesService', () => {
       await expect(
         service.uploadSignatureMaps(
           [{
-            transactionId,
+            id: transactionId,
             signatureMap: sdkTransaction.getSignatures()
           }],
           user,

--- a/back-end/apps/api/src/transactions/transactions.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.controller.spec.ts
@@ -151,7 +151,7 @@ describe('TransactionsController', () => {
   describe('importSignatures', () => {
     it('should transform, validate and import signature map for a single object', async () => {
       const dtoInput = {
-        transactionId: 1,
+        id: 1,
         signatureMap: new SignatureMap(),
       };
       const transformedDto = { transformed: 'value' };
@@ -174,11 +174,11 @@ describe('TransactionsController', () => {
     it('should transform, validate and import signature maps for an array of objects', async () => {
       const dtoInput = [
         {
-          transactionId: 1,
+          id: 1,
           signatureMap: new SignatureMap(),
         },
         {
-          transactionId: 2,
+          id: 2,
           signatureMap: new SignatureMap(),
         }
       ];

--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -668,10 +668,10 @@ describe('TransactionsService', () => {
       entityManager.update.mockResolvedValue(undefined);
 
       const result = await service.importSignatures(
-        [{ transactionId: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
         userWithKeys
       );
-      expect(result).toEqual([{ transactionId: transactionId }]);
+      expect(result).toEqual([{ id: transactionId }]);
       expect(emitUpdateTransactionStatus).toHaveBeenCalledWith(chainService, transactionId);
       expect(notifyTransactionAction).toHaveBeenCalledWith(notificationsService);
       expect(notifySyncIndicators).toHaveBeenCalledWith(
@@ -689,7 +689,7 @@ describe('TransactionsService', () => {
       entityManager.findOneBy.mockResolvedValue(null);
 
       const result = await service.importSignatures(
-        [{ transactionId: transactionId, signatureMap: new SignatureMap() }],
+        [{ id: transactionId, signatureMap: new SignatureMap() }],
         userWithKeys
       );
       expect(result[0].error).toContain(ErrorCodes.TNF);
@@ -707,7 +707,7 @@ describe('TransactionsService', () => {
       entityManager.findOneBy.mockResolvedValue(transaction);
 
       const result = await service.importSignatures(
-        [{ transactionId: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
         userWithKeys
       );
       expect(result[0].error).toContain(ErrorCodes.TNRS);
@@ -726,11 +726,11 @@ describe('TransactionsService', () => {
       jest.mocked(isExpired).mockReturnValue(true);
 
       const result = await service.importSignatures(
-        [{ transactionId: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
         userWithKeys
       );
       expect(result[0]).toMatchObject({
-        transactionId: transactionId,
+        id: transactionId,
         error: ErrorCodes.TE,
       });
     });
@@ -750,11 +750,11 @@ describe('TransactionsService', () => {
       });
 
       const result = await service.importSignatures(
-        [{ transactionId: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
         userWithKeys
       );
       expect(result[0]).toMatchObject({
-        transactionId: transactionId,
+        id: transactionId,
         error: ErrorCodes.ISNMPN,
       });
     });
@@ -776,11 +776,11 @@ describe('TransactionsService', () => {
       entityManager.update.mockRejectedValue(new Error('fail'));
 
       const result = await service.importSignatures(
-        [{ transactionId: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
         userWithKeys
       );
       expect(result[0]).toMatchObject({
-        transactionId: transactionId,
+        id: transactionId,
         error: 'An unexpected error occurred while importing the signatures',
       });
     });

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -418,8 +418,8 @@ export class TransactionsService {
     user: User,
   ): Promise<SignatureImportResultDto[]> {
     const results = new Set<SignatureImportResultDto>();
-    for (const { transactionId, signatureMap: map } of dto) {
-      const transaction = await this.entityManager.findOneBy(Transaction, { id: transactionId });
+    for (const { id, signatureMap: map } of dto) {
+      const transaction = await this.entityManager.findOneBy(Transaction, { id });
       try {
         /* Verify that the transaction exists */
         if (!transaction) throw new BadRequestException(ErrorCodes.TNF);
@@ -450,20 +450,20 @@ export class TransactionsService {
 
         await this.entityManager.update(
           Transaction,
-          { id: transactionId },
+          { id },
           { transactionBytes: sdkTransaction.toBytes() },
         );
 
-        results.add({ transactionId });
-        emitUpdateTransactionStatus(this.chainService, transactionId);
+        results.add({ id });
+        emitUpdateTransactionStatus(this.chainService, id);
         notifyTransactionAction(this.notificationsService);
-        notifySyncIndicators(this.notificationsService, transactionId, transaction.status, {
+        notifySyncIndicators(this.notificationsService, id, transaction.status, {
           transactionId: transaction.transactionId,
           network: transaction.mirrorNetwork,
         });
       } catch (error) {
         results.add({
-          transactionId,
+          id,
           error:
             error instanceof BadRequestException
               ? error.message

--- a/front-end/src/renderer/services/organization/transaction.ts
+++ b/front-end/src/renderer/services/organization/transaction.ts
@@ -113,7 +113,7 @@ export const uploadSignatures = async (
 
     const signatureMap = getSignatureMapForPublicKeys(publicKeys, transaction);
     formattedMaps.push({
-      transactionId: transactionId,
+      id: transactionId,
       signatureMap: formatSignatureMap(signatureMap),
     });
   }
@@ -140,7 +140,7 @@ export const importSignatures = async (
   const imports = Array.isArray(signatureImport) ? signatureImport : [signatureImport];
   for (const signatureImport of imports) {
     formattedMaps.push({
-      transactionId: signatureImport.transactionId,
+      id: signatureImport.id,
       signatureMap: formatSignatureMap(signatureImport.signatureMap),
     });
   }

--- a/front-end/src/shared/interfaces/organization/transactions/index.ts
+++ b/front-end/src/shared/interfaces/organization/transactions/index.ts
@@ -102,11 +102,11 @@ export type IDefaultNetworks = 'mainnet' | 'testnet' | 'previewnet' | 'local-nod
 
 /** Request/Response DTOs */
 export interface ISignatureImport {
-  transactionId: number; // ID of the transaction to which the signatures belong. In a bulk transaction (File Append with multiple transactions inside), this ID refers to the parent transaction.
+  id: number; // Database ID of the transaction to which the signatures belong. In a bulk transaction (File Append with multiple transactions inside), this ID refers to the parent transaction.
   signatureMap: SignatureMap;
 }
 
 export interface SignatureImportResultDto {
-  transactionId: number;
+  id: number; // The database ID of the transaction
   error?: string;
 }


### PR DESCRIPTION
**Description**:
Confusion exists between the transactionId of a transaction, and the id of a transaction. This caused an issue when handing work off from one person to another. For just the signature uploading, this has been changed to use the property name of 'id' instead of 'transactionId'. Some comments have also been added to help explain the name change. 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
