### PR TITLE
chore: add `--no-hints` option to `prisma generate command

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -24,7 +24,7 @@
     "publish": "npm run build && electron-builder -m -p 'onTagOrDraft'",
     "test:main": "vitest --config src/tests/vitest.config.main.ts --passWithNoTests",
     "test:main:coverage": "vitest --config src/tests/vitest.config.main.ts --coverage.enabled --coverage.include=src/main",
-    "generate:database": "prisma generate"
+    "generate:database": "prisma generate --no-hints"
   },
   "dependencies": {
     "@electron-toolkit/utils": "3.0.0",


### PR DESCRIPTION
### Description

Changes below update `front-end/package.json` and adds `--no-hints` option to `prisma generate` command.
This removes the `Tip` line in command output:

<img width="1011" height="220" alt="Image" src="https://github.com/user-attachments/assets/2f0af577-4214-4631-bfa7-d2cd289035ee" />

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
