### PR TITLE
Added missing return at the end of getServiceEndpoint()

### DIFF
--- a/front-end/src/renderer/utils/sdk/createTransactions.ts
+++ b/front-end/src/renderer/utils/sdk/createTransactions.ts
@@ -475,6 +475,8 @@ export const getServiceEndpoint = (serviceEndpoint: ComponentServiceEndpoint | n
     }
     return serviceEndpoint;
   }
+
+  return null;
 };
 
 const setNodeData = (


### PR DESCRIPTION
**Description**:

`createTransaction.getServiceEndpoint()` is missing a final `return null`.
This makes its return type to be `ServiceEndpoint | null | undefined` (in place of` ServiceEndpoint | null`) and `mirrorNodeDataService.getNodeInfo()` type checking unhappy.
Changes below add the missing `return null`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
