### PR TITLE
fix: navigation from CreateTransaction when hitting Save

### DIFF
--- a/front-end/src/renderer/components/SaveDraftButton.vue
+++ b/front-end/src/renderer/components/SaveDraftButton.vue
@@ -9,7 +9,7 @@ import { useRoute, useRouter } from 'vue-router';
 
 import { addDraft, getDraft, updateDraft } from '@renderer/services/transactionDraftsService';
 
-import { getTransactionFromBytes, isUserLoggedIn } from '@renderer/utils';
+import { getTransactionFromBytes, isUserLoggedIn, redirectToPreviousTransactionsTab } from '@renderer/utils';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 
@@ -51,11 +51,13 @@ const handleDraft = async () => {
         });
         emit('draft-saved');
         toast.success('Draft updated');
-        router.push('/transactions?tab=Drafts');
+        await redirectToPreviousTransactionsTab(router)
       }
     } else {
-      await sendAddDraft(user.personal.id, transactionBytes);
+      await addDraft(user.personal.id, transactionBytes, props.description);
       emit('draft-saved');
+      toast.success('Draft saved');
+      await redirectToPreviousTransactionsTab(router)
     }
   } catch (error) {
     console.log(error);
@@ -63,12 +65,6 @@ const handleDraft = async () => {
 };
 
 /* Functions */
-async function sendAddDraft(userId: string, transactionBytes: Uint8Array) {
-  await addDraft(userId, transactionBytes, props.description);
-  router.push('/transactions?tab=Drafts');
-  toast.success('Draft saved');
-}
-
 function getTransactionBytes() {
   if (!props.getTransaction) return;
   const transaction = props.getTransaction();


### PR DESCRIPTION
**Description**:

Follow-up to PR https://github.com/hashgraph/hedera-transaction-tool/pull/1886 to make the navigation when leaving `Create Transaction` consistent: make sure to go back to the previous `Transactions` tab after hitting `Save`.
