### PR TITLE
Input field "Amount" in transfer transaction formats hbars accordingly

### DIFF
--- a/front-end/src/renderer/components/ui/AppHbarInput.vue
+++ b/front-end/src/renderer/components/ui/AppHbarInput.vue
@@ -31,6 +31,11 @@ const handleUpdateValue = async (value: string) => {
     return;
   }
 
+  if (value.startsWith('.')) {
+    value = '0' + value;
+    setInputValue(value);
+  }
+
   const separatorIndex = value.search(/[.,]/);
 
   if (separatorIndex !== -1 && value.length - separatorIndex - 1 > 8) {


### PR DESCRIPTION
Description:
- leading '.' are now converted to zero + '.' (. -> 0.)
- preserved the logic for converting the dot into a zero despite having a validator for some edge test cases (user tries to apply '.' without typing anything else).
