### PR TITLE
fix: `Create and Share` crashes if current user has no key pair

### DIFF
--- a/front-end/src/renderer/components/Transaction/TransactionGroupProcessor.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionGroupProcessor.vue
@@ -294,6 +294,11 @@ async function sendSignedTransactionsToOrganization() {
   });
   if (passwordModalOpened(personalPassword)) return;
 
+  /* Verifies the user has at least one key pair */
+  if (user.keyPairs.length == 0) {
+    throw new Error("You don't have any key pair. Please add one and retry.");
+  }
+
   /* Verifies there is actual transaction to process */
   if (!transactionGroup.groupItems[0].transactionBytes) throw new Error('No Transactions provided');
 


### PR DESCRIPTION
**Description**:

Changes below add logic to verify number of key pairs of the current user.
If zero, operation is aborted using message: `You don't have any key pair. Please add one and retry.`

**Related issue(s)**:

Fixes #1879

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
