### PR TITLE
Add expiring soon status

### DIFF
--- a/front-end/src/renderer/pages/TransactionDetails/components/ExpiringBadge.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/ExpiringBadge.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { computed, ref, onMounted, onUnmounted } from 'vue';
+
+import { TransactionStatus } from '@shared/interfaces';
+
+/* Constants */
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+const ONE_MINUTE_MS = 60 * 1000;
+
+/* Props */
+const props = withDefaults(
+  defineProps<{
+    validStart: Date | null;
+    transactionStatus: TransactionStatus | null;
+    /**
+     * Badge variant:
+     * - 'simple': Shows "Expiring soon" text
+     * - 'countdown': Shows "Expires in HH:MM" with live countdown
+     *
+     * To switch variants, change this prop value.
+     * To remove the feature entirely, delete this component and its usage.
+     */
+    variant?: 'simple' | 'countdown';
+  }>(),
+  {
+    variant: 'simple',
+  },
+);
+
+/* State */
+const now = ref(Date.now());
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+/* Computed */
+const inProgressStatuses = [
+  TransactionStatus.NEW,
+  TransactionStatus.WAITING_FOR_SIGNATURES,
+  TransactionStatus.WAITING_FOR_EXECUTION,
+];
+
+const timeUntilExpiry = computed(() => {
+  if (!props.validStart) return null;
+  return props.validStart.getTime() - now.value;
+});
+
+const shouldShowBadge = computed(() => {
+  if (!props.validStart) return false;
+  if (!props.transactionStatus || !inProgressStatuses.includes(props.transactionStatus)) {
+    return false;
+  }
+  const remaining = timeUntilExpiry.value;
+  return remaining !== null && remaining > 0 && remaining <= TWENTY_FOUR_HOURS_MS;
+});
+
+const countdownText = computed(() => {
+  if (!timeUntilExpiry.value || timeUntilExpiry.value <= 0) return '';
+
+  const totalMinutes = Math.floor(timeUntilExpiry.value / ONE_MINUTE_MS);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  return `Expires in ${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+});
+
+/* Lifecycle - Only start interval for countdown variant */
+onMounted(() => {
+  if (props.variant === 'countdown') {
+    intervalId = setInterval(() => {
+      now.value = Date.now();
+    }, ONE_MINUTE_MS);
+  }
+});
+
+onUnmounted(() => {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+});
+</script>
+
+<template>
+  <span v-if="shouldShowBadge" class="badge bg-danger text-break ms-2">
+    <!-- VARIANT: Simple text badge -->
+    <template v-if="variant === 'simple'">Expiring soon</template>
+
+    <!-- VARIANT: Countdown badge -->
+    <template v-else-if="variant === 'countdown'">{{ countdownText }}</template>
+  </span>
+</template>

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -50,8 +50,11 @@ import {
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppConfirmModal from '@renderer/components/ui/AppConfirmModal.vue';
 import AppDropDown from '@renderer/components/ui/AppDropDown.vue';
+import ExpiringBadge from './ExpiringBadge.vue';
 
 import { TransactionStatus } from '@shared/interfaces';
+
+import { getTransactionValidStart } from '@renderer/utils/sdk/transactions';
 import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
 import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
 import { errorToastOptions, successToastOptions } from '@renderer/utils/toastOptions.ts';
@@ -254,6 +257,10 @@ const isTransactionFailed = computed(() => {
 
 const isManualFlagVisible = computed(() => {
   return props.organizationTransaction?.isManual && transactionIsInProgress.value;
+});
+
+const validStartDate = computed(() => {
+  return props.sdkTransaction ? getTransactionValidStart(props.sdkTransaction) : null;
 });
 
 /* Handlers */
@@ -690,6 +697,13 @@ watch(
           Transaction Version Mismatch
         </span>
         <span v-else-if="isManualFlagVisible" class="badge bg-info text-break ms-2">Manual</span>
+        <!-- Expiring Soon Badge -->
+        <ExpiringBadge
+          :valid-start="validStartDate"
+          :transaction-status="props.organizationTransaction?.status ?? null"
+          variant="simple"
+        />
+        <!-- To use countdown variant: change variant="simple" to variant="countdown" -->
       </h2>
     </div>
 


### PR DESCRIPTION
**Problem**
A red "Expiring soon" badge has to appear when there is less than a day (< 24 Hours) from when a transaction is due.

**Solution**
Created a component that is shown when there are less than 24 hours from when the transaction is due:
```
<ExpiringBadge
   :valid-start="validStartDate"
   :transaction-status="props.organizationTransaction?.status ?? null"
   variant="simple"
/>
<!-- To use countdown variant: change variant="simple" to variant="countdown" -->
```
---

**Simple Variant** 

<img width="1097" height="327" alt="image" src="https://github.com/user-attachments/assets/9b51318b-be75-4c6f-b91e-1c188ad08ad8" />

---

**Countdown Variant** that shows remaining time in HH:MM format

<img width="1094" height="292" alt="image" src="https://github.com/user-attachments/assets/88f123ba-69eb-4fa3-a764-f573a2c0c50e" />
