### PR TITLE
chore: added interface definition to storeNetwork.ts

### DIFF
--- a/front-end/src/renderer/stores/storeNetwork.ts
+++ b/front-end/src/renderer/stores/storeNetwork.ts
@@ -2,7 +2,7 @@
 
 import type { Network, NetworkExchangeRateSetResponse } from '@shared/interfaces';
 
-import { computed, ref } from 'vue';
+import { computed, ref, type ComputedRef, type Ref } from 'vue';
 import { defineStore } from 'pinia';
 
 import { Client } from '@hashgraph/sdk';
@@ -14,7 +14,19 @@ import { setClient } from '@renderer/services/transactionService';
 
 import { getClientFromMirrorNode, getNodeNumbersFromNetwork } from '@renderer/utils';
 
-const useNetworkStore = defineStore('network', () => {
+export interface NetworkStore {
+  network: Ref<string>;
+  exchangeRateSet: Ref<NetworkExchangeRateSetResponse | null>;
+  mirrorNodeBaseURL: Ref<string>;
+  client: Ref<Client>;
+  currentRate: ComputedRef<number | null>;
+  nodeNumbers: Ref<number[]>;
+  setup: (defaultNetwork?: Network) => Promise<void>;
+  setNetwork: (newNetwork: Network) => Promise<void>;
+  getMirrorNodeREST: (network: Network) => string;
+}
+
+const useNetworkStore = defineStore('network', (): NetworkStore => {
   /* State */
   const network = ref<Network>(CommonNetwork.MAINNET);
   const mirrorNodeBaseURL = ref(getMirrorNodeREST(network.value));
@@ -100,7 +112,7 @@ const useNetworkStore = defineStore('network', () => {
     network,
     exchangeRateSet,
     mirrorNodeBaseURL,
-    client,
+    client: client as Ref<Client>,
     currentRate,
     nodeNumbers,
     setup,


### PR DESCRIPTION
**Description**:
Changes below add an interface definition to `storeNetwork`.

Sometimes IntelliJ reports type inference warning when editing `storeNetwork.ts` (see below).
And, in some very rare cases, this is reported by typescript compiler itself and breaks build.
Root cause is unclear : may be a bug in typescript compiler (?).
Adding an `interface` fixes the issue and also brings clarity.

<img width="2356" height="1174" alt="image" src="https://github.com/user-attachments/assets/2976da6e-0a39-4041-9401-23aaa7025083" />


**Notes for reviewer**:
No semantic changes.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
