### PR TITLE
chore: removed unused @ready:not event from BeginDataMigration

### DIFF
--- a/front-end/src/renderer/components/GlobalAppProcesses/components/BeginDataMigration.vue
+++ b/front-end/src/renderer/components/GlobalAppProcesses/components/BeginDataMigration.vue
@@ -18,7 +18,6 @@ const show = ref(false);
 /* Emits */
 const emit = defineEmits<{
   (event: 'ready'): void;
-  (event: 'ready:not'): void;
   (event: 'migrate:start'): void;
 }>();
 
@@ -47,7 +46,6 @@ const checkShouldChoose = async () => {
 
 const initialize = async () => {
   show.value = await checkShouldChoose();
-  if (show.value) emit('ready:not');
   if (!show.value) emit('ready');
 };
 


### PR DESCRIPTION
**Description**:

Changes below remove unused `@ready:not` event from `BeginDataMigration`.

**Notes for reviewer**:

`GlobalAppProcesses` is the only user of `BeginDataMigration` and its uses `ready` and  `migrate:start` events but not `ready:not`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
