### PR TITLE
chore: update frontend version to 0.22.0 in configuration files

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1655,7 +1655,7 @@ The Initial Developer of electron-to-chromium@1.5.88,
 is Kilian Valkhof (https://github.com/kilian/electron-to-chromium).
 Copyright Kilian Valkhof. All Rights Reserved.
 
-The Initial Developer of electron-updater@6.3.9,
+The Initial Developer of electron-updater@6.6.2,
 is Vladimir Krivosheev (https://github.com/electron-userland/electron-builder).
 Copyright Vladimir Krivosheev. All Rights Reserved.
 

--- a/back-end/apps/api/example.env
+++ b/back-end/apps/api/example.env
@@ -47,6 +47,6 @@ PGADMIN_DEFAULT_PASSWORD=pgadmin4
 NODE_ENV=development
 
 # Frontend version control (optional)
-LATEST_SUPPORTED_FRONTEND_VERSION=0.21.0
+LATEST_SUPPORTED_FRONTEND_VERSION=0.22.0
 MINIMUM_SUPPORTED_FRONTEND_VERSION=0.21.0
 FRONTEND_REPO_URL=https://github.com/hashgraph/hedera-transaction-tool/releases

--- a/back-end/apps/api/package.json
+++ b/back-end/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/api",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/chain/package.json
+++ b/back-end/apps/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/chain",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/notifications/package.json
+++ b/back-end/apps/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/notifications",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "back-end",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "",
   "author": "",
   "private": true,

--- a/back-end/typeorm/package.json
+++ b/back-end/typeorm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "private": true,
   "scripts": {
     "build": "tsc",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-transaction-tool",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Transaction tool application",
   "author": {
     "name": "Hedera",


### PR DESCRIPTION
**Description**:
This pull request updates the project to version 0.22.0 across all backend and frontend packages, and also updates the latest supported frontend version in the environment configuration. Additionally, it updates a library version reference in the `NOTICE` file.

Version updates:

* Bumped version numbers from `0.21.0` to `0.22.0` in the following `package.json` files: `back-end/package.json`, `back-end/apps/api/package.json`, `back-end/apps/chain/package.json`, `back-end/apps/notifications/package.json`, `back-end/typeorm/package.json`, and `front-end/package.json`. [[1]](diffhunk://#diff-d1c5d2322c31c65053bc0b5356afe6821cc44aa37a8733f5c0227e0f3c053e35L3-R3) [[2]](diffhunk://#diff-99b1c8b2f8265809468bda8592450aee836bcc51d4a1f2f2cd716e49c6fe58c3L3-R3) [[3]](diffhunk://#diff-2ad1bc17da00af17ba969215f351a7981db8c4920aa70ca37c8545607c59dfb6L3-R3) [[4]](diffhunk://#diff-df4fdc006a9461f8a8131afed679b1fb80743c91216998c32bf0b4679f675973L3-R3) [[5]](diffhunk://#diff-734f8b0d49eec4ad207e761f0eaefdbc8187c6ab63ee39c343b2661d5b065fbbL3-R3) [[6]](diffhunk://#diff-f573261b8354834cb5d2110af3a0e0e20157fa2fe40af594186b2a715a306ea0L3-R3)

Configuration updates:

* Updated `LATEST_SUPPORTED_FRONTEND_VERSION` from `0.21.0` to `0.22.0` in `back-end/apps/api/example.env` to match the new frontend release.

Legal and documentation updates:

* Updated the referenced version of `electron-updater` from `6.3.9` to `6.6.2` in the `NOTICE` file.