### PR TITLE
feat: add conditional tooltip on hover in the transaction overview ta…

### DIFF
--- a/front-end/src/renderer/pages/Transactions/components/Drafts.vue
+++ b/front-end/src/renderer/pages/Transactions/components/Drafts.vue
@@ -216,6 +216,12 @@ async function fetchDrafts() {
   }
 }
 
+const getDraftDescription = (draft: TransactionDraft | TransactionGroup) => {
+  return (draft as TransactionDraft).type
+    ? (draft as TransactionDraft).description
+    : (draft as TransactionGroup).description;
+}
+
 /* Hooks */
 onBeforeMount(async () => {
   await fetchDrafts();
@@ -320,11 +326,13 @@ watch([currentPage, pageSize], async () => {
                     }}</span>
                 </td>
                 <td>
-                  <span class="text-wrap-two-line-ellipsis" :data-testid="'span-draft-tx-description-' + i">{{
-                      (draft as TransactionDraft).type
-                        ? (draft as TransactionDraft).description
-                        : (draft as TransactionGroup).description
-                    }}</span>
+                  <span
+                    class="text-wrap-two-line-ellipsis"
+                    :data-testid="'span-draft-tx-description-' + i"
+                    :title="getDraftDescription(draft)?.length > 120 ? getDraftDescription(draft) : ''"
+                  >
+                    {{getDraftDescription(draft)}}
+                  </span>
                 </td>
                 <td class="text-center">
                   <input

--- a/front-end/src/renderer/pages/Transactions/components/TransactionNodeRow.vue
+++ b/front-end/src/renderer/pages/Transactions/components/TransactionNodeRow.vue
@@ -146,7 +146,12 @@ const handleDetails = async () => {
 
     <!-- Column #3 : Description -->
     <td>
-      <span class="text-wrap-two-line-ellipsis">{{ props.node.description }}</span>
+      <span 
+        :title="props.node.description.length > 120 ? props.node.description : ''"
+        class="text-wrap-two-line-ellipsis"
+      >
+        {{ props.node.description }}
+      </span>
     </td>
 
     <template v-if="props.collection === TransactionNodeCollection.HISTORY">


### PR DESCRIPTION
Description:
Transaction overview table now display a minimal tool tip on hover, displaying the full content of the description field.
The tool tip conditionally shows depending on the text length in order to avoid unnecessary overlap.
