### PR TITLE
chore: fixing confusion between the two definitions of IGroup interface.

### DIFF
--- a/front-end/src/renderer/components/Transaction/TransactionProcessor/components/BigFileOrganizationRequestHandler.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionProcessor/components/BigFileOrganizationRequestHandler.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
-import type { IGroup, TransactionApproverDto } from '@shared/interfaces';
+import type { TransactionApproverDto } from '@shared/interfaces';
 import type { GroupItem } from '@renderer/stores/storeTransactionGroup';
-import { addApprovers, addObservers, type ApiGroupItem } from '@renderer/services/organization';
+import {
+  addApprovers,
+  addObservers,
+  type ApiGroupItem,
+  type IGroup,
+} from '@renderer/services/organization';
 import { TransactionRequest, type Handler, type Processable } from '..';
 
 import { ref } from 'vue';
@@ -211,7 +216,7 @@ async function submitGroup(groupItems: GroupItem[], signature: string[], keyToSi
       true,
       apiGroupItems,
     );
-    const group: IGroup = await getApiGroupById(user.selectedOrganization.serverUrl, id);
+    const group = await getApiGroupById(user.selectedOrganization.serverUrl, id);
     await safeAwait(submitApproversObservers(group));
     emit('transaction:group:submit:success', id);
   } catch (error) {

--- a/front-end/src/renderer/components/Transaction/TransactionProcessor/components/MultipleAccountUpdateRequestHandler.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionProcessor/components/MultipleAccountUpdateRequestHandler.vue
@@ -5,9 +5,9 @@ import {
   type Handler,
   type Processable,
 } from '..';
-import type { IGroup, TransactionApproverDto } from '@shared/interfaces';
+import type { TransactionApproverDto } from '@shared/interfaces';
 import type { GroupItem } from '@renderer/stores/storeTransactionGroup';
-import type { ApiGroupItem } from '@renderer/services/organization';
+import type { ApiGroupItem, IGroup } from '@renderer/services/organization';
 
 import { ref } from 'vue';
 import {
@@ -303,7 +303,7 @@ async function submitGroup(groupItems: GroupItem[], signature: string[], keyToSi
       true,
       apiGroupItems,
     );
-    const group: IGroup = await getApiGroupById(user.selectedOrganization.serverUrl, id);
+    const group = await getApiGroupById(user.selectedOrganization.serverUrl, id);
     await safeAwait(submitApproversObservers(group));
     emit('transaction:group:submit:success', id);
   } catch (error) {

--- a/front-end/src/renderer/pages/Transactions/components/InProgress.vue
+++ b/front-end/src/renderer/pages/Transactions/components/InProgress.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { IGroup, ITransaction } from '@shared/interfaces';
+import type { ITransaction } from '@shared/interfaces';
 
 import { computed, onBeforeMount, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
 
@@ -16,7 +16,11 @@ import useNextTransactionStore from '@renderer/stores/storeNextTransaction';
 import { useRouter } from 'vue-router';
 import useDisposableWs from '@renderer/composables/useDisposableWs';
 
-import { getApiGroupById, getTransactionsForUser } from '@renderer/services/organization';
+import {
+  getApiGroupById,
+  getTransactionsForUser,
+  type IGroup,
+} from '@renderer/services/organization';
 
 import { getTransactionType, getTransactionValidStart } from '@renderer/utils/sdk/transactions';
 import {

--- a/front-end/src/renderer/pages/Transactions/components/ReadyForReview.vue
+++ b/front-end/src/renderer/pages/Transactions/components/ReadyForReview.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { IGroup, ITransaction } from '@shared/interfaces';
+import type { ITransaction } from '@shared/interfaces';
 
 import { computed, onBeforeMount, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
 
@@ -18,7 +18,11 @@ import { useRouter } from 'vue-router';
 import useDisposableWs from '@renderer/composables/useDisposableWs';
 import useMarkNotifications from '@renderer/composables/useMarkNotifications';
 
-import { getApiGroupById, getTransactionsToApprove } from '@renderer/services/organization';
+import {
+  getApiGroupById,
+  getTransactionsToApprove,
+  type IGroup,
+} from '@renderer/services/organization';
 
 import {
   getNotifiedTransactions,

--- a/front-end/src/renderer/pages/Transactions/components/ReadyToSign.vue
+++ b/front-end/src/renderer/pages/Transactions/components/ReadyToSign.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
-import {
-  type IGroup,
-  type ITransaction,
-  NotificationType,
-  TransactionStatus,
-} from '@shared/interfaces';
+import { type ITransaction, NotificationType, TransactionStatus } from '@shared/interfaces';
 
 import { computed, onBeforeMount, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
 
@@ -21,7 +16,11 @@ import useNextTransactionStore from '@renderer/stores/storeNextTransaction';
 import { useRouter } from 'vue-router';
 import useDisposableWs from '@renderer/composables/useDisposableWs';
 
-import { getApiGroupById, getTransactionsToSign } from '@renderer/services/organization';
+import {
+  getApiGroupById,
+  getTransactionsToSign,
+  type IGroup,
+} from '@renderer/services/organization';
 
 import {
   assertIsLoggedInOrganization,

--- a/front-end/src/renderer/services/organization/transactionGroup.ts
+++ b/front-end/src/renderer/services/organization/transactionGroup.ts
@@ -15,6 +15,7 @@ export interface ApiGroupItem {
 
 export interface IGroupItem {
   seq: number;
+  transactionId: number;
   transaction: ITransaction;
 }
 
@@ -24,7 +25,7 @@ export interface IGroup {
   atomic: boolean;
   sequential: boolean;
   createdAt: string;
-  groupValidStart: Date;
+  groupValidStart: string;
   groupItems: IGroupItem[];
 }
 
@@ -67,7 +68,7 @@ export const getApiGroups = async (serverUrl: string) => {
 /* Get transaction groups */
 export const getApiGroupById = async (serverUrl: string, id: number) => {
   return commonRequestHandler(async () => {
-    const { data } = await axiosWithCredentials.get(`${serverUrl}/transaction-groups/${id}`, {
+    const { data } = await axiosWithCredentials.get<IGroup>(`${serverUrl}/transaction-groups/${id}`, {
       withCredentials: true,
     });
 


### PR DESCRIPTION
**Description**:
Changes below fixed some confusions about `IGroup` interface.

There are two definitions of `IGroup` interface:
1) `front-end/src/renderer/services/organization/transactionGroup.ts`
2) `front-end/src/shared/interfaces/organization/transactions/index.ts`

Several files uses definition 2 but they should in fact use 1.
Changes below fix that.
To enable this, definition 1 must be added one missing field: `groupValidStart`.

Note: it's probably feasible to merge those two definitions of `IGroup` ; this will be done later.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
