### PR TITLE
chore: disabling solo deployment for LoginTests, RegistrationTests and SettingsTests

### DIFF
--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -69,13 +69,13 @@ jobs:
         test-suite:
           - name: Registration
             command: RegistrationTests
-            soloRequired: true
+            soloRequired: false
           - name: Login
             command: LoginTests
             soloRequired: false
           - name: Settings
             command: SettingsTests
-            soloRequired: true
+            soloRequired: false
           - name: Transactions
             command: TransactionTests
             soloRequired: true


### PR DESCRIPTION
**Description**:
Changes below make solo deployment optional in automation tests.
And they disable it for `LoginTests`, `RegistrationsTests` and `SettingsTests` since those suites do not use solo.
Execution time for those suites goes from 8mn to 1mn30 :)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
