### PR TITLE
chore: bump version to 0.20.0 in package.json files

### DIFF
--- a/back-end/apps/api/package.json
+++ b/back-end/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/api",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/chain/package.json
+++ b/back-end/apps/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/chain",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/notifications/package.json
+++ b/back-end/apps/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/notifications",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "back-end",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "",
   "author": "",
   "private": true,

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-transaction-tool",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Transaction tool application",
   "author": {
     "name": "Hedera",


### PR DESCRIPTION
This pull request updates the project version from `0.19.0` to `0.20.0` across all major package manifests. No other changes are included.

Version bump:

* Updated the version field to `0.20.0` in `back-end/package.json`, `back-end/apps/api/package.json`, `back-end/apps/chain/package.json`, `back-end/apps/notifications/package.json`, and `front-end/package.json`. [[1]](diffhunk://#diff-d1c5d2322c31c65053bc0b5356afe6821cc44aa37a8733f5c0227e0f3c053e35L3-R3) [[2]](diffhunk://#diff-99b1c8b2f8265809468bda8592450aee836bcc51d4a1f2f2cd716e49c6fe58c3L3-R3) [[3]](diffhunk://#diff-2ad1bc17da00af17ba969215f351a7981db8c4920aa70ca37c8545607c59dfb6L3-R3) [[4]](diffhunk://#diff-df4fdc006a9461f8a8131afed679b1fb80743c91216998c32bf0b4679f675973L3-R3) [[5]](diffhunk://#diff-f573261b8354834cb5d2110af3a0e0e20157fa2fe40af594186b2a715a306ea0L3-R3)