### PR TITLE
fix: sign buttons may be stuck in spinning state

### DIFF
--- a/back-end/docker-compose.yaml
+++ b/back-end/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
       - POSTGRES_PASSWORD
     container_name: postgres
     volumes:
-      - ./pgdata:/var/lib/postgresql/data
+      - ./pgdata:/var/lib/postgresql
     # for development, allow postgres to be accessible
     ports:
       - '5432:5432'

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -74,7 +74,6 @@ const createTooltips = useCreateTooltips();
 const group = ref<IGroup | null>(null);
 const shouldApprove = ref(false);
 const isConfirmModalShown = ref(false);
-const publicKeysRequiredToSign = ref<string[]>([]);
 const disableSignAll = ref(false);
 const isSigningAll = ref(false);
 const signingItemSeq = ref(-1);
@@ -85,7 +84,7 @@ const tooltipRef = ref<HTMLElement[]>([]);
 /* Computed */
 const showSignAll = computed(() => {
   return (
-    isLoggedInOrganization(user.selectedOrganization) && publicKeysRequiredToSign.value.length > 0
+    isLoggedInOrganization(user.selectedOrganization) && Object.keys(unsignedSignersToCheck.value).length >= 1
   );
 });
 
@@ -93,7 +92,6 @@ const showSignAll = computed(() => {
 async function handleFetchGroup(id: string | number) {
   if (isLoggedInOrganization(user.selectedOrganization) && !isNaN(Number(id))) {
     try {
-      const updatedPublicKeysRequiredToSign: string[] = [];
       const updatedUnsignedSignersToCheck: Record<number, string[]> = {};
 
       group.value = await getApiGroupById(user.selectedOrganization.serverUrl, Number(id));
@@ -129,17 +127,11 @@ async function handleFetchGroup(id: string | number) {
             usersPublicKeys.length > 0
           ) {
             updatedUnsignedSignersToCheck[txId] = usersPublicKeys;
-            usersPublicKeys.forEach(key => {
-              if (!updatedPublicKeysRequiredToSign.includes(key)) {
-                updatedPublicKeysRequiredToSign.push(key);
-              }
-            });
           }
         }
       }
 
       unsignedSignersToCheck.value = updatedUnsignedSignersToCheck;
-      publicKeysRequiredToSign.value = updatedPublicKeysRequiredToSign;
 
       // bootstrap tooltips needs to be recreated when the items' status might have changed
       // since their title is not updated

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -79,7 +79,7 @@ const disableSignAll = ref(false);
 const isSigningAll = ref(false);
 const signingItemSeq = ref(-1);
 const isApproving = ref(false);
-const unsignedSignersToCheck = ref<Record<string, string[]>>({});
+const unsignedSignersToCheck = ref<Record<number, string[]>>({});
 const tooltipRef = ref<HTMLElement[]>([]);
 
 /* Computed */
@@ -94,7 +94,7 @@ async function handleFetchGroup(id: string | number) {
   if (isLoggedInOrganization(user.selectedOrganization) && !isNaN(Number(id))) {
     try {
       const updatedPublicKeysRequiredToSign: string[] = [];
-      const updatedUnsignedSignersToCheck: Record<string, string[]> = {};
+      const updatedUnsignedSignersToCheck: Record<number, string[]> = {};
 
       group.value = await getApiGroupById(user.selectedOrganization.serverUrl, Number(id));
       disableSignAll.value = false;

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -637,7 +637,7 @@ watchEffect(() => {
                                     loading-text="Signing..."
                                     type="button"
                                     color="primary"
-                                    @click.prevent="handleSignGroupItem(groupItem)"
+                                    @click.prevent="handleSignGroupItem(groupItem as IGroupItem)"
                                     :data-testid="`sign-group-item-${index}`"
                                     :disabled="
                                       unsignedSignersToCheck[groupItem.transaction.id] ===


### PR DESCRIPTION
**Description**:

Instead of relying on data refresh triggered by WS messages to update the button state, we now trigger explicit refresh (either of group or of group item) at the end of the sign operation to avoid being stuck in the loading state.

**Related issue(s)**:

Fixes #1873 
