### PR TITLE
chore: setting playwright retries and timeout according CI or DEV environment

### DIFF
--- a/automation/playwright.config.js
+++ b/automation/playwright.config.js
@@ -3,7 +3,8 @@ import { defineConfig } from 'playwright/test';
 export default defineConfig({
   reporter: process.env.CI ? [['github'], ['list']] : 'list',
   reportSlowTests: null,
-  retries: 3,
+  retries: process.env.CI ? 3 : 0,
+  timeout: process.env.CI ? 30_000 : 3600_000,
   workers: 1,
 
   projects: [


### PR DESCRIPTION
**Description**:

Changes below update `playwright.config.js` so that:
- `retries` is 0 in `DEV` mode and 3 in `CI` mode
- `timeout` is 1h in `DEV` mode and 30s in `CI` mode

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
