### PR TITLE
chore: defined interface for TransactionBaseModel.computeSignatureKey() result

### DIFF
--- a/front-end/src/renderer/components/SignatureStatus.vue
+++ b/front-end/src/renderer/components/SignatureStatus.vue
@@ -1,30 +1,13 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
-import { Key } from '@hashgraph/sdk';
-
-import { ableToSign } from '@renderer/utils';
+import { ableToSign, type SignatureAudit } from '@renderer/utils';
 
 import SignatureStatusEntities from '@renderer/components/SignatureStatusEntities.vue';
 
 /* Props */
 const props = defineProps<{
-  signatureKeyObject: {
-    signatureKeys: Key[];
-    accountsKeys: {
-      [accountId: string]: Key;
-    };
-    receiverAccountsKeys: {
-      [accountId: string]: Key;
-    };
-    newKeys: Key[];
-    payerKey: {
-      [accountId: string]: Key;
-    };
-    nodeAdminKeys: {
-      [accountId: string]: Key;
-    };
-  };
+  signatureKeyObject: SignatureAudit;
   clean?: boolean;
   publicKeysSigned: string[];
 }>();

--- a/front-end/src/renderer/utils/transactionSignatureModels/index.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/index.ts
@@ -6,6 +6,7 @@ import TransactionFactory from './transaction-factory';
 import { flattenKeyList } from '../../services/keyPairService';
 import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
 import type { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
+import type { SignatureAudit } from './transaction.model';
 
 export * from './account-create-transaction.model';
 export * from './account-update-transaction.model';
@@ -27,7 +28,7 @@ export const computeSignatureKey = async (
   mirrorNodeLink: string,
   accountInfoCache: AccountByIdCache,
   nodeInfoCache: NodeByIdCache,
-) => {
+): Promise<SignatureAudit> => {
   const transactionModel = TransactionFactory.fromTransaction(transaction);
 
   return await transactionModel.computeSignatureKey(mirrorNodeLink, accountInfoCache, nodeInfoCache);

--- a/front-end/src/renderer/utils/transactionSignatureModels/transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/transaction.model.ts
@@ -5,6 +5,15 @@ import type { INodeInfoParsed } from '@shared/interfaces';
 import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
 import type { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
 
+export interface SignatureAudit {
+  signatureKeys: Key[];
+  accountsKeys: Record<string, Key>;
+  receiverAccountsKeys: Record<string, Key>;
+  newKeys: Key[];
+  payerKey: Record<string, Key>;
+  nodeAdminKeys: Record<number, Key>;
+}
+
 export abstract class TransactionBaseModel<T extends SDKTransaction> {
   constructor(protected transaction: T) {}
 
@@ -37,7 +46,11 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
     return null;
   }
 
-  async computeSignatureKey(mirrorNodeLink: string, accountInfoCache: AccountByIdCache, nodeInfoCache: NodeByIdCache) {
+  async computeSignatureKey(
+    mirrorNodeLink: string,
+    accountInfoCache: AccountByIdCache,
+    nodeInfoCache: NodeByIdCache,
+  ): Promise<SignatureAudit> {
     const feePayerAccountId = this.getFeePayerAccountId();
     const accounts = this.getSigningAccounts();
     const receiverAccounts = this.getReceiverAccounts();
@@ -88,7 +101,11 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
     for (const accountId of receiverAccounts) {
       try {
         const accountInfo = await accountInfoCache.lookup(accountId, mirrorNodeLink);
-        if (accountInfo?.receiverSignatureRequired && accountInfo?.key && !hasKey(accountInfo.key)) {
+        if (
+          accountInfo?.receiverSignatureRequired &&
+          accountInfo?.key &&
+          !hasKey(accountInfo.key)
+        ) {
           signatureKeys.push(accountInfo.key);
           receiverAccountsKeys[accountId] = accountInfo.key;
           currentKeyList.push(accountInfo.key);


### PR DESCRIPTION
**Description**:

Result of `TransactionBaseModel.computeSignatureKey()` now conforms to `SignatureAudit` interface.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
