### PR TITLE
fix: change path of volume mount

### DIFF
--- a/back-end/docker-compose.yaml
+++ b/back-end/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
       - POSTGRES_PASSWORD
     container_name: postgres
     volumes:
-      - ./pgdata:/var/lib/postgresql/data
+      - ./pgdata:/var/lib/postgresql
     # for development, allow postgres to be accessible
     ports:
       - '5432:5432'

--- a/back-end/k8s/back-end/postgres-deployment.yaml
+++ b/back-end/k8s/back-end/postgres-deployment.yaml
@@ -33,12 +33,10 @@ spec:
                 secretKeyRef:
                   name: postgres-secret
                   key: database
-            - name: PGDATA
-              value: "/var/lib/postgresql/data/pgdata"
           ports:
             - containerPort: 5432
           volumeMounts:
-            - mountPath: "/var/lib/postgresql/data"
+            - mountPath: "/var/lib/postgresql"
               name: postgredb
       volumes:
         - name: postgredb

--- a/back-end/k8s/dev/deployments/postgres-deployment.yaml
+++ b/back-end/k8s/dev/deployments/postgres-deployment.yaml
@@ -29,12 +29,10 @@ spec:
               value: postgres
             - name: POSTGRES_DB
               value: postgres
-            - name: PGDATA
-              value: '/var/lib/postgresql/data/pgdata'
           ports:
             - containerPort: 5432
           volumeMounts:
-            - mountPath: '/var/lib/postgresql/data'
+            - mountPath: '/var/lib/postgresql'
               name: postgredb
       volumes:
         - name: postgredb


### PR DESCRIPTION
**Description**:
Postgres recently released version 18. This version changes the default path of the volume. Changing the path to the new default solves the issue.

**Related issue(s)**:

Fixes #1863 

**Notes for reviewer**:
If using docker-compose, be sure to delete the pgdata directory in the backend. The old pgdata will not work with a newer version of postgres

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
