### PR TITLE
feat: transaction details tab should indicate when a transaction is configured for manual submission

### DIFF
--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -255,13 +255,7 @@ const isTransactionFailed = computed(() => {
 });
 
 const isManualFlagVisible = computed(() => {
-  return props.organizationTransaction?.isManual && isTransactionNotYetSubmitted.value
-})
-
-const isTransactionNotYetSubmitted = computed(() => {
-  return props.organizationTransaction?.status === TransactionStatus.NEW
-    || props.organizationTransaction?.status === TransactionStatus.WAITING_FOR_SIGNATURES
-    || props.organizationTransaction?.status === TransactionStatus.WAITING_FOR_EXECUTION;
+  return props.organizationTransaction?.isManual && transactionIsInProgress.value;
 });
 
 /* Handlers */
@@ -694,9 +688,7 @@ watch(
         <span v-else-if="isTransactionVersionMismatch" class="badge bg-danger text-break ms-2">
           Transaction Version Mismatch
         </span>
-        <span v-else-if="isManualFlagVisible" class="badge bg-info text-break ms-2">
-          Manual
-        </span>
+        <span v-else-if="isManualFlagVisible" class="badge bg-info text-break ms-2">Manual</span>
       </h2>
     </div>
 


### PR DESCRIPTION
**Description**:

Changes below update `Transaction Details` tab header to display a badge if transaction is configured for manual submission. Badge is visible only for transactions that are still to be submitted (ie `NEW`, `WAITING_FOR_SIGNATURES` or `WAITING_FOR_EXECUTION` state).
Visual design is aligned on other badges displayed in `Transaction Details` header (`FAILED` and `Transaction Version Mismatch`).

<img width="1316" height="313" alt="image" src="https://github.com/user-attachments/assets/77f29286-67cc-48d6-8d39-94904f2cc930" />

**Related issue(s)**:

Fixes #1627 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
