### PR TITLE
chore: inlining createPersonalUser() and setupSafeNetwork() in storeUser.ts

### DIFF
--- a/front-end/src/renderer/stores/storeUser.ts
+++ b/front-end/src/renderer/stores/storeUser.ts
@@ -13,9 +13,9 @@ import { defineStore } from 'pinia';
 
 import { Prisma } from '@prisma/client';
 
-import { ACCOUNT_SETUP_STARTED } from '@shared/constants';
+import { ACCOUNT_SETUP_STARTED, SELECTED_NETWORK } from '@shared/constants';
 
-import { add, remove } from '@renderer/services/claimService';
+import { add, getStoredClaim, remove } from '@renderer/services/claimService';
 
 import useAfterOrganizationSelection from '@renderer/composables/user/useAfterOrganizationSelection';
 import useVersionCheck from '@renderer/composables/useVersionCheck';
@@ -76,13 +76,22 @@ const useUserStore = defineStore('user', () => {
   /* Actions */
   /** Personal */
   const login = async (id: string, email: string, useKeychain: boolean) => {
-    personal.value = ush.createPersonalUser(id, email, useKeychain);
-    await ush.setupSafeNetwork(id, network.setup);
+    personal.value = {
+      isLoggedIn: true,
+      id,
+      email,
+      password: null,
+      useKeychain: useKeychain,
+    };
+    const { data } = await safeAwait(getStoredClaim(id, SELECTED_NETWORK));
+    await safeAwait(network.setup(data));
     await selectOrganization(null);
   };
 
   const logout = () => {
-    personal.value = ush.createPersonalUser();
+    personal.value = {
+      isLoggedIn: false,
+    };
     selectedOrganization.value = null;
     organizations.value = [];
     publicKeyToAccounts.value = [];

--- a/front-end/src/renderer/utils/userStoreHelpers.ts
+++ b/front-end/src/renderer/utils/userStoreHelpers.ts
@@ -18,7 +18,7 @@ import type {
 import { Prisma } from '@prisma/client';
 import { Mnemonic } from '@hashgraph/sdk';
 
-import { SELECTED_NETWORK, SESSION_STORAGE_AUTH_TOKEN_PREFIX } from '@shared/constants';
+import { SESSION_STORAGE_AUTH_TOKEN_PREFIX } from '@shared/constants';
 
 import {
   getUserState,
@@ -42,7 +42,6 @@ import {
   compareHash,
   compareDataToHashes,
 } from '@renderer/services/electronUtilsService';
-import { getStoredClaim } from '@renderer/services/claimService';
 import { get as getStoredMnemonics } from '@renderer/services/mnemonicService';
 
 import { safeAwait } from './safeAwait';
@@ -153,21 +152,6 @@ export const accountSetupRequiredParts = (
 };
 
 /* Entity creation */
-export const createPersonalUser = (
-  id?: string,
-  email?: string,
-  useKeychain?: boolean,
-): PersonalUser =>
-  id && email
-    ? {
-        isLoggedIn: true,
-        id,
-        email,
-        password: null,
-        useKeychain: useKeychain || false,
-      }
-    : { isLoggedIn: false };
-
 export const createRecoveryPhrase = async (words: string[]): Promise<RecoveryPhrase> => {
   try {
     const mnemonic = await Mnemonic.fromWords(words);
@@ -257,14 +241,6 @@ export const getPublicKeyToAccounts = async (
   }
 
   return [...publicKeyToAccounts];
-};
-
-export const setupSafeNetwork = async (
-  userId: string,
-  setNetwork: (network: string | undefined) => Promise<void>,
-) => {
-  const { data } = await safeAwait(getStoredClaim(userId, SELECTED_NETWORK));
-  await safeAwait(setNetwork(data));
 };
 
 export const getMnemonics = async (user: PersonalUser | null) => {


### PR DESCRIPTION
**Description**:

Changes below inline logic from `createPersonalUser()` and `setupSafeNetwork()` into `storeUser.ts`.
Those two methods are used by `storeUser` only and pretty thin => inlining improves readability.

**Notes for reviewer**:

No semantic change

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
