### PR TITLE
fix: build break in MultipleAccountUpdateRequestHandler vue

### DIFF
--- a/front-end/src/renderer/components/Transaction/TransactionProcessor/requests.ts
+++ b/front-end/src/renderer/components/Transaction/TransactionProcessor/requests.ts
@@ -165,4 +165,20 @@ export class MultipleAccountUpdateRequest extends CustomRequest {
 
     this.requestKey = keyList;
   }
+
+  getAccountIdTransactionKey(accountId: string) {
+    const keyList = new KeyList([this.key]);
+    const accountInfo = this.accountInfoMap.get(accountId);
+
+    if (accountInfo) {
+      accountInfo.key && keyList.push(accountInfo.key);
+
+      if (!this.accountIsPayer && this.payerId) {
+        const payerInfo = this.accountInfoMap.get(this.payerId);
+        payerInfo?.key && keyList.push(payerInfo.key);
+      }
+    }
+
+    return keyList;
+  }
 }


### PR DESCRIPTION
**Description**:
I wrongly removed `getAccountIdTransactionKey()` from` request.ts` in #1882  … :(
Changes below fix the build break.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
