### PR TITLE
fix: title of TransactionGroupDetails with only 1 transaction.

### DIFF
--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -678,14 +678,14 @@ function itemStatusBadgeClass(item: IGroupItem): string {
           </AppButton>
           <NextTransactionCursor />
 
-          <Transition mode="out-in" name="fade">
-            <template v-if="pageTitle">
-              <h2 class="text-title text-bold flex-1 text-one-line-ellipsis">
-                {{ pageTitle }}
-              </h2>
-            </template>
-          </Transition>
-        </div>
+            <Transition mode="out-in" name="fade">
+              <template v-if="pageTitle">
+                <h2 class="text-title text-bold flex-1 text-one-line-ellipsis">
+                  {{ pageTitle }}
+                </h2>
+              </template>
+            </Transition>
+          </div>
 
         <div class="flex-centered gap-4">
           <Transition name="fade" mode="out-in">


### PR DESCRIPTION
**Description**:

- Trivial fix for the TransactionGroupDetails page title when the group contains 1 transaction
- (Also 1 isolated reformatting)

**Notes for reviewer**:

Without fix:
<img width="808" height="118" alt="Screenshot 2026-02-09 at 11 02 02" src="https://github.com/user-attachments/assets/6f8bc3fa-af81-4ef6-98b2-bad65ccde766" />

With fix:
<img width="808" height="118" alt="Screenshot 2026-02-09 at 11 02 25" src="https://github.com/user-attachments/assets/8d46b6f4-290c-4443-9ca5-9b7d0e33bf98" />

