### PR TITLE
chore: removed obsolete `transaction-base-key` attributes.

### DIFF
--- a/front-end/src/renderer/components/Transaction/Create/AccountDelete/AccountDelete.vue
+++ b/front-end/src/renderer/components/Transaction/Create/AccountDelete/AccountDelete.vue
@@ -4,7 +4,7 @@ import type { CreateTransactionFunc } from '@renderer/components/Transaction/Cre
 import type { AccountDeleteData } from '@renderer/utils/sdk';
 
 import { computed, onMounted, reactive, ref, watch } from 'vue';
-import { Key, KeyList, Transaction } from '@hashgraph/sdk';
+import { Transaction } from '@hashgraph/sdk';
 
 import useUserStore from '@renderer/stores/storeUser';
 
@@ -54,18 +54,6 @@ const createDisabled = computed(() => {
     accountData.accountInfo.value?.deleted ||
     transferAccountData.accountInfo.value?.deleted
   );
-});
-
-const transactionKey = computed(() => {
-  const keys: Key[] = [];
-  accountData.key.value && keys.push(accountData.key.value);
-  if (
-    transferAccountData.accountInfo?.value?.receiverSignatureRequired &&
-    transferAccountData.key?.value
-  ) {
-    transferAccountData.key.value && keys.push(transferAccountData.key.value);
-  }
-  return new KeyList(keys);
 });
 
 /* Handlers */
@@ -132,7 +120,6 @@ watch(
 <template>
   <BaseTransaction
     ref="baseTransactionRef"
-    :transaction-base-key="transactionKey"
     :create-transaction="createTransaction"
     :pre-create-assert="preCreateAssert"
     :create-disabled="createDisabled"

--- a/front-end/src/renderer/components/Transaction/Create/AccountUpdate/AccountUpdate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/AccountUpdate/AccountUpdate.vue
@@ -4,7 +4,7 @@ import type { CreateTransactionFunc } from '@renderer/components/Transaction/Cre
 import type { AccountUpdateData, AccountUpdateDataMultiple } from '@renderer/utils/sdk';
 
 import { computed, onMounted, reactive, ref, watch } from 'vue';
-import { AccountId, Key, KeyList, Transaction } from '@hashgraph/sdk';
+import { AccountId, Transaction } from '@hashgraph/sdk';
 
 import { useRoute } from 'vue-router';
 import useAccountId from '@renderer/composables/useAccountId';
@@ -57,13 +57,6 @@ const createDisabled = computed(() => {
     (data.stakeType === 'Account' && !isAccountId(data.stakedAccountId)) ||
     (data.stakeType === 'Node' && data.stakedNodeId === null)
   );
-});
-
-const transactionKey = computed(() => {
-  const keys: Key[] = [];
-  accountData.key.value && keys.push(accountData.key.value);
-  data.ownerKey && keys.push(data.ownerKey);
-  return new KeyList(keys);
 });
 
 const customRequest = computed(() => {
@@ -149,7 +142,6 @@ watch(
 <template>
   <BaseTransaction
     ref="baseTransactionRef"
-    :transaction-base-key="transactionKey"
     :create-transaction="createTransaction"
     :pre-create-assert="preCreateAssert"
     :create-disabled="createDisabled"

--- a/front-end/src/renderer/components/Transaction/Create/ApproveHbarAllowance/ApproveHbarAllowance.vue
+++ b/front-end/src/renderer/components/Transaction/Create/ApproveHbarAllowance/ApproveHbarAllowance.vue
@@ -4,7 +4,7 @@ import type { CreateTransactionFunc } from '@renderer/components/Transaction/Cre
 import type { ApproveHbarAllowanceData } from '@renderer/utils/sdk';
 
 import { computed, reactive, ref, watch } from 'vue';
-import { Hbar, Key, KeyList, Transaction } from '@hashgraph/sdk';
+import { Hbar, Transaction } from '@hashgraph/sdk';
 
 import useAccountId from '@renderer/composables/useAccountId';
 
@@ -41,12 +41,6 @@ const createTransaction = computed<CreateTransactionFunc>(() => {
 
 const createDisabled = computed(() => !spenderData.key.value || !ownerData.key.value);
 
-const transactionKey = computed(() => {
-  const keys: Key[] = [];
-  ownerData.key.value && keys.push(ownerData.key.value);
-  return new KeyList(keys);
-});
-
 /* Handlers */
 const handleDraftLoaded = (transaction: Transaction) => {
   handleUpdateData(getApproveHbarAllowanceTransactionData(transaction));
@@ -82,7 +76,6 @@ watch(
     :create-transaction="createTransaction"
     :pre-create-assert="preCreateAssert"
     :create-disabled="createDisabled"
-    :transaction-base-key="transactionKey"
     @draft-loaded="handleDraftLoaded"
   >
     <ApproveHbarAllowanceFormData

--- a/front-end/src/renderer/components/Transaction/Create/FileAppend/FileAppend.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileAppend/FileAppend.vue
@@ -3,7 +3,7 @@ import type { CreateTransactionFunc } from '@renderer/components/Transaction/Cre
 import type { FileAppendData } from '@renderer/utils/sdk';
 
 import { computed, onMounted, reactive, ref } from 'vue';
-import { Key, KeyList, Transaction } from '@hashgraph/sdk';
+import { Key, Transaction } from '@hashgraph/sdk';
 
 import useUserStore from '@renderer/stores/storeUser';
 
@@ -45,12 +45,6 @@ const createDisabled = computed(
   () => (!isLoggedInOrganization(user.selectedOrganization) && !signatureKey.value) || !data.fileId,
 );
 
-const transactionKey = computed(() => {
-  const keys: Key[] = [];
-  signatureKey.value && keys.push(signatureKey.value);
-  return new KeyList(keys);
-});
-
 /* Handlers */
 const handleDraftLoaded = (transaction: Transaction) => {
   handleUpdateData(getFileAppendTransactionData(transaction));
@@ -84,7 +78,6 @@ onMounted(() => {
     :create-transaction="createTransaction"
     :pre-create-assert="preCreateAssert"
     :create-disabled="createDisabled"
-    :transaction-base-key="transactionKey"
     @draft-loaded="handleDraftLoaded"
   >
     <FileAppendFormData

--- a/front-end/src/renderer/components/Transaction/Create/FileCreate/FileCreate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileCreate/FileCreate.vue
@@ -5,7 +5,7 @@ import type { CreateTransactionFunc } from '@renderer/components/Transaction/Cre
 import type { FileCreateData } from '@renderer/utils/sdk';
 
 import { computed, reactive, ref, watch } from 'vue';
-import { Key, KeyList, Transaction } from '@hashgraph/sdk';
+import { Transaction } from '@hashgraph/sdk';
 
 import useUserStore from '@renderer/stores/storeUser';
 import useNetworkStore from '@renderer/stores/storeNetwork';
@@ -55,12 +55,6 @@ const createTransaction = computed<CreateTransactionFunc>(() => {
 });
 
 const createDisabled = computed(() => !data.ownerKey);
-
-const transactionKey = computed(() => {
-  const keys: Key[] = [];
-  data.ownerKey && keys.push(data.ownerKey);
-  return new KeyList(keys);
-});
 
 /* Handlers */
 const handleDraftLoaded = (transaction: Transaction) => {
@@ -134,7 +128,6 @@ watch(
     :create-transaction="createTransaction"
     :pre-create-assert="preCreateAssert"
     :create-disabled="createDisabled"
-    :transaction-base-key="transactionKey"
     @draft-loaded="handleDraftLoaded"
     @executed:success="handleExecutedSuccess"
   >

--- a/front-end/src/renderer/components/Transaction/Create/FileUpdate/FileUpdate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileUpdate/FileUpdate.vue
@@ -3,7 +3,7 @@ import type { CreateTransactionFunc } from '@renderer/components/Transaction/Cre
 import type { FileUpdateData } from '@renderer/utils/sdk';
 
 import { computed, onMounted, reactive, ref, watch } from 'vue';
-import { Key, KeyList, Transaction } from '@hashgraph/sdk';
+import { Key, Transaction } from '@hashgraph/sdk';
 
 import useUserStore from '@renderer/stores/storeUser';
 
@@ -46,13 +46,6 @@ const createDisabled = computed(
   () => (!isLoggedInOrganization(user.selectedOrganization) && !signatureKey.value) || !data.fileId,
 );
 
-const transactionKey = computed(() => {
-  const keys: Key[] = [];
-  data.ownerKey && keys.push(data.ownerKey);
-  signatureKey.value && keys.push(signatureKey.value);
-  return new KeyList(keys);
-});
-
 /* Handlers */
 const handleDraftLoaded = (transaction: Transaction) => {
   handleUpdateData(getFileUpdateTransactionData(transaction));
@@ -94,7 +87,6 @@ watch(
     :create-transaction="createTransaction"
     :pre-create-assert="preCreateAssert"
     :create-disabled="createDisabled"
-    :transaction-base-key="transactionKey"
     @draft-loaded="handleDraftLoaded"
   >
     <FileUpdateFormData

--- a/front-end/src/renderer/components/Transaction/Create/NodeCreate/NodeCreate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/NodeCreate/NodeCreate.vue
@@ -3,7 +3,7 @@ import type { CreateTransactionFunc } from '@renderer/components/Transaction/Cre
 import type { NodeData } from '@renderer/utils/sdk/createTransactions';
 
 import { computed, reactive, ref, watch } from 'vue';
-import { Key, KeyList, Transaction } from '@hashgraph/sdk';
+import { Transaction } from '@hashgraph/sdk';
 
 import { useToast } from 'vue-toast-notification';
 
@@ -47,12 +47,6 @@ const createTransaction = computed<CreateTransactionFunc>(() => {
 
 const createDisabled = computed(() => {
   return !data.adminKey;
-});
-
-const transactionKey = computed(() => {
-  const keys: Key[] = [];
-  data.adminKey && keys.push(data.adminKey);
-  return new KeyList(keys);
 });
 
 /* Handlers */
@@ -110,7 +104,6 @@ watch(
     ref="baseTransactionRef"
     :create-transaction="createTransaction"
     :pre-create-assert="preCreateAssert"
-    :transaction-base-key="transactionKey"
     :create-disabled="createDisabled"
     @executed:success="handleExecutedSuccess"
     @draft-loaded="handleDraftLoaded"

--- a/front-end/src/renderer/components/Transaction/Create/NodeUpdate/NodeUpdate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/NodeUpdate/NodeUpdate.vue
@@ -4,7 +4,7 @@ import type { NodeUpdateData } from '@renderer/utils/sdk/createTransactions';
 import type { CreateTransactionFunc } from '@renderer/components/Transaction/Create/BaseTransaction';
 
 import { computed, reactive, ref, watch } from 'vue';
-import { Key, KeyList, NodeUpdateTransaction, Transaction } from '@hashgraph/sdk';
+import { NodeUpdateTransaction, Transaction } from '@hashgraph/sdk';
 
 import { useRoute } from 'vue-router';
 import { useToast } from 'vue-toast-notification';
@@ -12,7 +12,7 @@ import useAccountId from '@renderer/composables/useAccountId';
 import useNodeId from '@renderer/composables/useNodeId';
 
 import { createNodeUpdateTransaction } from '@renderer/utils/sdk/createTransactions';
-import { getComponentServiceEndpoint, getNodeUpdateData, isAccountId } from '@renderer/utils';
+import { getComponentServiceEndpoint, getNodeUpdateData } from '@renderer/utils';
 
 import BaseTransaction from '@renderer/components/Transaction/Create/BaseTransaction';
 import NodeUpdateFormData from '@renderer/components/Transaction/Create/NodeUpdate/NodeUpdateFormData.vue';
@@ -49,21 +49,6 @@ const createTransaction = computed<CreateTransactionFunc>(() => {
       },
       (nodeData.nodeInfo?.value as INodeInfoParsed) || null,
     );
-});
-
-const transactionKey = computed(() => {
-  const keys: Key[] = [];
-
-  const oldAccountId = nodeData.nodeInfo?.value?.node_account_id?.toString()?.trim();
-  if (isAccountId(data.nodeAccountId) && oldAccountId !== data.nodeAccountId.trim()) {
-    nodeData.accountData.key.value && keys.push(nodeData.accountData.key.value);
-    newNodeAccountData.key.value && keys.push(newNodeAccountData.key.value);
-  }
-
-  data.adminKey && keys.push(data.adminKey);
-  nodeData.key.value && keys.push(nodeData.key.value);
-
-  return new KeyList(keys);
 });
 
 /* Handlers */
@@ -134,7 +119,6 @@ watch(
     ref="baseTransactionRef"
     :create-transaction="createTransaction"
     :pre-create-assert="preCreateAssert"
-    :transaction-base-key="transactionKey"
     @executed:success="handleExecutedSuccess"
     @draft-loaded="handleDraftLoaded"
   >

--- a/front-end/src/renderer/components/Transaction/Create/TransferHbar/TransferHbar.vue
+++ b/front-end/src/renderer/components/Transaction/Create/TransferHbar/TransferHbar.vue
@@ -4,7 +4,7 @@ import type { CreateTransactionFunc } from '@renderer/components/Transaction/Cre
 import type { TransferHbarData } from '@renderer/utils/sdk';
 
 import { computed, reactive, ref, watch } from 'vue';
-import { Hbar, Key, KeyList, Transaction } from '@hashgraph/sdk';
+import { Hbar, Transaction } from '@hashgraph/sdk';
 
 import useNetworkStore from '@renderer/stores/storeNetwork';
 
@@ -49,29 +49,6 @@ const createDisabled = computed(() => {
     totalBalanceAdjustments.value === 0 ||
     (user.selectedOrganization === null && anyTransfersExceedingBalance.value)
   );
-});
-
-const transactionKey = computed(() => {
-  const keys: Key[] = [];
-  const addedKeysForAccountIds: string[] = [];
-  for (const transfer of data.transfers) {
-    if (!transfer.isApproved) {
-      const accountId = transfer.accountId.toString();
-
-      const key = accountInfos.value[accountId]?.key;
-      const receiverSigRequired = accountInfos.value[accountId]?.receiverSignatureRequired;
-
-      if (
-        key &&
-        !addedKeysForAccountIds.includes(accountId) &&
-        (transfer.amount.isNegative() || (!transfer.amount.isNegative() && receiverSigRequired))
-      ) {
-        keys.push(key);
-        addedKeysForAccountIds.push(accountId);
-      }
-    }
-  }
-  return new KeyList(keys);
 });
 
 const totalBalance = computed(() => {
@@ -149,7 +126,6 @@ watch(
     :create-transaction="createTransaction"
     :pre-create-assert="preCreateAssert"
     :create-disabled="createDisabled"
-    :transaction-base-key="transactionKey"
     @draft-loaded="handleDraftLoaded"
   >
     <TransferHbarFormData


### PR DESCRIPTION
**Description**:
Changes below remove obsolete `:transaction-base-key` attributes from `<BaseTransaction>` references.
This attribute has been removed on Aug 16 by the following commit: https://github.com/hashgraph/hedera-transaction-tool/commit/b6dfb4c6d4f53da6418793ee53dfb272a4d25abb

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
