### PR TITLE
fix: fixed regression in TransactionsService.importSignature()

### DIFF
--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -530,7 +530,7 @@ export class TransactionsService {
         const params: any = {};
 
         batch.forEach((update, idx) => {
-          caseSQL += `WHEN :id${idx} THEN :bytes${idx} `;
+          caseSQL += `WHEN :id${idx} THEN :bytes${idx}::bytea `;
           params[`id${idx}`] = update.id;
           params[`bytes${idx}`] = update.transactionBytes;
         });


### PR DESCRIPTION
**Description**:

Changes below fix construction of TypeORM request in `TransactionsService.importSignature()`.
Without this change, postgresql rejects sql request and reports:

`ERROR:  column "transactionBytes" is of type bytea but expression is of type text at character 47`

It looks like a regression introduced in #2050. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
