### PR TITLE
Fix: button gap in transaction table

### DIFF
--- a/front-end/src/renderer/pages/Transactions/components/SignGroupButton.vue
+++ b/front-end/src/renderer/pages/Transactions/components/SignGroupButton.vue
@@ -78,6 +78,7 @@ const handleSign = async (personalPassword: string|null) => {
 
 <template>
   <AppButton
+    v-bind="$attrs"
     :disabled="signOnGoing"
     :loading="signOnGoing"
     loading-text="Sign All"

--- a/front-end/src/renderer/pages/Transactions/components/TransactionNodeRow.vue
+++ b/front-end/src/renderer/pages/Transactions/components/TransactionNodeRow.vue
@@ -181,20 +181,18 @@ const handleDetails = async () => {
     <td class="text-center">
       <div class="d-flex justify-content-center gap-4">
         <template v-if="props.collection === TransactionNodeCollection.READY_TO_SIGN">
-          <div :data-testid="`button-transaction-node-sign-${index}`">
-            <SignSingleButton
-              v-if="props.node.transactionId"
-              :transactionId="props.node.transactionId"
-              @transactionSigned="(tid: number) => emit('transactionSigned', tid)"
-            />
-          </div>
-          <div :data-testid="`button-transaction-node-sign-${index}`">
-            <SignGroupButton
-              v-if="props.node.groupId"
-              :group-id="props.node.groupId"
-              @transactionGroupSigned="(gid: number) => emit('transactionGroupSigned', gid)"
-            />
-          </div>
+          <SignSingleButton
+            v-if="props.node.transactionId"
+            :data-testid="`button-transaction-node-sign-${index}`"
+            :transactionId="props.node.transactionId"
+            @transactionSigned="(tid: number) => emit('transactionSigned', tid)"
+          />
+          <SignGroupButton
+            v-if="props.node.groupId"
+            :data-testid="`button-transaction-node-sign-${index}`"
+            :group-id="props.node.groupId"
+            @transactionGroupSigned="(gid: number) => emit('transactionGroupSigned', gid)"
+          />
         </template>
         <AppButton
           :data-testid="`button-transaction-node-details-${index}`"


### PR DESCRIPTION
**Description**:

Recent change in TransactionNodeRow to silence execution warnings related to data-testid has broken the buttons gap.

