### PR TITLE
fix: adjust websocket connection recovery settings and clean up code

### DIFF
--- a/back-end/apps/notifications/src/websocket/websocket.gateway.ts
+++ b/back-end/apps/notifications/src/websocket/websocket.gateway.ts
@@ -1,4 +1,5 @@
 import { Inject, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { ClientProxy } from '@nestjs/microservices';
 import {
   OnGatewayConnection,
@@ -19,12 +20,14 @@ import { AuthWebsocket, AuthWebsocketMiddleware } from './middlewares/auth-webso
 import { FrontendVersionWebsocketMiddleware } from './middlewares/frontend-version-websocket.middleware';
 import { roomKeys } from './helpers';
 import { DebouncedNotificationBatcher } from '../utils';
-import { ConfigService } from '@nestjs/config';
 
 @WebSocketGateway({
   path: '/ws',
   cors: { origin: true, methods: ['GET', 'POST'], credentials: true },
-  connectionStateRecovery: { maxDisconnectionDuration: 2 * 60 * 1000 },
+  connectionStateRecovery: {
+    maxDisconnectionDuration: 30 * 1000,
+    skipMiddlewares: false,
+  },
   transports: ['websocket', 'polling'],
 })
 export class WebsocketGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
@@ -80,11 +83,6 @@ export class WebsocketGateway implements OnGatewayInit, OnGatewayConnection, OnG
     const newMessage = new NotificationMessage(message, [content]);
     await this.batcher.add(newMessage);
   }
-
-  // async notifyClients(userId{ message, content }: NotifyClientDto) {
-  //   const newMessage = new NotificationMessage(message, [content]);
-  //   await this.batcher.add(newMessage);
-  // }
 
   async notifyUser(userId: number, message: string, data: any | any[]) {
     const content = Array.isArray(data) ? data : [data];


### PR DESCRIPTION
**Description**:
This pull request makes a few targeted updates to the WebSocket gateway in the notifications service. The main change is a reduction in the maximum disconnection duration for connection state recovery, along with additional configuration options for connection recovery.

WebSocket connection recovery configuration:

* Reduced the `maxDisconnectionDuration` for connection state recovery from 2 minutes to 30 seconds and explicitly set `skipMiddlewares` to `false` in the `@WebSocketGateway` decorator options.

Code cleanup:

* Removed commented-out legacy code for the `notifyClients` method in the `WebsocketGateway` class.

Dependency management:

* Moved the import of `ConfigService` to the top of the file for better organization.

**Related issue(s)**:

Fixes #2156 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
