### PR TITLE
fixed the select button text color issue in light/dark themes

### DIFF
--- a/front-end/src/renderer/pages/Transactions/components/History.vue
+++ b/front-end/src/renderer/pages/Transactions/components/History.vue
@@ -31,8 +31,7 @@ import {
   isLoggedInOrganization,
   isUserLoggedIn,
 } from '@renderer/utils';
-import { getDisplayTransactionType } from '@renderer/utils/sdk/transactions';
-import { getTransactionFromBytes } from '@renderer/utils/transactions';
+import * as sdkTransactionUtils from '@renderer/utils/sdk/transactions';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppLoader from '@renderer/components/ui/AppLoader.vue';
@@ -242,22 +241,6 @@ function setPreviousTransactionsIds(id: string | number) {
   }
 }
 
-/**
- * Gets the display transaction type for local transactions.
- * For freeze transactions, extracts the specific freeze type from the transaction body.
- */
-function getLocalTransactionDisplayType(transaction: Transaction): string {
-  if (transaction.type === 'FREEZE' && transaction.body) {
-    try {
-      const sdkTx = getTransactionFromBytes(transaction.body);
-      return getDisplayTransactionType(sdkTx, false, true);
-    } catch {
-      return transaction.type;
-    }
-  }
-  return transaction.type;
-}
-
 /* Hooks */
 onBeforeMount(async () => {
   setGetTransactionsFunction();
@@ -432,7 +415,7 @@ watch(
                     <TransactionId :transaction-id="transaction.transaction_id" wrap />
                   </td>
                   <td :data-testid="`td-transaction-type-${index}`">
-                    <span class="text-bold">{{ getLocalTransactionDisplayType(transaction) }}</span>
+                    <span class="text-bold">{{ transaction.type }}</span>
                   </td>
                   <td :data-testid="`td-transaction-description-${index}`">
                     <span class="text-wrap-two-line-ellipsis">{{ transaction.description }}</span>
@@ -480,7 +463,7 @@ watch(
                   </td>
                   <td :data-testid="`td-transaction-type-${index}`">
                     <span class="text-bold">{{
-                      getDisplayTransactionType(transactionData.transaction, false, true)
+                      sdkTransactionUtils.getTransactionType(transactionData.transaction, false, true)
                     }}</span>
                   </td>
                   <td :data-testid="`td-transaction-description-${index}`">

--- a/front-end/src/renderer/utils/sdk/transactions.ts
+++ b/front-end/src/renderer/utils/sdk/transactions.ts
@@ -19,8 +19,6 @@ import {
   TransferTransaction,
 } from '@hashgraph/sdk';
 import { TransactionTypeName } from '@shared/interfaces';
-import { getTransactionById } from '@renderer/services/organization';
-import { hexToUint8Array } from '@renderer/utils';
 
 export const getTransactionPayerId = (transaction: Transaction) =>
   transaction.transactionId?.accountId?.toString() || null;
@@ -123,80 +121,4 @@ export const getFreezeTypeString = (freezeType: FreezeType) => {
     default:
       return 'Unknown';
   }
-};
-
-/**
- * Gets the display transaction type, including specific freeze types.
- * For freeze transactions, returns the specific freeze type (e.g., "Freeze Upgrade").
- * For other transactions, returns the standard type.
- *
- * @param transaction - SDK Transaction instance or Uint8Array
- * @param short - Whether to use short format (no spaces)
- * @param removeTransaction - Whether to remove " Transaction" suffix
- * @returns Display string for transaction type
- */
-export const getDisplayTransactionType = (
-  transaction: Transaction | Uint8Array,
-  short = false,
-  removeTransaction = false,
-): string => {
-  // Deserialize if needed
-  let sdkTransaction = transaction;
-  if (transaction instanceof Uint8Array) {
-    try {
-      sdkTransaction = Transaction.fromBytes(transaction);
-    } catch (error) {
-      console.error('Failed to deserialize transaction:', error);
-      return formatTransactionType('Freeze Transaction', short, removeTransaction);
-    }
-  }
-
-  // Check if this is a freeze transaction
-  if (sdkTransaction instanceof FreezeTransaction) {
-    const freezeType = sdkTransaction.freezeType;
-    if (freezeType) {
-      const freezeTypeStr = getFreezeTypeString(freezeType);
-      return formatTransactionType(freezeTypeStr, short, removeTransaction);
-    }
-  }
-
-  // Fall back to standard transaction type
-  return getTransactionType(sdkTransaction, short, removeTransaction);
-};
-
-// Cache to avoid re-fetching freeze types
-const freezeTypeCache = new Map<number, number | null>();
-
-/**
- * Fetches the freeze type for a transaction from the backend.
- * Uses caching to avoid redundant API calls.
- *
- * @param serverUrl - The organization server URL
- * @param transactionId - The transaction ID
- * @returns The freeze type code (1-5) or null if not a freeze transaction or on error
- */
-export const getFreezeTypeForTransaction = async (
-  serverUrl: string,
-  transactionId: number,
-): Promise<number | null> => {
-  if (freezeTypeCache.has(transactionId)) {
-    return freezeTypeCache.get(transactionId)!;
-  }
-
-  try {
-    const txFull = await getTransactionById(serverUrl, transactionId);
-    const bytes = hexToUint8Array(txFull.transactionBytes);
-    const sdkTx = Transaction.fromBytes(bytes);
-
-    if (sdkTx instanceof FreezeTransaction && sdkTx.freezeType) {
-      const code = sdkTx.freezeType._code;
-      freezeTypeCache.set(transactionId, code);
-      return code;
-    }
-  } catch (error) {
-    console.error('Failed to fetch freeze type:', error);
-  }
-
-  freezeTypeCache.set(transactionId, null);
-  return null;
 };


### PR DESCRIPTION
## Fix Select button text color in dark theme

### Problem
The "Select" button in the Accounts and Files pages had poor contrast when selected. The button used a dark background (`bg-secondary` = `#333666`) but kept dark text (`text-dark-emphasis`), making the text unreadable.

### Solution
Made the text color conditional based on the selection state:
- **Unselected**: Dark text (`text-dark-emphasis`) on transparent background
- **Selected**: White text (`text-white`) on dark background (`bg-secondary`)

The icon retains the `text-headline` class for consistent sizing, and inherits the white color from the parent button when selected.

### Files Changed
- `front-end/src/renderer/pages/Accounts/Accounts.vue`
- `front-end/src/renderer/pages/Files/Files.vue`

### Before/After

## Before

<img width="333" height="204" alt="image" src="https://github.com/user-attachments/assets/a344a3cd-2610-4f7f-be4c-2388e446e258" />

## After

<img width="277" height="176" alt="image" src="https://github.com/user-attachments/assets/df790b38-10b2-4e1e-8101-63d24f395568" />

