### PR TITLE
feat: add signer/signature counters to ITransactionNode

### DIFF
--- a/back-end/apps/api/src/transactions/dto/ITransactionNode.ts
+++ b/back-end/apps/api/src/transactions/dto/ITransactionNode.ts
@@ -1,3 +1,6 @@
+// WARNING : MUST BE KEPT IN SYNC WITH
+// shared/src/ITransactionNode.ts
+
 export interface ITransactionNode {   //   Single   Group
   transactionId?: number;             //      x
   groupId?: number;                   //              x
@@ -13,6 +16,11 @@ export interface ITransactionNode {   //   Single   Group
   isManual?: boolean;                 //      x
   groupItemCount?: number;            //              x
   groupCollectedCount?: number;       //              x
+  internalSignerCount: number;        //      x       x
+  internalSignatureCount: number;     //      x       x
+  externalSignerCount: number;        //      x       x
+  externalSignatureCount: number;     //      x       x
+  unexpectedSignatureCount: number;   //      x       x
 }
 
 export enum TransactionNodeCollection {
@@ -26,20 +34,25 @@ export enum TransactionNodeCollection {
 
 /*
 
-    ITransactionNode | Single Transaction | Transaction Group    |
-    ---------------- + ------------------ + -------------------- +
-    transactionId    | tx id              | undefined            |
-    groupId          | undefined          | group id             |
-    description      | tx description     | group description    |
-    createdAt        | tx created at      | group created at     |
-    validStart       | tx valid start     | min item valid start |
-    updatedAt        | tx updated at      | max item updated at  |
-    executedAt       | tx executed at     | max item executed at |
-    status           | tx status          | undefined            |
-    statusCode       | tx status code     | undefined            |
-    sdkTransactionId | hiero tx id        | undefined            |
-    transactionType  | tx type            | undefined            |
-    isManual         | tx is manual       | undefined            |
-    groupItemCount   | 0                  | group item count     |
+    ITransactionNode         | Single Transaction    | Transaction Group           |
+    ------------------------ + --------------------- + --------------------------- +
+    transactionId            | tx id                 | undefined                   |
+    groupId                  | undefined             | group id                    |
+    description              | tx description        | group description           |
+    createdAt                | tx created at         | group created at            |
+    validStart               | tx valid start        | min item valid start        |
+    updatedAt                | tx updated at         | max item updated at         |
+    executedAt               | tx executed at        | max item executed at        |
+    status                   | tx status             | undefined                   |
+    statusCode               | tx status code        | undefined                   |
+    sdkTransactionId         | hiero tx id           | undefined                   |
+    transactionType          | tx type               | undefined                   |
+    isManual                 | tx is manual          | undefined            |
+    groupItemCount           | 0                     | group item count            |
+    internalSignerCount      | int. signer count     | count(int. signer union)    |
+    externalSignerCount      | ext. signer count     | count(ext. signer union)    |
+    internalSignatureCount   | int. signature count  | count(ext. signature union) |
+    externalSignatureCount   | ext. signature. count | count(ext. signature union) |
+    unexpectedSignatureCount | unx. signature. count | count(unx. signature union) |
 
  */

--- a/back-end/apps/api/src/transactions/dto/transaction-node.dto.ts
+++ b/back-end/apps/api/src/transactions/dto/transaction-node.dto.ts
@@ -43,4 +43,19 @@ export class TransactionNodeDto implements ITransactionNode {
 
   @Expose()
   groupCollectedCount?: number;
+
+  @Expose()
+  internalSignerCount: number;
+
+  @Expose()
+  internalSignatureCount: number;
+
+  @Expose()
+  externalSignerCount: number;
+
+  @Expose()
+  externalSignatureCount: number;
+
+  @Expose()
+  unexpectedSignatureCount: number;
 }

--- a/back-end/apps/api/src/transactions/nodes/transaction-nodes.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/nodes/transaction-nodes.controller.spec.ts
@@ -77,6 +77,11 @@ describe('TransactionNodesController', () => {
       isManual: false,
       groupItemCount: undefined,
       groupCollectedCount: undefined,
+      internalSignerCount: 0,
+      internalSignatureCount: 0,
+      externalSignerCount: 0,
+      externalSignatureCount: 0,
+      unexpectedSignatureCount: 0
     };
   });
 

--- a/back-end/apps/api/src/transactions/nodes/transaction-nodes.service.ts
+++ b/back-end/apps/api/src/transactions/nodes/transaction-nodes.service.ts
@@ -1,11 +1,20 @@
 import { Injectable } from '@nestjs/common';
 import { Transaction, TransactionStatus, TransactionType, User } from '@entities';
-import { Filtering, Pagination } from '@app/common';
+import {
+  Filtering,
+  TransactionSignatureService,
+  Pagination,
+  produceSigningReport,
+  produceSigningReportForArray,
+} from '@app/common';
 import { TransactionNodeDto } from '../dto';
 import { TransactionNodeCollection } from '../dto/ITransactionNode';
 import { TransactionsService } from '../transactions.service';
 import { TransactionGroupsService } from '../groups';
 import { compareTransactionNodes } from './transaction-nodes.util';
+import { Transaction as SDKTransaction } from '@hashgraph/sdk/lib/exports';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
 
 const PAGINATION_ALL: Pagination = {
   page: 0,
@@ -19,6 +28,8 @@ export class TransactionNodesService {
   constructor(
     private readonly transactionsService: TransactionsService,
     private readonly transactionGroupsService: TransactionGroupsService,
+    private readonly transactionSignatureService: TransactionSignatureService,
+    @InjectDataSource() private dataSource: DataSource,
   ) {}
 
   async getTransactionNodes(
@@ -116,6 +127,11 @@ export class TransactionNodesService {
       if (groupId === -1) {
         // transactions contains the single transactions
         for (const t of transactions) {
+          const signingReport = await produceSigningReport(
+            t,
+            this.transactionSignatureService,
+            this.dataSource.manager,
+          );
           const node = new TransactionNodeDto();
           node.transactionId = t.id;
           node.groupId = undefined;
@@ -131,10 +147,20 @@ export class TransactionNodesService {
           node.isManual = t.isManual;
           node.groupItemCount = undefined;
           node.groupCollectedCount = undefined;
+          node.internalSignerCount = signingReport.internalSigners.size;
+          node.externalSignerCount = signingReport.externalSigners.size;
+          node.internalSignatureCount = signingReport.internalSignatures.size;
+          node.externalSignatureCount = signingReport.externalSignatures.size;
+          node.unexpectedSignatureCount = signingReport.unexpectedSignatures.size;
           result.push(node);
         }
       } else {
         const group = await this.transactionGroupsService.getTransactionGroup(user, groupId);
+        const signingReport = await produceSigningReportForArray(
+          transactions,
+          this.transactionSignatureService,
+          this.dataSource.manager,
+        );
         const node = new TransactionNodeDto();
         node.transactionId = undefined;
         node.groupId = groupId;
@@ -150,6 +176,11 @@ export class TransactionNodesService {
         node.isManual = undefined;
         node.groupItemCount = group.groupItems.length;
         node.groupCollectedCount = transactions.length;
+        node.internalSignerCount = signingReport.internalSigners.size;
+        node.externalSignerCount = signingReport.externalSigners.size;
+        node.internalSignatureCount = signingReport.internalSignatures.size;
+        node.externalSignatureCount = signingReport.externalSignatures.size;
+        node.unexpectedSignatureCount = signingReport.unexpectedSignatures.size;
         result.push(node);
       }
     }

--- a/back-end/apps/api/src/transactions/nodes/transaction-nodes.util.spec.ts
+++ b/back-end/apps/api/src/transactions/nodes/transaction-nodes.util.spec.ts
@@ -19,6 +19,11 @@ const singleNode1: ITransactionNode = {
   isManual: false,
   groupItemCount: undefined,
   groupCollectedCount: undefined,
+  internalSignerCount: 0,
+  internalSignatureCount: 0,
+  externalSignerCount: 0,
+  externalSignatureCount: 0,
+  unexpectedSignatureCount: 0,
 };
 
 const singleNodeDate2 = 1000;
@@ -38,6 +43,11 @@ const singleNode2: ITransactionNode = {
   isManual: false,
   groupItemCount: undefined,
   groupCollectedCount: undefined,
+  internalSignerCount: 0,
+  internalSignatureCount: 0,
+  externalSignerCount: 0,
+  externalSignatureCount: 0,
+  unexpectedSignatureCount: 0,
 };
 
 const groupNodeDate1 = 2000;
@@ -57,6 +67,11 @@ const groupNode1: ITransactionNode = {
   isManual: undefined,
   groupItemCount: 42,
   groupCollectedCount: 21,
+  internalSignerCount: 0,
+  internalSignatureCount: 0,
+  externalSignerCount: 0,
+  externalSignatureCount: 0,
+  unexpectedSignatureCount: 0,
 };
 
 const groupNodeDate2 = 3000;
@@ -76,6 +91,11 @@ const groupNode2: ITransactionNode = {
   isManual: undefined,
   groupItemCount: 21,
   groupCollectedCount: 10,
+  internalSignerCount: 0,
+  internalSignatureCount: 0,
+  externalSignerCount: 0,
+  externalSignatureCount: 0,
+  unexpectedSignatureCount: 0,
 };
 
 const malformedNodeDate2 = 3000;
@@ -97,7 +117,12 @@ const malformedNode: ITransactionNode = {
   isManual: undefined,
   groupItemCount: 21,
   groupCollectedCount: 10,
-}
+  internalSignerCount: 0,
+  internalSignatureCount: 0,
+  externalSignerCount: 0,
+  externalSignatureCount: 0,
+  unexpectedSignatureCount: 0,
+};
 
 describe('Transaction Node Utils', () => {
   it('compareTransactionNodes()', () => {

--- a/back-end/apps/api/src/transactions/transactions.controller.ts
+++ b/back-end/apps/api/src/transactions/transactions.controller.ts
@@ -178,6 +178,7 @@ export class TransactionsController {
   }
 
   /* Returns whether a user should sign a transaction with id */
+  /* NO LONGER USED BY FRONT-END */
   @ApiOperation({
     summary: 'Check if the current user should sign the transaction with the provided id',
     description: 'Check if the current user should sign the transaction with the provided id.',

--- a/shared/src/ITransactionNode.ts
+++ b/shared/src/ITransactionNode.ts
@@ -1,3 +1,6 @@
+// WARNING : MUST BE KEPT IN SYNC WITH
+// back-end/apps/api/src/transactions/dto/ITransactionNode.ts
+
 export interface ITransactionNode {   //   Single   Group
   transactionId?: number;             //      x
   groupId?: number;                   //              x
@@ -13,6 +16,11 @@ export interface ITransactionNode {   //   Single   Group
   isManual?: boolean;                 //      x
   groupItemCount?: number;            //              x
   groupCollectedCount?: number;       //              x
+  internalSignerCount: number;        //      x       x
+  internalSignatureCount: number;     //      x       x
+  externalSignerCount: number;        //      x       x
+  externalSignatureCount: number;     //      x       x
+  unexpectedSignatureCount: number;   //      x       x
 }
 
 export enum TransactionNodeCollection {
@@ -41,5 +49,6 @@ export enum TransactionNodeCollection {
     transactionType  | tx type            | undefined            |
     isManual         | tx is manual       | undefined            |
     groupItemCount   | 0                  | group item count     |
+    externalSignCount| tx ext. sign. count| sum of item ext. sign. Count|
 
  */


### PR DESCRIPTION
**Description**:

Changes below extend `GET /transaction-nodes` to return five new counters in each `ITransactionNode`:
- `internalSignerCount`
- `internalSignatureCount`
- `externalSignerCount`
- `externalSignatureCount`
- `unexpectedSignatureCount`


**Notes for reviewer**:
```
M       back-end/apps/api/src/transactions/dto/ITransactionNode.ts
M       shared/src/ITransactionNode.ts
        # Added the following counters to ITransactionNode interface:
        #   - internalSignerCount
        #   - internalSignatureCount
        #   - externalSignerCount
        #   - externalSignatureCount
        #   - unexpectedSignatureCount

M       back-end/apps/api/src/transactions/dto/transaction-node.dto.ts
M       back-end/apps/api/src/transactions/nodes/transaction-nodes.service.ts
M       back-end/libs/common/src/utils/transaction/index.ts
        # Updated GET /transaction-nodes to compute and return new counters

M       back-end/apps/api/src/transactions/nodes/transaction-nodes.controller.spec.ts
M       back-end/apps/api/src/transactions/nodes/transaction-nodes.service.spec.ts
M       back-end/apps/api/src/transactions/nodes/transaction-nodes.util.spec.ts
        # Aligned tests to new transaction-nodes capabilities

M       back-end/apps/api/src/transactions/transactions.controller.ts
        # Added comments
```
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
