### PR TITLE
feat: allow users to set the date/time format to either UTC or local time

### DIFF
--- a/back-end/docker-compose.yaml
+++ b/back-end/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
       - POSTGRES_PASSWORD
     container_name: postgres
     volumes:
-      - ./pgdata:/var/lib/postgresql/data
+      - ./pgdata:/var/lib/postgresql
     # for development, allow postgres to be accessible
     ports:
       - '5432:5432'

--- a/front-end/src/renderer/components/Transaction/Create/FileData/FileDataFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileData/FileDataFormData.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts';
+
 import type { FileData } from '@renderer/utils';
 
 import { isHederaSpecialFileId } from '@shared/hederaSpecialFiles';
@@ -21,6 +23,9 @@ defineProps<{
 defineEmits<{
   (event: 'update:data', data: FileData): void;
 }>();
+
+/* Composables */
+const { dateTimeSettingLabel } = useDateTimeSetting();
 </script>
 <template>
   <div class="row">
@@ -62,7 +67,8 @@ defineEmits<{
   <div class="row mt-6">
     <div class="form-group col-4 col-xxxl-3">
       <label class="form-label"
-        >Expiration <span class="text-muted text-italic">- Local time</span></label
+        >Expiration
+        <span class="text-muted text-italic">{{ `- ${dateTimeSettingLabel}` }}</span></label
       >
       <AppDatePicker
         :model-value="data.expirationTime ? data.expirationTime : undefined"

--- a/front-end/src/renderer/components/Transaction/Create/Freeze/FreezeFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/Freeze/FreezeFormData.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts';
+
 import type { FreezeData } from '@renderer/utils/sdk';
 
 import { formatAccountId } from '@renderer/utils';
@@ -15,6 +17,9 @@ const props = defineProps<{
 const emit = defineEmits<{
   (event: 'update:data', data: FreezeData): void;
 }>();
+
+/* Composables */
+const { dateTimeSettingLabel } = useDateTimeSetting();
 
 /* Handlers */
 function handleOnBlur() {
@@ -58,7 +63,7 @@ const fileHashimeVisibleAtFreezeType = [2, 3];
   >
     <div class="form-group" :class="[columnClass]">
       <label class="form-label"
-        >Start <span class="text-muted text-italic">- Local time</span
+        >Start <span class="text-muted text-italic">{{ `- ${dateTimeSettingLabel}` }}</span
         ><span class="text-danger">*</span></label
       >
       <RunningClockDatePicker

--- a/front-end/src/renderer/components/Transaction/Create/SystemDelete/SystemDeleteFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/SystemDelete/SystemDeleteFormData.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts';
+
 import type { SystemData, SystemDeleteData } from '@renderer/utils/sdk';
 
 import { getMinimumExpirationTime, getMaximumExpirationTime } from '@renderer/utils';
@@ -16,6 +18,9 @@ const emit = defineEmits<{
   (event: 'update:data', data: SystemDeleteData): void;
 }>();
 
+/* Composables */
+const { dateTimeSettingLabel } = useDateTimeSetting();
+
 /* Handlers */
 const handleSystemDataUpdate = (data: SystemData) => {
   emit('update:data', {
@@ -30,7 +35,7 @@ const handleSystemDataUpdate = (data: SystemData) => {
   <div class="row mt-6">
     <div class="form-group col-4 col-xxxl-3">
       <label class="form-label"
-        >Expiration <span class="text-muted text-italic">- Local time</span>
+        >Expiration <span class="text-muted text-italic">{{ `- ${dateTimeSettingLabel}` }}</span>
         <span class="text-danger">*</span></label
       >
       <AppDatePicker

--- a/front-end/src/renderer/components/Transaction/Details/FreezeDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/FreezeDetails.vue
@@ -3,8 +3,10 @@ import { onBeforeMount, ref } from 'vue';
 
 import { Transaction, FreezeTransaction } from '@hashgraph/sdk';
 
-import { getDateStringExtended, uint8ToHex } from '@renderer/utils';
+import { uint8ToHex } from '@renderer/utils';
 import { getFreezeTypeString } from '@renderer/utils/sdk/transactions';
+
+import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
 
 /* Props */
 const props = defineProps<{
@@ -44,7 +46,7 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
     <div v-if="transaction.startTimestamp" :class="commonColClass">
       <h4 :class="detailItemLabelClass">Start Time</h4>
       <p :class="detailItemValueClass">
-        {{ getDateStringExtended(transaction.startTimestamp.toDate()) }}
+        <DateTimeString :date="transaction.startTimestamp.toDate()"/>
       </p>
     </div>
 

--- a/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
@@ -9,6 +9,7 @@ import useUserStore from '@renderer/stores/storeUser';
 import { useRoute } from 'vue-router';
 
 import useAccountId from '@renderer/composables/useAccountId';
+import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts';
 
 import * as claim from '@renderer/services/claimService';
 
@@ -35,6 +36,7 @@ const user = useUserStore();
 /* Composables */
 const route = useRoute();
 const account = useAccountId();
+const { dateTimeSettingLabel } = useDateTimeSetting();
 
 /* State */
 const localValidStart = ref<Date>(props.validStart);
@@ -130,7 +132,8 @@ const columnClass = 'col-4 col-xxxl-3';
     </div>
     <div class="form-group" :class="[columnClass]">
       <label class="form-label"
-        >Valid Start <span class="text-muted text-italic">- Local time</span></label
+        >Valid Start
+        <span class="text-muted text-italic">{{ `- ${dateTimeSettingLabel}` }}</span></label
       >
       <RunningClockDatePicker
         :model-value="validStart"

--- a/front-end/src/renderer/components/ui/AppDatePicker.vue
+++ b/front-end/src/renderer/components/ui/AppDatePicker.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import type { DatePickerInstance, VueDatePickerProps } from '@vuepic/vue-datepicker';
 
-import { computed, onBeforeMount, ref } from 'vue';
-import { DateTimeOptions } from '@renderer/utils';
+import { computed, ref } from 'vue';
 
 import DatePicker from '@vuepic/vue-datepicker';
 import AppButton from '@renderer/components/ui/AppButton.vue';
@@ -24,21 +23,16 @@ const emit = defineEmits<{
 }>();
 
 /* Composables */
-const { getDateTimeSetting } = useDateTimeSetting();
+const { isUtcSelected } = useDateTimeSetting();
 
 /* State */
 const datePicker = ref<DatePickerInstance>(null);
-const dateTimeSetting = ref<DateTimeOptions>();
 
 /* Computed */
-const useUTC = computed(() => {
-  return dateTimeSetting.value === DateTimeOptions.UTC_TIME;
-});
-
 const inputValue = computed(() => {
   let result: string | Date | undefined;
   if (props.modelValue) {
-    result = useUTC.value ? new Date(props.modelValue!.toUTCString()) : props.modelValue;
+    result = isUtcSelected.value ? new Date(props.modelValue.toUTCString()) : props.modelValue;
   } else {
     result = undefined;
   }
@@ -58,17 +52,12 @@ function handleUpdate(value: string | Date) {
     emit('update:modelValue', value);
   }
 }
-
-/* Hooks */
-onBeforeMount(async () => {
-  dateTimeSetting.value = await getDateTimeSetting();
-});
 </script>
 <template>
   <DatePicker
     ref="datePicker"
     :model-value="inputValue"
-    :utc="useUTC ? 'preserve' : undefined"
+    :utc="isUtcSelected ? 'preserve' : undefined"
     :clearable="clearable"
     auto-apply
     partial-flow

--- a/front-end/src/renderer/components/ui/AppDatePicker.vue
+++ b/front-end/src/renderer/components/ui/AppDatePicker.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import type { DatePickerInstance, VueDatePickerProps } from '@vuepic/vue-datepicker';
 
-import { ref } from 'vue';
+import { computed, onBeforeMount, ref } from 'vue';
+import { DateTimeOptions } from '@renderer/utils';
 
 import DatePicker from '@vuepic/vue-datepicker';
 import AppButton from '@renderer/components/ui/AppButton.vue';
+import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts';
 
 /* Props */
-defineProps<
+const props = defineProps<
   {
     modelValue: Date | undefined;
     nowButtonVisible?: boolean;
@@ -21,20 +23,52 @@ const emit = defineEmits<{
   (event: 'close'): void;
 }>();
 
+/* Composables */
+const { getDateTimeSetting } = useDateTimeSetting();
+
 /* State */
 const datePicker = ref<DatePickerInstance>(null);
+const dateTimeSetting = ref<DateTimeOptions>();
+
+/* Computed */
+const useUTC = computed(() => {
+  return dateTimeSetting.value === DateTimeOptions.UTC_TIME;
+});
+
+const inputValue = computed(() => {
+  let result: string | Date | undefined;
+  if (props.modelValue) {
+    result = useUTC.value ? new Date(props.modelValue!.toUTCString()) : props.modelValue;
+  } else {
+    result = undefined;
+  }
+  return result;
+});
 
 /* Handlers */
 function handleNow() {
   emit('update:modelValue', new Date());
   datePicker.value?.closeMenu();
 }
+
+function handleUpdate(value: string | Date) {
+  if (typeof value === 'string') {
+    emit('update:modelValue', new Date(value));
+  } else {
+    emit('update:modelValue', value);
+  }
+}
+
+/* Hooks */
+onBeforeMount(async () => {
+  dateTimeSetting.value = await getDateTimeSetting();
+});
 </script>
 <template>
   <DatePicker
     ref="datePicker"
-    :model-value="modelValue"
-    @update:model-value="$emit('update:modelValue', $event)"
+    :model-value="inputValue"
+    :utc="useUTC ? 'preserve' : undefined"
     :clearable="clearable"
     auto-apply
     partial-flow
@@ -56,11 +90,12 @@ function handleNow() {
     enable-seconds
     @open="$emit('open')"
     @close="$emit('close')"
+    @update:model-value="handleUpdate"
   >
     <template #action-row>
       <div class="d-flex justify-content-end gap-4 w-100">
         <AppButton
-          v-if="nowButtonVisible"
+          v-if="props.nowButtonVisible"
           class="text-body min-w-unset"
           size="small"
           type="button"

--- a/front-end/src/renderer/components/ui/DateTimeString.vue
+++ b/front-end/src/renderer/components/ui/DateTimeString.vue
@@ -1,0 +1,41 @@
+<script lang="ts" setup>
+import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts';
+import { DateTimeOptions, getDateString, getDateStringExtended } from '@renderer/utils';
+import { computed, onBeforeMount, ref } from 'vue';
+
+/* Props */
+const props = withDefaults(
+  defineProps<{
+    date: Date | null;
+    extended?: boolean;
+  }>(),
+  {
+    date: null,
+    extended: true,
+  },
+);
+
+/* Composables */
+const { getDateTimeSetting } = useDateTimeSetting();
+
+/* State */
+const dateTimeSetting = ref<DateTimeOptions>();
+
+/* Computed */
+const extendedDateString = computed(() => {
+  return props.date ? getDateStringExtended(props.date, dateTimeSetting.value) : '';
+});
+const dateString = computed(() => {
+  return props.date ? getDateString(props.date, dateTimeSetting.value) : '';
+});
+
+/* Hooks */
+onBeforeMount(async () => {
+  dateTimeSetting.value = await getDateTimeSetting();
+});
+</script>
+
+<template>
+    <span v-if="props.extended">{{ extendedDateString }}</span>
+    <span v-else>{{ dateString }}</span>
+</template>

--- a/front-end/src/renderer/components/ui/DateTimeString.vue
+++ b/front-end/src/renderer/components/ui/DateTimeString.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
+import { computed } from 'vue';
+import { getDateString, getDateStringExtended } from '@renderer/utils';
 import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts';
-import { DateTimeOptions, getDateString, getDateStringExtended } from '@renderer/utils';
-import { computed, onBeforeMount, ref } from 'vue';
 
 /* Props */
 const props = withDefaults(
@@ -16,26 +16,18 @@ const props = withDefaults(
 );
 
 /* Composables */
-const { getDateTimeSetting } = useDateTimeSetting();
-
-/* State */
-const dateTimeSetting = ref<DateTimeOptions>();
+const { isUtcSelected } = useDateTimeSetting();
 
 /* Computed */
 const extendedDateString = computed(() => {
-  return props.date ? getDateStringExtended(props.date, dateTimeSetting.value) : '';
+  return props.date ? getDateStringExtended(props.date, isUtcSelected.value) : '';
 });
 const dateString = computed(() => {
-  return props.date ? getDateString(props.date, dateTimeSetting.value) : '';
-});
-
-/* Hooks */
-onBeforeMount(async () => {
-  dateTimeSetting.value = await getDateTimeSetting();
+  return props.date ? getDateString(props.date, isUtcSelected.value) : '';
 });
 </script>
 
 <template>
-    <span v-if="props.extended">{{ extendedDateString }}</span>
-    <span v-else>{{ dateString }}</span>
+  <span v-if="props.extended">{{ extendedDateString }}</span>
+  <span v-else>{{ dateString }}</span>
 </template>

--- a/front-end/src/renderer/composables/user/useDateTimeSetting.ts
+++ b/front-end/src/renderer/composables/user/useDateTimeSetting.ts
@@ -1,0 +1,52 @@
+import useUserStore from '@renderer/stores/storeUser';
+
+import { DATE_TIME_PREFERENCE } from '@shared/constants';
+
+import { add, getStoredClaim, update } from '@renderer/services/claimService';
+
+import { DateTimeOptions, isUserLoggedIn, safeAwait } from '@renderer/utils';
+import { ref } from 'vue';
+
+export default function useDateTimeSetting() {
+  const DEFAULT_OPTION = DateTimeOptions.UTC_TIME;
+
+  const DATE_TIME_OPTIONS = [
+    { value: DateTimeOptions.UTC_TIME, label: 'UTC Time' },
+    { value: DateTimeOptions.LOCAL_TIME, label: 'Local Time' },
+  ];
+
+  /* Stores */
+  const user = useUserStore();
+
+  /* States */
+  const dateTimeSetting = ref<DateTimeOptions | null>(null);
+
+  /* Functions */
+
+  const getDateTimeSetting = async () => {
+    let result: DateTimeOptions;
+    if (dateTimeSetting.value === null) {
+       result = DEFAULT_OPTION;
+      if (isUserLoggedIn(user.personal)) {
+        const claimValue = await safeAwait(getStoredClaim(user.personal.id, DATE_TIME_PREFERENCE));
+        if (claimValue.data) {
+          result = claimValue.data as DateTimeOptions;
+        }
+      }
+    } else {
+      result = dateTimeSetting.value;
+    }
+    return result;
+  };
+
+  const setDateTimeSetting = async (format: DateTimeOptions) => {
+    if (isUserLoggedIn(user.personal)) {
+      const claimValue = await safeAwait(getStoredClaim(user.personal.id, DATE_TIME_PREFERENCE));
+      const addOrUpdate = claimValue.data !== undefined ? update : add;
+      await addOrUpdate(user.personal.id, DATE_TIME_PREFERENCE, format);
+    }
+    dateTimeSetting.value = null; // force a reload of the setting at next use to make sure cache is in sync with DB
+  };
+
+  return { DATE_TIME_OPTIONS, getDateTimeSetting, setDateTimeSetting };
+}

--- a/front-end/src/renderer/composables/user/useDateTimeSetting.ts
+++ b/front-end/src/renderer/composables/user/useDateTimeSetting.ts
@@ -4,13 +4,18 @@ import { DATE_TIME_PREFERENCE } from '@shared/constants';
 
 import { add, getStoredClaim, update } from '@renderer/services/claimService';
 
-import { DateTimeOptions, isUserLoggedIn, safeAwait } from '@renderer/utils';
-import { ref } from 'vue';
+import { isUserLoggedIn, safeAwait } from '@renderer/utils';
+import { computed, onBeforeMount, ref } from 'vue';
+
+export enum DateTimeOptions {
+  UTC_TIME = 'utc-time',
+  LOCAL_TIME = 'local-time',
+}
 
 export default function useDateTimeSetting() {
   const DEFAULT_OPTION = DateTimeOptions.UTC_TIME;
 
-  const DATE_TIME_OPTIONS = [
+  const DATE_TIME_OPTION_LABELS = [
     { value: DateTimeOptions.UTC_TIME, label: 'UTC Time' },
     { value: DateTimeOptions.LOCAL_TIME, label: 'Local Time' },
   ];
@@ -21,12 +26,24 @@ export default function useDateTimeSetting() {
   /* States */
   const dateTimeSetting = ref<DateTimeOptions | null>(null);
 
-  /* Functions */
+  /* Computed */
+  const isUtcSelected = computed(() => {
+    return dateTimeSetting.value === DateTimeOptions.UTC_TIME;
+  });
 
-  const getDateTimeSetting = async () => {
+  const dateTimeSettingLabel = computed(() => {
+    return isUtcSelected.value ? 'UTC Time' : 'Local Time';
+  });
+
+  /* Hooks */
+  onBeforeMount(async () => {
+    dateTimeSetting.value = await getDateTimeSetting();
+  });
+
+  async function getDateTimeSetting(): Promise<DateTimeOptions> {
     let result: DateTimeOptions;
     if (dateTimeSetting.value === null) {
-       result = DEFAULT_OPTION;
+      result = DEFAULT_OPTION;
       if (isUserLoggedIn(user.personal)) {
         const claimValue = await safeAwait(getStoredClaim(user.personal.id, DATE_TIME_PREFERENCE));
         if (claimValue.data) {
@@ -37,16 +54,22 @@ export default function useDateTimeSetting() {
       result = dateTimeSetting.value;
     }
     return result;
-  };
+  }
 
-  const setDateTimeSetting = async (format: DateTimeOptions) => {
+  async function setDateTimeSetting(format: DateTimeOptions) {
     if (isUserLoggedIn(user.personal)) {
       const claimValue = await safeAwait(getStoredClaim(user.personal.id, DATE_TIME_PREFERENCE));
       const addOrUpdate = claimValue.data !== undefined ? update : add;
       await addOrUpdate(user.personal.id, DATE_TIME_PREFERENCE, format);
     }
     dateTimeSetting.value = null; // force a reload of the setting at next use to make sure cache is in sync with DB
-  };
+  }
 
-  return { DATE_TIME_OPTIONS, getDateTimeSetting, setDateTimeSetting };
+  return {
+    DATE_TIME_OPTION_LABELS,
+    isUtcSelected,
+    dateTimeSettingLabel,
+    getDateTimeSetting,
+    setDateTimeSetting,
+  };
 }

--- a/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
+++ b/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
@@ -18,6 +18,7 @@ import { useToast } from 'vue-toast-notification';
 import { useRouter, useRoute, onBeforeRouteLeave } from 'vue-router';
 import useAccountId from '@renderer/composables/useAccountId';
 import useSetDynamicLayout, { LOGGED_IN_LAYOUT } from '@renderer/composables/useSetDynamicLayout';
+import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts';
 
 import { deleteGroup } from '@renderer/services/transactionGroupsService';
 
@@ -53,6 +54,7 @@ const toast = useToast();
 const payerData = useAccountId();
 const network = useNetworkStore();
 useSetDynamicLayout(LOGGED_IN_LAYOUT);
+const { dateTimeSettingLabel } = useDateTimeSetting();
 
 /* State */
 const groupDescription = ref('');
@@ -517,7 +519,9 @@ onBeforeRouteLeave(async to => {
           <div class="d-flex justify-content-between align-items-center mb-5">
             <div>
               <label class="form-label"
-                >Group Valid Start <span class="text-muted text-italic">- Local time</span></label
+                >Group Valid Start<span class="text-muted text-italic">{{
+                  `- ${dateTimeSettingLabel}`
+                }}</span></label
               >
               <RunningClockDatePicker
                 :model-value="transactionGroup.groupValidStart"

--- a/front-end/src/renderer/pages/Settings/components/GeneralTab/components/DateTimeSetting.vue
+++ b/front-end/src/renderer/pages/Settings/components/GeneralTab/components/DateTimeSetting.vue
@@ -1,0 +1,42 @@
+<script lang="ts" setup>
+import type { DateTimeOptions } from '@renderer/utils';
+
+import { onBeforeMount, ref } from 'vue';
+import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts';
+import AppSelect from '@renderer/components/ui/AppSelect.vue';
+
+/* Composables */
+const { DATE_TIME_OPTIONS, getDateTimeSetting, setDateTimeSetting } = useDateTimeSetting();
+
+/* State */
+const currentSetting = ref<DateTimeOptions>();
+
+const handleUpdateSetting = async (selection: DateTimeOptions | undefined) => {
+  if (selection) {
+    await setDateTimeSetting(selection);
+    currentSetting.value = selection;
+  }
+};
+
+/* Hooks */
+onBeforeMount(async () => {
+  currentSetting.value = await getDateTimeSetting();
+});
+</script>
+
+<template>
+  <div class="mt-4">
+    <div class="col-sm-5 col-lg-4">
+      <label class="form-label me-3">Date/Time Format</label>
+      <AppSelect
+        :color="'secondary'"
+        :items="DATE_TIME_OPTIONS"
+        :value="currentSetting"
+        button-class="w-100"
+        toggle-text="Select Format"
+        toggler-icon
+        @update:value="handleUpdateSetting"
+      />
+    </div>
+  </div>
+</template>

--- a/front-end/src/renderer/pages/Settings/components/GeneralTab/components/DateTimeSetting.vue
+++ b/front-end/src/renderer/pages/Settings/components/GeneralTab/components/DateTimeSetting.vue
@@ -1,16 +1,16 @@
 <script lang="ts" setup>
-import type { DateTimeOptions } from '@renderer/utils';
-
+import { DateTimeOptions } from '@renderer/composables/user/useDateTimeSetting.ts';
 import { onBeforeMount, ref } from 'vue';
 import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts';
 import AppSelect from '@renderer/components/ui/AppSelect.vue';
 
 /* Composables */
-const { DATE_TIME_OPTIONS, getDateTimeSetting, setDateTimeSetting } = useDateTimeSetting();
+const { DATE_TIME_OPTION_LABELS, getDateTimeSetting, setDateTimeSetting } = useDateTimeSetting();
 
 /* State */
 const currentSetting = ref<DateTimeOptions>();
 
+/* Handlers */
 const handleUpdateSetting = async (selection: DateTimeOptions | undefined) => {
   if (selection) {
     await setDateTimeSetting(selection);
@@ -30,7 +30,7 @@ onBeforeMount(async () => {
       <label class="form-label me-3">Date/Time Format</label>
       <AppSelect
         :color="'secondary'"
-        :items="DATE_TIME_OPTIONS"
+        :items="DATE_TIME_OPTION_LABELS"
         :value="currentSetting"
         button-class="w-100"
         toggle-text="Select Format"

--- a/front-end/src/renderer/pages/Settings/components/GeneralTab/components/DefaultSettings.vue
+++ b/front-end/src/renderer/pages/Settings/components/GeneralTab/components/DefaultSettings.vue
@@ -2,12 +2,14 @@
 import DefaultOrganization from './DefaultOrganization.vue';
 import MaxTransactionFeeSetting from './MaxTransactionFeeSetting.vue';
 import UpdateLocation from './UpdateLocation.vue';
+import DateTimeSetting from '@renderer/pages/Settings/components/GeneralTab/components/DateTimeSetting.vue';
 </script>
 <template>
   <div class="p-4 border border-2 rounded-3 mt-5">
     <p>Default Settings</p>
     <MaxTransactionFeeSetting />
     <DefaultOrganization />
+    <DateTimeSetting />
     <UpdateLocation />
   </div>
 </template>

--- a/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
@@ -24,13 +24,11 @@ import { getApiGroupById, getTransactionById } from '@renderer/services/organiza
 import { getTransaction } from '@renderer/services/transactionService';
 
 import {
-  getTransactionDateExtended,
   getTransactionId,
   getTransactionPayerId,
-  getTransactionType,
+  getTransactionType, getTransactionValidStart,
 } from '@renderer/utils/sdk/transactions';
 import {
-  getDateStringExtended,
   getUInt8ArrayFromBytesString,
   KEEP_NEXT_QUERY_KEY,
   openTransactionInHashscan,
@@ -51,6 +49,7 @@ import txTypeComponentMapping from '@renderer/components/Transaction/Details/txT
 import TransactionDetailsHeader from './components/TransactionDetailsHeader.vue';
 import TransactionDetailsStatusStepper from './components/TransactionDetailsStatusStepper.vue';
 import { getGroup } from '@renderer/services/transactionGroupsService';
+import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
 
 /* Stores */
 const user = useUserStore();
@@ -323,13 +322,13 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
                 <div :class="commonColClass">
                   <h4 :class="detailItemLabelClass">Created at</h4>
                   <p :class="detailItemValueClass" data-testid="p-transaction-details-created-at">
-                    {{
-                      getDateStringExtended(
+                    <DateTimeString
+                      :date="
                         new Date(
                           orgTransaction?.createdAt || localTransaction?.created_at || Date.now(),
-                        ),
-                      )
-                    }}
+                        )
+                      "
+                    />
                   </p>
                 </div>
 
@@ -340,13 +339,13 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
                 >
                   <h4 :class="detailItemLabelClass">Executed at</h4>
                   <p :class="detailItemValueClass" data-testid="p-transaction-details-executed_at">
-                    {{
-                      getDateStringExtended(
+                    <DateTimeString
+                      :date="
                         new Date(
                           orgTransaction?.executedAt || localTransaction?.executed_at || Date.now(),
-                        ),
-                      )
-                    }}
+                        )
+                      "
+                    />
                   </p>
                 </div>
               </div>
@@ -402,7 +401,7 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
                 <div :class="commonColClass">
                   <h4 :class="detailItemLabelClass">Valid Start</h4>
                   <p :class="detailItemValueClass" data-testid="p-transaction-details-valid-start">
-                    {{ getTransactionDateExtended(sdkTransaction) }}
+                    <DateTimeString :date="getTransactionValidStart(sdkTransaction)"/>
                   </p>
                 </div>
 

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -38,7 +38,6 @@ import { decryptPrivateKey } from '@renderer/services/keyPairService';
 import { saveFileToPath, showSaveDialog } from '@renderer/services/electronUtilsService.ts';
 
 import {
-  getDateStringExtended,
   getPrivateKey,
   getTransactionBodySignatureWithoutNodeAccountId,
   redirectToDetails,
@@ -54,6 +53,7 @@ import AppCustomIcon from '@renderer/components/ui/AppCustomIcon.vue';
 import AppModal from '@renderer/components/ui/AppModal.vue';
 import AppLoader from '@renderer/components/ui/AppLoader.vue';
 import EmptyTransactions from '@renderer/components/EmptyTransactions.vue';
+import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
 
 /* Stores */
 const user = useUserStore();
@@ -614,9 +614,7 @@ watchEffect(() => {
                                 }}</span>
                               </td>
                               <td data-testid="td-group-valid-start-time">
-                                {{
-                                  getDateStringExtended(new Date(groupItem.transaction.validStart))
-                                }}
+                                <DateTimeString :date="new Date(groupItem.transaction.validStart)"/>
                               </td>
                               <td class="text-center">
                                 <div class="d-flex justify-content-center flex-wrap gap-3">

--- a/front-end/src/renderer/pages/Transactions/components/Drafts.vue
+++ b/front-end/src/renderer/pages/Transactions/components/Drafts.vue
@@ -29,6 +29,7 @@ import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppLoader from '@renderer/components/ui/AppLoader.vue';
 import AppPager from '@renderer/components/ui/AppPager.vue';
 import EmptyTransactions from '@renderer/components/EmptyTransactions.vue';
+import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
 
 /* Store */
 const user = useUserStore();
@@ -293,7 +294,7 @@ watch([currentPage, pageSize], async () => {
               <tr>
                 <td>
                   <span class="text-secondary" :data-testid="'span-draft-tx-date-' + i">
-                    {{ draft.created_at.toLocaleString() }}
+                    <DateTimeString :date="draft.created_at" :extended="false" />
                   </span>
                 </td>
                 <td>

--- a/front-end/src/renderer/pages/Transactions/components/Groups.vue
+++ b/front-end/src/renderer/pages/Transactions/components/Groups.vue
@@ -21,6 +21,7 @@ import {
   deleteGroup,
 } from '@renderer/services/transactionGroupsService';
 import EmptyTransactionGroup from '@renderer/components/EmptyTransactionGroup.vue';
+import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
 
 /* Store */
 const user = useUserStore();
@@ -182,7 +183,7 @@ watch([currentPage, pageSize], async () => {
                 <td>{{ i + 1 }}</td>
                 <td>
                   <span class="text-secondary">
-                    {{ group.created_at.toLocaleString() }}
+                    <DateTimeString :date="group.created_at" :extended="false" />
                   </span>
                 </td>
                 <td>

--- a/front-end/src/renderer/pages/Transactions/components/History.vue
+++ b/front-end/src/renderer/pages/Transactions/components/History.vue
@@ -28,7 +28,6 @@ import {
   getTransactionId,
   getStatusFromCode,
   getNotifiedTransactions,
-  getDateStringExtended,
   hexToUint8Array,
   redirectToDetails,
   isLoggedInOrganization,
@@ -41,6 +40,7 @@ import AppLoader from '@renderer/components/ui/AppLoader.vue';
 import AppPager from '@renderer/components/ui/AppPager.vue';
 import EmptyTransactions from '@renderer/components/EmptyTransactions.vue';
 import TransactionsFilter from '@renderer/components/Filter/TransactionsFilter.vue';
+import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
 
 /* Stores */
 const user = useUserStore();
@@ -422,7 +422,7 @@ watch(
                   </td>
                   <td :data-testid="`td-transaction-createdAt-${index}`">
                     <span class="text-small text-secondary">
-                      {{ getDateStringExtended(transaction.created_at) }}
+                      <DateTimeString :date="transaction.created_at"/>
                     </span>
                   </td>
                   <td class="text-center">
@@ -478,9 +478,9 @@ watch(
                   </td>
                   <td :data-testid="`td-transaction-createdAt-${index}`">
                     <span class="text-small text-secondary">
-                      {{
-                        getDateStringExtended(new Date(transactionData.transactionRaw.createdAt))
-                      }}
+                      <DateTimeString
+                        :date="new Date(transactionData.transactionRaw.createdAt)"
+                      />
                     </span>
                   </td>
                   <td>
@@ -488,13 +488,11 @@ watch(
                       :data-testid="`td-transaction-executedAt-${index}`"
                       class="text-small text-secondary"
                     >
-                      {{
-                        transactionData.transactionRaw.executedAt
-                          ? getDateStringExtended(
-                              new Date(transactionData.transactionRaw.executedAt),
-                            )
-                          : 'N/A'
-                      }}
+                      <DateTimeString
+                        v-if="transactionData.transactionRaw.executedAt"
+                        :date="new Date(transactionData.transactionRaw.executedAt)"
+                      />
+                      <span v-else>N/A</span>
                     </span>
                   </td>
                   <td class="text-center">

--- a/front-end/src/renderer/pages/Transactions/components/InProgress.vue
+++ b/front-end/src/renderer/pages/Transactions/components/InProgress.vue
@@ -19,22 +19,23 @@ import useDisposableWs from '@renderer/composables/useDisposableWs';
 import { getApiGroupById, getTransactionsForUser } from '@renderer/services/organization';
 
 import {
-  getTransactionDateExtended,
   getTransactionId,
   getTransactionType,
+  getTransactionValidStart,
 } from '@renderer/utils/sdk/transactions';
 import {
   redirectToDetails,
   redirectToGroupDetails,
   isLoggedInOrganization,
   hexToUint8Array,
-  getDateStringExtended, getTransactionGroupUpdatedAt,
+  getTransactionGroupUpdatedAt,
 } from '@renderer/utils';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppLoader from '@renderer/components/ui/AppLoader.vue';
 import AppPager from '@renderer/components/ui/AppPager.vue';
 import EmptyTransactions from '@renderer/components/EmptyTransactions.vue';
+import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
 
 /* Stores */
 const user = useUserStore();
@@ -318,18 +319,18 @@ watch([currentPage, pageSize, () => user.selectedOrganization], async () => {
                   </td>
                   <td>{{ groups.get(group[0])?.description }}</td>
                   <td>
-                    {{
-                      group[1][0].transaction instanceof Transaction
-                        ? getTransactionDateExtended(group[1][0].transaction)
-                        : 'N/A'
-                    }}
+                    <DateTimeString
+                      v-if="group[1][0].transaction instanceof Transaction"
+                      :date="getTransactionValidStart(group[1][0].transaction)"
+                    />
+                    <span v-else>N/A</span>
                   </td>
                   <td>
-                    {{
-                      groups.get(group[0])
-                        ? getDateStringExtended(getTransactionGroupUpdatedAt(groups.get(group[0])))
-                        : 'N/A'
-                    }}
+                    <DateTimeString
+                      v-if="groups.get(group[0])"
+                      :date="getTransactionGroupUpdatedAt(groups.get(group[0]))"
+                    />
+                    <span v-else>N/A</span>
                   </td>
                   <td class="text-center">
                     <AppButton
@@ -360,18 +361,18 @@ watch([currentPage, pageSize, () => user.selectedOrganization], async () => {
                       }}</span>
                     </td>
                     <td :data-testid="`td-transaction-valid-start-in-progress-${index}`">
-                      {{
-                        tx.transaction instanceof Transaction
-                          ? getTransactionDateExtended(tx.transaction)
-                          : 'N/A'
-                      }}
+                      <DateTimeString
+                        v-if="tx.transaction instanceof Transaction"
+                        :date="getTransactionValidStart(tx.transaction)"
+                      />
+                      <span v-else>N/A</span>
                     </td>
                     <td :data-testid="`td-transaction-date-modified-in-progress-${index}`">
-                      {{
-                        tx.transaction instanceof Transaction
-                          ? getDateStringExtended(new Date(tx.transactionRaw.updatedAt))
-                          : 'N/A'
-                      }}
+                      <DateTimeString
+                        v-if="tx.transaction instanceof Transaction"
+                        :date="new Date(tx.transactionRaw.updatedAt)"
+                      />
+                      <span v-else>N/A</span>
                     </td>
                     <td class="text-center">
                       <AppButton

--- a/front-end/src/renderer/pages/Transactions/components/ReadyForExecution.vue
+++ b/front-end/src/renderer/pages/Transactions/components/ReadyForExecution.vue
@@ -25,18 +25,18 @@ import {
   hexToUint8Array,
   redirectToDetails,
   isLoggedInOrganization,
-  getDateStringExtended,
 } from '@renderer/utils';
 import {
-  getTransactionDateExtended,
   getTransactionId,
   getTransactionType,
+  getTransactionValidStart,
 } from '@renderer/utils/sdk/transactions';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppLoader from '@renderer/components/ui/AppLoader.vue';
 import AppPager from '@renderer/components/ui/AppPager.vue';
 import EmptyTransactions from '@renderer/components/EmptyTransactions.vue';
+import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
 
 /* Stores */
 const user = useUserStore();
@@ -316,18 +316,18 @@ watch(
                   }}</span>
                 </td>
                 <td :data-testid="`td-transaction-valid-start-ready-execution-${index}`">
-                  {{
-                    tx.transaction instanceof Transaction
-                      ? getTransactionDateExtended(tx.transaction)
-                      : 'N/A'
-                  }}
+                  <DateTimeString
+                    v-if="tx.transaction instanceof Transaction"
+                    :date="getTransactionValidStart(tx.transaction)"
+                  />
+                  <span v-else>N/A</span>
                 </td>
                 <td :data-testid="`td-transaction-date-modified-ready-execution-${index}`">
-                  {{
-                    tx.transaction instanceof Transaction
-                      ? getDateStringExtended(new Date(tx.transactionRaw.updatedAt))
-                      : 'N/A'
-                  }}
+                  <DateTimeString
+                    v-if="tx.transaction instanceof Transaction"
+                    :date="new Date(tx.transactionRaw.updatedAt)"
+                  />
+                  <span v-else>N/A</span>
                 </td>
                 <td class="text-center">
                   <AppButton

--- a/front-end/src/renderer/pages/Transactions/components/ReadyForReview.vue
+++ b/front-end/src/renderer/pages/Transactions/components/ReadyForReview.vue
@@ -26,18 +26,19 @@ import {
   redirectToDetails,
   redirectToGroupDetails,
   isLoggedInOrganization,
-  getDateStringExtended, getTransactionGroupUpdatedAt,
+  getTransactionGroupUpdatedAt,
 } from '@renderer/utils';
 import {
-  getTransactionDateExtended,
   getTransactionId,
   getTransactionType,
+  getTransactionValidStart,
 } from '@renderer/utils/sdk/transactions';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppLoader from '@renderer/components/ui/AppLoader.vue';
 import AppPager from '@renderer/components/ui/AppPager.vue';
 import EmptyTransactions from '@renderer/components/EmptyTransactions.vue';
+import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
 
 /* Stores */
 const user = useUserStore();
@@ -366,25 +367,16 @@ watch(
                   </td>
                   <td>{{ groups.get(group[0])?.description }}</td>
                   <td>
-                    {{
-                      group[1][0].transaction instanceof Transaction
-                        ? getTransactionDateExtended(group[1][0].transaction)
-                        : 'N/A'
-                    }}
+                    <DateTimeString v-if="group[1][0].transaction instanceof Transaction" :date="getTransactionValidStart(group[1][0].transaction)" />
+                    <span v-else>N/A</span>
                   </td>
                   <td>
-                    {{
-                      groups.get(group[0])
-                        ? getDateStringExtended(getTransactionGroupUpdatedAt(groups.get(group[0])))
-                        : 'N/A'
-                    }}
+                    <DateTimeString v-if="groups.get(group[0])" :date="getTransactionGroupUpdatedAt(groups.get(group[0]))" />
+                    <span v-else>N/A</span>
                   </td>
                   <td>
-                    {{
-                      groups.get(group[0])
-                        ? getDateStringExtended(getTransactionGroupUpdatedAt(groups.get(group[0])))
-                        : 'N/A'
-                    }}
+                    <DateTimeString v-if="groups.get(group[0])" :date="getTransactionGroupUpdatedAt(groups.get(group[0]))" />
+                    <span v-else>N/A</span>
                   </td>
                   <td class="text-center">
                     <AppButton
@@ -415,18 +407,12 @@ watch(
                       }}</span>
                     </td>
                     <td :data-testid="`td-review-transaction-valid-start-${index}`">
-                      {{
-                        tx.transaction instanceof Transaction
-                          ? getTransactionDateExtended(tx.transaction)
-                          : 'N/A'
-                      }}
+                      <DateTimeString v-if="tx.transaction instanceof Transaction" :date="getTransactionValidStart(tx.transaction)" />
+                      <span v-else>N/A</span>
                     </td>
                     <td :data-testid="`td-review-transaction-date-modified-${index}`">
-                      {{
-                        tx.transaction instanceof Transaction
-                          ? getDateStringExtended(new Date(tx.transactionRaw.updatedAt))
-                          : 'N/A'
-                      }}
+                      <DateTimeString v-if="tx.transaction instanceof Transaction" :date="new Date(tx.transactionRaw.updatedAt)" />
+                      <span v-else>N/A</span>
                     </td>
                     <td class="text-center">
                       <AppButton

--- a/front-end/src/renderer/pages/Transactions/components/ReadyToSign.vue
+++ b/front-end/src/renderer/pages/Transactions/components/ReadyToSign.vue
@@ -25,18 +25,19 @@ import {
   redirectToDetails,
   redirectToGroupDetails,
   isLoggedInOrganization,
-  getDateStringExtended, getTransactionGroupUpdatedAt,
+  getTransactionGroupUpdatedAt,
 } from '@renderer/utils';
 import {
-  getTransactionDateExtended,
   getTransactionId,
   getTransactionType,
+  getTransactionValidStart,
 } from '@renderer/utils/sdk/transactions';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppLoader from '@renderer/components/ui/AppLoader.vue';
 import AppPager from '@renderer/components/ui/AppPager.vue';
 import EmptyTransactions from '@renderer/components/EmptyTransactions.vue';
+import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
 
 /* Stores */
 const user = useUserStore();
@@ -397,18 +398,12 @@ watch(
                     {{ groups.get(group[0])?.description }}
                   </td>
                   <td>
-                    {{
-                      group[1][0].transaction instanceof Transaction
-                        ? getTransactionDateExtended(group[1][0].transaction)
-                        : 'N/A'
-                    }}
+                    <DateTimeString v-if="group[1][0].transaction instanceof Transaction" :date="getTransactionValidStart(group[1][0].transaction)"/>
+                    <span v-else>N/A</span>
                   </td>
                   <td>
-                    {{
-                      groups.get(group[0])
-                        ? getDateStringExtended(getTransactionGroupUpdatedAt(groups.get(group[0])))
-                        : 'N/A'
-                    }}
+                    <DateTimeString v-if="groups.get(group[0])" :date="getTransactionGroupUpdatedAt(groups.get(group[0]))"/>
+                    <span v-else>N/A</span>
                   </td>
                   <td class="text-center">
                     <AppButton
@@ -440,18 +435,18 @@ watch(
                       }}</span>
                     </td>
                     <td :data-testid="`td-transaction-valid-start-for-sign-${index}`">
-                      {{
-                        tx.transaction instanceof Transaction
-                          ? getTransactionDateExtended(tx.transaction)
-                          : 'N/A'
-                      }}
+                      <DateTimeString
+                        v-if="tx.transaction instanceof Transaction"
+                        :date="getTransactionValidStart(tx.transaction)"
+                      />
+                      <span v-else>N/A</span>
                     </td>
                     <td :data-testid="`td-transaction-date-modified-for-sign-${index}`">
-                      {{
-                        tx.transaction instanceof Transaction
-                          ? getDateStringExtended(new Date(tx.transactionRaw.updatedAt))
-                          : 'N/A'
-                      }}
+                      <DateTimeString
+                        v-if="tx.transaction instanceof Transaction"
+                        :date="new Date(tx.transactionRaw.updatedAt)"
+                      />
+                      <span v-else>N/A</span>
                     </td>
                     <td class="text-center">
                       <AppButton

--- a/front-end/src/renderer/utils/index.ts
+++ b/front-end/src/renderer/utils/index.ts
@@ -126,8 +126,28 @@ export enum DateTimeOptions {
   LOCAL_TIME = 'local-time',
 }
 
-export const getDateStringExtended = (date: Date) => {
-  return `${date.toDateString()} ${date.toLocaleTimeString()}`;
+export const getDateString = (date: Date, format: DateTimeOptions = DateTimeOptions.UTC_TIME) => {
+  return format === DateTimeOptions.UTC_TIME
+    ? date.toLocaleString('en-US', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+        timeZone: 'UTC', // Force UTC time
+      })
+    : date.toLocaleString();
+};
+
+export const getDateStringExtended = (
+  date: Date,
+  format: DateTimeOptions = DateTimeOptions.UTC_TIME,
+) => {
+  return format === DateTimeOptions.UTC_TIME
+    ? date.toUTCString()
+    : `${date.toDateString()} ${date.toLocaleTimeString()}`;
 };
 
 export const throwError = (errorMessage: string) => {

--- a/front-end/src/renderer/utils/index.ts
+++ b/front-end/src/renderer/utils/index.ts
@@ -107,7 +107,7 @@ export const base64ToUint8Array = (base64String: string) => {
     bytes[i] = binaryString.charCodeAt(i);
   }
   return bytes;
-}
+};
 
 export const encodeString = (str: string) => {
   return new TextEncoder().encode(str);
@@ -119,6 +119,11 @@ export function stringToHex(str: string): string {
 
 export function hexToString(hex: string) {
   return decodeURIComponent(hex.replace(/\s+/g, '').replace(/[0-9a-f]{2}/g, '%$&'));
+}
+
+export enum DateTimeOptions {
+  UTC_TIME = 'utc-time',
+  LOCAL_TIME = 'local-time',
 }
 
 export const getDateStringExtended = (date: Date) => {

--- a/front-end/src/renderer/utils/index.ts
+++ b/front-end/src/renderer/utils/index.ts
@@ -121,13 +121,8 @@ export function hexToString(hex: string) {
   return decodeURIComponent(hex.replace(/\s+/g, '').replace(/[0-9a-f]{2}/g, '%$&'));
 }
 
-export enum DateTimeOptions {
-  UTC_TIME = 'utc-time',
-  LOCAL_TIME = 'local-time',
-}
-
-export const getDateString = (date: Date, format: DateTimeOptions = DateTimeOptions.UTC_TIME) => {
-  return format === DateTimeOptions.UTC_TIME
+export function getDateString(date: Date, isUtcSelected = true) {
+  return isUtcSelected
     ? date.toLocaleString('en-US', {
         year: 'numeric',
         month: '2-digit',
@@ -139,16 +134,11 @@ export const getDateString = (date: Date, format: DateTimeOptions = DateTimeOpti
         timeZone: 'UTC', // Force UTC time
       })
     : date.toLocaleString();
-};
+}
 
-export const getDateStringExtended = (
-  date: Date,
-  format: DateTimeOptions = DateTimeOptions.UTC_TIME,
-) => {
-  return format === DateTimeOptions.UTC_TIME
-    ? date.toUTCString()
-    : `${date.toDateString()} ${date.toLocaleTimeString()}`;
-};
+export function getDateStringExtended(date: Date, isUtcSelected = true) {
+  return isUtcSelected ? date.toUTCString() : `${date.toDateString()} ${date.toLocaleTimeString()}`;
+}
 
 export const throwError = (errorMessage: string) => {
   throw new Error(errorMessage);

--- a/front-end/src/shared/constants/index.ts
+++ b/front-end/src/shared/constants/index.ts
@@ -20,6 +20,7 @@ export const DEFAULT_MAX_TRANSACTION_FEE_CLAIM_KEY = 'default_max_transaction_fe
 export const SELECTED_NETWORK = 'selected_network';
 export const LAST_SELECTED_ORGANIZATION = 'last_selected_organization';
 export const DEFAULT_ORGANIZATION_OPTION = 'default_organization_option';
+export const DATE_TIME_PREFERENCE = 'date_time_preference';
 export const USE_KEYCHAIN = 'use_keychain';
 export const UPDATE_LOCATION = 'update_location';
 export const ACCOUNT_SETUP_STARTED = 'account_setup_started';


### PR DESCRIPTION
**Description**:

- Add a `Date/Time Format` setting to the `Default Settings` section (UTC is set by default)
- Display dates according to that setting
- Display either 'Local Time' or 'UTC Time' where relevant
- Manipulate date/time according to the setting in DatePicker

**Related issue(s)**:

Fixes #1650

**Notes for reviewer**:

<img width="984" height="758" alt="Screenshot 2025-10-07 at 18 17 38" src="https://github.com/user-attachments/assets/880d8d52-c79e-401a-ba72-debc43f44de7" />

<img width="982" height="804" alt="Screenshot 2025-10-07 at 18 16 38" src="https://github.com/user-attachments/assets/8fa869bb-581e-4961-8578-3e0dce047a56" />

<img width="982" height="506" alt="Screenshot 2025-10-07 at 18 16 17" src="https://github.com/user-attachments/assets/e955e82a-a5f0-41d6-b6f6-b7f1663ff5f7" />

<img width="982" height="480" alt="Screenshot 2025-10-07 at 18 15 30" src="https://github.com/user-attachments/assets/b1af7b70-4d2e-42b1-8817-a0ad4c0f854b" />

<img width="982" height="501" alt="Screenshot 2025-10-07 at 18 14 47" src="https://github.com/user-attachments/assets/c9efa0f5-7052-4e15-88f8-26a7acb3f116" />

