### PR TITLE
Fixing Flickering Buttons

### DIFF
--- a/front-end/src/renderer/components/ui/AppDropDown.vue
+++ b/front-end/src/renderer/components/ui/AppDropDown.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
   colorOnActive?: boolean;
   buttonClass?: string;
   compact?: boolean;
+  disabled?: boolean;
 }>();
 
 /* Emits */
@@ -71,6 +72,7 @@ watch(
       data-bs-popper-config='{"strategy":"fixed"}'
       :data-testid="dataTestid"
       :class="[active ? null : 'text-body', compact ? 'min-w-unset px-4' : '', buttonClass]"
+      :disabled="disabled"
     >
       <template v-if="compact">
         <i class="bi bi-three-dots-vertical"></i>

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -146,7 +146,7 @@ const confirmModalButtonText = ref('');
 const confirmModalLoadingText = ref('');
 const confirmCallback = ref<((...args: any[]) => void) | null>(null);
 
-const fullyLoaded = ref(false);
+const isRefreshing = ref(false);
 const loadingStates = reactive<{ [key: string]: string | null }>({
   [reject]: null,
   [approve]: null,
@@ -225,8 +225,6 @@ const canArchive = computed(() => {
 
 const visibleButtons = computed(() => {
   const buttons: ActionButton[] = [];
-
-  if (!fullyLoaded.value) return buttons;
 
   /* The order is important REJECT, APPROVE, SIGN, SUBMIT, PREVIOUS, NEXT, CANCEL, ARCHIVE, EXPORT */
   shouldApprove.value && buttons.push(reject, approve);
@@ -616,9 +614,6 @@ const updateTransactionVersionMismatch = (): void => {
 /* Hooks */
 onMounted(() => {
   updateTransactionVersionMismatch();
-  if (!isLoggedInOrganization(user.selectedOrganization)) {
-    fullyLoaded.value = true;
-  }
 });
 
 /* Watchers */
@@ -627,11 +622,12 @@ watch(
   async transaction => {
     assertIsLoggedInOrganization(user.selectedOrganization);
 
-    fullyLoaded.value = false;
+    isRefreshing.value = true;
 
     if (!transaction) {
       publicKeysRequiredToSign.value = null;
       shouldApprove.value = false;
+      isRefreshing.value = false;
       return;
     }
 
@@ -650,7 +646,7 @@ watch(
     results[0].status === 'fulfilled' && (publicKeysRequiredToSign.value = results[0].value);
     results[1].status === 'fulfilled' && (shouldApprove.value = results[1].value);
 
-    fullyLoaded.value = true;
+    isRefreshing.value = false;
 
     results.forEach(
       r =>
@@ -701,6 +697,7 @@ watch(
           <div>
             <AppButton
               :color="primaryButtons.includes(visibleButtons[0]) ? 'primary' : 'secondary'"
+              :disabled="isRefreshing || Boolean(loadingStates[visibleButtons[0]])"
               :loading="Boolean(loadingStates[visibleButtons[0]])"
               :loading-text="loadingStates[visibleButtons[0]] || ''"
               :data-testid="buttonsDataTestIds[visibleButtons[0]]"
@@ -716,6 +713,7 @@ watch(
           <div class="d-none d-lg-block">
             <AppButton
               :color="primaryButtons.includes(visibleButtons[1]) ? 'primary' : 'secondary'"
+              :disabled="isRefreshing || Boolean(loadingStates[visibleButtons[1]])"
               :loading="Boolean(loadingStates[visibleButtons[1]])"
               :loading-text="loadingStates[visibleButtons[1]] || ''"
               :data-testid="buttonsDataTestIds[visibleButtons[1]]"
@@ -733,6 +731,7 @@ watch(
               class="d-lg-none"
               :color="'secondary'"
               :items="dropDownItems"
+              :disabled="isRefreshing"
               compact
               @select="handleDropDownItem($event as ActionButton)"
               data-testid="button-more-dropdown-sm"
@@ -741,6 +740,7 @@ watch(
               class="d-none d-lg-block"
               :color="'secondary'"
               :items="dropDownItems.slice(1)"
+              :disabled="isRefreshing"
               compact
               @select="handleDropDownItem($event as ActionButton)"
               data-testid="button-more-dropdown-lg"
@@ -751,6 +751,7 @@ watch(
           <div class="d-lg-none">
             <AppButton
               :color="primaryButtons.includes(visibleButtons[1]) ? 'primary' : 'secondary'"
+              :disabled="isRefreshing || Boolean(loadingStates[visibleButtons[1]])"
               :loading="Boolean(loadingStates[visibleButtons[1]])"
               :loading-text="loadingStates[visibleButtons[1]] || ''"
               :data-testid="buttonsDataTestIds[visibleButtons[1]]"


### PR DESCRIPTION
**Problem**
When a user signs a transaction and it moves from one status to another, the action buttons (Sign, Cancel, etc.) in the top-right corner of the Transaction Details page flicker - they appear, disappear, and reappear inconsistently. This happens during status transitions like "Waiting for Signatures" → "Awaiting Execution".

The button flickering is caused by the fullyLoaded flag being reset to false every time the transaction data changes.

1. When you click "Sign", after signing completes, fetchTransaction() is called
2. This updates the organizationTransaction prop
3. A watcher in TransactionDetailsHeader.vue detects this change and immediately sets fullyLoaded = false
4. The visibleButtons computed property checks: if (!fullyLoaded.value) return []; - returning an empty array
5. All buttons disappear
6. The watcher then runs async operations (mirror node API call + backend API call)
7. When those complete, fullyLoaded = true is set
8. Buttons reappear

**Solution**
Buttons change from enabled/disabled state instead of being shown/hidden. 
