### PR TITLE
Added missing await in mainWindow.createWindow().

### DIFF
--- a/front-end/src/main/windows/mainWindow.ts
+++ b/front-end/src/main/windows/mainWindow.ts
@@ -56,10 +56,10 @@ async function createWindow() {
   });
 
   if (process.env.VITE_DEV_SERVER_URL) {
-    mainWindow.loadURL(process.env.VITE_DEV_SERVER_URL);
+    await mainWindow.loadURL(process.env.VITE_DEV_SERVER_URL);
     mainWindow.webContents.openDevTools();
   } else {
-    mainWindow.loadFile(join(process.env.DIST, 'index.html'));
+    await mainWindow.loadFile(join(process.env.DIST, 'index.html'));
   }
 
   return mainWindow;


### PR DESCRIPTION
**Description**:
Changes below add two missing await in `mainWindow.ts`:
1) `await` in line 59 avoid buggy behavior described in #2266 
2) `await` in line 62 is for sanity (and avoid potential issues in production / CI mode)

**Related issue(s)**:

Fixes #2266 

**Notes for reviewer**:
See #2266 for reproducing the issue.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
