### PR TITLE
fix: avoid showing organization login dialog when opening the app

### DIFF
--- a/front-end/src/renderer/components/GlobalAppProcesses/GlobalAppProcesses.vue
+++ b/front-end/src/renderer/components/GlobalAppProcesses/GlobalAppProcesses.vue
@@ -47,12 +47,12 @@ const handleImportantModalReady = async () => {
 const handleBeginMigrationReadyState = async () => {
   await withLoader(tryAutoLogin);
 
+  await user.refetchOrganizations();
   const redirect = await redirectIfRequiredKeysToMigrate();
   if (!redirect) {
     await withLoader(selectDefaultOrganization);
   }
 
-  await user.refetchOrganizations();
   await setupStores();
 };
 


### PR DESCRIPTION
**Description**:

Avoid showing the login dialog at each startup when auto selecting the default (if set by user) or last used organization.
Fix consists in moving the proper initialization of the organizations (whether server is connected, user logged, etc...) before that selection is made. 

**Related issue(s)**:

Fixes #1798 
