### PR TITLE
fix: replaced storeNotifications.setup() by watching logic

### DIFF
--- a/front-end/src/renderer/composables/user/useSetupStores.ts
+++ b/front-end/src/renderer/composables/user/useSetupStores.ts
@@ -1,5 +1,4 @@
 import useContactsStore from '@renderer/stores/storeContacts';
-import useNotificationsStore from '@renderer/stores/storeNotifications';
 import useWebsocketConnection from '@renderer/stores/storeWebsocketConnection';
 
 import { useToast } from 'vue-toast-notification';
@@ -7,13 +6,12 @@ import { useToast } from 'vue-toast-notification';
 export default function useSetupStores() {
   /* Stores */
   const contacts = useContactsStore();
-  const notifications = useNotificationsStore();
   const ws = useWebsocketConnection();
 
   const toast = useToast();
 
   const setupStores = async () => {
-    const results = await Promise.allSettled([contacts.fetch(), notifications.setup(), ws.setup()]);
+    const results = await Promise.allSettled([contacts.fetch(), ws.setup()]);
     results.forEach(r => {
       if (r.status === 'rejected') {
         const errorMessage =

--- a/front-end/src/renderer/pages/AccountSetup/components/NewPassword.vue
+++ b/front-end/src/renderer/pages/AccountSetup/components/NewPassword.vue
@@ -3,7 +3,6 @@ import { computed, ref, watch } from 'vue';
 
 import useUserStore from '@renderer/stores/storeUser';
 import useContactsStore from '@renderer/stores/storeContacts';
-import useNotificationsStore from '@renderer/stores/storeNotifications';
 
 import { useToast } from 'vue-toast-notification';
 import usePersonalPassword from '@renderer/composables/usePersonalPassword';
@@ -29,7 +28,6 @@ const props = defineProps<{
 /* Stores */
 const user = useUserStore();
 const contacts = useContactsStore();
-const notifications = useNotificationsStore();
 
 /* Composables */
 const toast = useToast();
@@ -91,7 +89,6 @@ const handleChangePassword = async () => {
 
       await user.refetchUserState();
       await contacts.fetch();
-      await notifications.fetchPreferences();
 
       props.handleContinue();
 


### PR DESCRIPTION
**Description**:

Changes below remove `storeNotifications.setup()` method and replace it by `watch()` logic.
This avoids some duplicated calls to backend endpoints:
- `GET /notification-preferences`
- `GET /notifications`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
