### PR TITLE
Endpoint Input auto strips protocol

### DIFF
--- a/front-end/src/renderer/components/Transaction/Create/NodeCreate/NodeFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/NodeCreate/NodeFormData.vue
@@ -169,14 +169,32 @@ function handleInputValidation(e: Event) {
 }
 
 /* Functions */
+function stripProtocolAndPath(input: string): string {
+  let result = input.trim();
+
+  // Remove protocol prefix (http://, https://, grpc://, etc.)
+  result = result.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//, '');
+
+  // Remove path (everything after the first /)
+  // Preserve trailing dot for FQDN
+  const slashIndex = result.indexOf('/');
+  if (slashIndex !== -1) {
+    result = result.substring(0, slashIndex);
+  }
+
+  return result;
+}
+
 function getEndpointData(ipOrDomain: string, port: string) {
   let ip = '';
   let domain = '';
 
-  if (ipOrDomain.match(validIp)) {
-    ip = ipOrDomain;
+  const cleanedInput = stripProtocolAndPath(ipOrDomain);
+
+  if (cleanedInput.match(validIp)) {
+    ip = cleanedInput;
   } else {
-    domain = ipOrDomain;
+    domain = cleanedInput;
   }
 
   return {
@@ -192,7 +210,9 @@ function getGrpcWebProxyEndpoint(field: 'domainName' | 'port', value: string) {
     grpcWebProxyEndpoint: {
       ipAddressV4: '',
       domainName:
-        field === 'domainName' ? value : props.data.grpcWebProxyEndpoint?.domainName || '',
+        field === 'domainName'
+          ? stripProtocolAndPath(value)
+          : props.data.grpcWebProxyEndpoint?.domainName || '',
       port: field === 'port' ? value : props.data.grpcWebProxyEndpoint?.port || '',
     },
   });


### PR DESCRIPTION
**Problem**

When creating or updating a node, users may paste full URLs into the gossip, service, and gRPC web proxy endpoint fields. For example, a user might enter:

- http://my.domain.com
- https://my.domain.com/api/v1/
- my.domain.com/api/v1

These endpoint fields expect only a domain name or IP address, not a full URL with protocol or path. The previous implementation stored the input as-is, which would result in invalid endpoint configurations.

**Solution**

Added a `stripProtocolAndPath()` helper function in **NodeFormData.vue** that automatically sanitizes endpoint inputs by:

1. Removing protocol prefixes - Strips http://, https://, grpc://, and any other URI scheme prefixes
2. Removing URL paths - Strips everything after the first / (e.g., /api/v1/)
3. Preserving trailing dots - Keeps trailing . as it is valid in Fully Qualified Domain Names (FQDNs)

The helper is applied in two places:

`getEndpointData()` - Used when adding gossip and service endpoints
`getGrpcWebProxyEndpoint() `- Used when updating the gRPC web proxy domain

**Examples**

Input  | Expected result after adding
-- | --
http://my.domain.com | my.domain.com
https://my.domain.com/api/v1/ | my.domain.com
my.domain.com/api/v1 | my.domain.com
my.domain.com. | my.domain.com.
192.168.1.1 | 192.168.1.1

<br class="Apple-interchange-newline">

**Before**

<img width="441" height="363" alt="image" src="https://github.com/user-attachments/assets/434d3200-0a3c-4a33-95ef-33f521e7d9d6" />


**After**

<img width="475" height="480" alt="image" src="https://github.com/user-attachments/assets/77e88a0c-e9a1-4ccd-8df6-79d297dcda4e" />
