### PR TITLE
chore: slow loading large transaction groups

### DIFF
--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
@@ -44,6 +44,7 @@ import BaseDraftLoad from '@renderer/components/Transaction/Create/BaseTransacti
 import BaseGroupHandler from '@renderer/components/Transaction/Create/BaseTransaction/BaseGroupHandler.vue';
 import BaseApproversObserverData from '@renderer/components/Transaction/Create/BaseTransaction/BaseApproversObserverData.vue';
 import { getTransactionType } from '@renderer/utils/sdk/transactions';
+import { AccountInfoCache } from '@renderer/utils/accountInfoCache.ts';
 
 /* Props */
 const { createTransaction, preCreateAssert, customRequest } = defineProps<{
@@ -250,7 +251,7 @@ function basePreCreateAssert() {
 }
 
 async function updateTransactionKey() {
-  const computedKeys = await computeSignatureKey(transaction.value, network.mirrorNodeBaseURL);
+  const computedKeys = await computeSignatureKey(transaction.value, network.mirrorNodeBaseURL, new AccountInfoCache());
   transactionKey.value = new KeyList(computedKeys.signatureKeys);
 }
 

--- a/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
+++ b/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
@@ -40,7 +40,7 @@ import TransactionSelectionModal from '@renderer/components/TransactionSelection
 import TransactionGroupProcessor from '@renderer/components/Transaction/TransactionGroupProcessor.vue';
 import SaveTransactionGroupModal from '@renderer/components/modals/SaveTransactionGroupModal.vue';
 import RunningClockDatePicker from '@renderer/components/RunningClockDatePicker.vue';
-import { getAccountInfo } from '@renderer/services/mirrorNodeDataService';
+import { AccountInfoCache } from '@renderer/utils/accountInfoCache.ts';
 
 /* Stores */
 const transactionGroup = useTransactionGroupStore();
@@ -238,6 +238,7 @@ async function handleOnFileChanged(e: Event) {
     let memo = '';
     let validStart: Date | null = null;
     const maxTransactionFee = ref<Hbar>(new Hbar(2));
+    const accountInfoCache = new AccountInfoCache();
 
     for (const row of rows) {
       const rowInfo =
@@ -253,7 +254,7 @@ async function handleOnFileChanged(e: Event) {
         case 'sender account':
           senderAccount = rowInfo[1];
           try {
-            await getAccountInfo(senderAccount, network.mirrorNodeBaseURL);
+            await accountInfoCache.fetch(senderAccount, network.mirrorNodeBaseURL);
           } catch (error) {
             toast.error(
               `Sender account ${senderAccount} does not exist on network. Review the CSV file.`,
@@ -265,7 +266,7 @@ async function handleOnFileChanged(e: Event) {
         case 'fee payer account':
           feePayer = rowInfo[1];
           try {
-            await getAccountInfo(feePayer, network.mirrorNodeBaseURL);
+            await accountInfoCache.fetch(feePayer, network.mirrorNodeBaseURL);
           } catch (error) {
             toast.error(
               `Fee payer account ${feePayer} does not exist on network. Review the CSV file.`,
@@ -308,7 +309,7 @@ async function handleOnFileChanged(e: Event) {
           feePayer = feePayer || senderAccount;
           const receiverAccount = rowInfo[0];
           try {
-            await getAccountInfo(receiverAccount, network.mirrorNodeBaseURL);
+            await accountInfoCache.fetch(receiverAccount, network.mirrorNodeBaseURL);
           } catch (error) {
             toast.error(
               `Receiver account ${receiverAccount} does not exist on network. Review the CSV file.`,

--- a/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
@@ -51,6 +51,7 @@ import txTypeComponentMapping from '@renderer/components/Transaction/Details/txT
 import TransactionDetailsHeader from './components/TransactionDetailsHeader.vue';
 import TransactionDetailsStatusStepper from './components/TransactionDetailsStatusStepper.vue';
 import { getGroup } from '@renderer/services/transactionGroupsService';
+import { AccountInfoCache } from '@renderer/utils/accountInfoCache.ts';
 
 /* Stores */
 const user = useUserStore();
@@ -143,6 +144,7 @@ async function fetchTransaction(id: string | number) {
     signatureKeyObject.value = await computeSignatureKey(
       sdkTransaction.value,
       network.mirrorNodeBaseURL,
+      new AccountInfoCache()
     );
   }
 

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -54,6 +54,7 @@ import AppCustomIcon from '@renderer/components/ui/AppCustomIcon.vue';
 import AppDropDown from '@renderer/components/ui/AppDropDown.vue';
 
 import { TransactionStatus } from '@shared/interfaces';
+import { AccountInfoCache } from '@renderer/utils/accountInfoCache.ts';
 
 /* Types */
 type ActionButton =
@@ -295,6 +296,7 @@ const handleSign = async () => {
       props.sdkTransaction,
       user.selectedOrganization.userKeys,
       network.mirrorNodeBaseURL,
+      new AccountInfoCache()
     );
 
     const restoredRequiredKeys = [];

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -54,6 +54,7 @@ import AppCustomIcon from '@renderer/components/ui/AppCustomIcon.vue';
 import AppModal from '@renderer/components/ui/AppModal.vue';
 import AppLoader from '@renderer/components/ui/AppLoader.vue';
 import EmptyTransactions from '@renderer/components/EmptyTransactions.vue';
+import { AccountInfoCache } from '@renderer/utils/accountInfoCache.ts';
 
 /* Stores */
 const user = useUserStore();
@@ -95,6 +96,7 @@ async function handleFetchGroup(id: string | number) {
     try {
       const updatedPublicKeysRequiredToSign: string[] = [];
       const updatedUnsignedSignersToCheck: Record<string, string[]> = {};
+      const accountInfoCache = new AccountInfoCache();
 
       group.value = await getApiGroupById(user.selectedOrganization.serverUrl, Number(id));
       disableSignAll.value = false;
@@ -121,6 +123,7 @@ async function handleFetchGroup(id: string | number) {
             tx,
             user.selectedOrganization.userKeys,
             network.mirrorNodeBaseURL,
+            accountInfoCache,
           );
 
           if (
@@ -203,6 +206,7 @@ const handleSignGroupItem = async (groupItem: IGroupItem) => {
       transaction,
       user.selectedOrganization.userKeys,
       network.mirrorNodeBaseURL,
+      new AccountInfoCache(),
     );
     const item: SignatureItem = {
       publicKeys: publicKeysRequired,
@@ -242,6 +246,7 @@ const handleSignAll = async () => {
     isSigningAll.value = true;
     const items: SignatureItem[] = [];
     if (group.value != undefined) {
+      const accountInfoCache = new AccountInfoCache();
       for (const groupItem of group.value.groupItems) {
         const transactionBytes = hexToUint8Array(groupItem.transaction.transactionBytes);
         const transaction = Transaction.fromBytes(transactionBytes);
@@ -255,6 +260,7 @@ const handleSignAll = async () => {
           transaction,
           user.selectedOrganization.userKeys,
           network.mirrorNodeBaseURL,
+          accountInfoCache,
         );
         const item: SignatureItem = {
           publicKeys: publicKeysRequired,

--- a/front-end/src/renderer/utils/accountInfoCache.ts
+++ b/front-end/src/renderer/utils/accountInfoCache.ts
@@ -1,0 +1,18 @@
+import type { IAccountInfoParsed } from '@shared/interfaces';
+import { getAccountInfo } from '@renderer/services/mirrorNodeDataService.ts';
+
+export class AccountInfoCache {
+  private readonly entries = new Map<string, Promise<IAccountInfoParsed | null>>();
+
+  public async fetch(
+    accountId: string,
+    mirrorNodeUrl: string,
+  ): Promise<IAccountInfoParsed | null> {
+    let result = this.entries.get(accountId) ?? null;
+    if (result === null) {
+      result = getAccountInfo(accountId, mirrorNodeUrl);
+      this.entries.set(accountId, result);
+    }
+    return result;
+  }
+}

--- a/front-end/src/renderer/utils/transactionSignatureModels/index.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/index.ts
@@ -4,6 +4,7 @@ import { Transaction as SDKTransaction } from '@hashgraph/sdk';
 
 import TransactionFactory from './transaction-factory';
 import { flattenKeyList } from '../../services/keyPairService';
+import type { AccountInfoCache } from '@renderer/utils/accountInfoCache.ts';
 
 export * from './account-create-transaction.model';
 export * from './account-update-transaction.model';
@@ -20,17 +21,18 @@ export * from './transfer-transaction.model';
 
 export const COUNCIL_ACCOUNTS = ['0.0.2', '0.0.50', '0.0.55'];
 
-export const computeSignatureKey = async (transaction: SDKTransaction, mirrorNodeLink: string) => {
+export const computeSignatureKey = async (transaction: SDKTransaction, mirrorNodeLink: string, accountInfoCache: AccountInfoCache) => {
   const transactionModel = TransactionFactory.fromTransaction(transaction);
 
-  return await transactionModel.computeSignatureKey(mirrorNodeLink);
+  return await transactionModel.computeSignatureKey(mirrorNodeLink, accountInfoCache);
 };
 
 /* Returns only users PK required to sign */
 export const usersPublicRequiredToSign = async (
-  transaction: Transaction,
+  transaction: SDKTransaction,
   userKeys: IUserKey[],
   mirrorNodeLink: string,
+  accountInfoCache: AccountInfoCache
 ): Promise<string[]> => {
   const publicKeysRequired: Set<string> = new Set<string>();
 
@@ -40,7 +42,7 @@ export const usersPublicRequiredToSign = async (
   /* Transaction signers' public keys */
   const signerPublicKeys = new Set([...transaction._signerPublicKeys]);
 
-  const requiredKeys = await computeSignatureKey(transaction, mirrorNodeLink);
+  const requiredKeys = await computeSignatureKey(transaction, mirrorNodeLink, accountInfoCache);
 
   const requiredUnsignedKeys = new Set<string>();
   requiredKeys.signatureKeys.forEach(key => {


### PR DESCRIPTION
**Description**:

Changes below optimize display of large transaction groups.

`TransactionGroupDetails.handleFetchGroup()` enumerates each transaction in the group and (indirectly) triggers `mirrorNodeDataService.getAccountInfo()` for each account id found in the transaction. Which means 2 to 4 times per transaction. When transactions have many common account ids (like payer ids), there are many redundant calls to mirror node.

Changes below:
- introduce a new class `AccountInfoCache` which caches calls to `getAccountInfo()` (in memory)
- `handleFetchGroup()` now creates an `AccountInfoCache` instance and passes it downstream
- `TransactionBaseModel.computeSignatureKey()` now retrieves account info through `AccountInfoCache`

```
`TransactionGroupDetails.handleFetchGroup()`
    => usersPublicRequiredToSign(..., accountInfoCache) 
        => computeSignatureKey(..., accountInfoCache)
            => TransactionBaseModel.computeSignatureKey(..., accountInfoCache) 
                => AccountInfoCache.fetch()
```


**Related issue(s)**:

Fixes #1768 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
