### PR TITLE
Hide "external" badge from non admin users

### DIFF
--- a/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
@@ -97,10 +97,7 @@ const creator = computed(() => {
 });
 
 const showExternal = computed(() => {
-  // External badges are displayed for the transaction creator only
-  return isLoggedInOrganization(user.selectedOrganization) ?
-    user.selectedOrganization?.userId === orgTransaction.value?.creatorId :
-    false;
+  return isLoggedInOrganization(user.selectedOrganization) && user.selectedOrganization.admin;
 });
 
 /* Functions */

--- a/front-end/src/renderer/pages/Transactions/components/TransactionNodeRow.vue
+++ b/front-end/src/renderer/pages/Transactions/components/TransactionNodeRow.vue
@@ -14,7 +14,8 @@ import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import SignSingleButton from '@renderer/pages/Transactions/components/SignSingleButton.vue';
 import SignGroupButton from '@renderer/pages/Transactions/components/SignGroupButton.vue';
-import { getStatusFromCode } from '@renderer/utils';
+import { getStatusFromCode, isLoggedInOrganization } from '@renderer/utils';
+import useUserStore from '@renderer/stores/storeUser.ts';
 import {
   type ITransactionNode,
   TransactionNodeCollection,
@@ -39,6 +40,7 @@ const emit = defineEmits<{
 }>();
 
 /* Stores */
+const user = useUserStore();
 const notifications = useNotificationsStore();
 
 /* State */
@@ -231,11 +233,15 @@ watch(() => props.node.description, () => {
   nextTick(() => checkTruncation());
 });
 
-// Fetch external status for the transaction
+// Fetch external status for the transaction (admin only)
 watch(
   () => props.node.transactionId,
   async transactionId => {
-    if (!transactionId) {
+    if (
+      !transactionId ||
+      !isLoggedInOrganization(user.selectedOrganization) ||
+      !user.selectedOrganization.admin
+    ) {
       isExternal.value = false;
       return;
     }


### PR DESCRIPTION
Fixes #2262

**Problem**                                                                                
  Non-admin users see an "External" badge on transactions in both the transaction list and the transaction  
  details page. This badge indicates that a transaction requires signatures from keys not belonging to any
  user in the organization.                                                                                 
                                                
  This information is only actionable for admin users — non-admin users cannot manage organization          
  membership or keys, so the badge creates confusion without providing any value.                           

  The badge was previously shown to the transaction creator, but the correct audience is admin users only.

  Affected locations:

  - Transaction list — the "External" badge next to the transaction type column
  - Transaction details — the "External" badge next to individual public keys in the signature status
  section

  **Solution**
  Gate the "External" badge behind an admin check in both locations.

  `TransactionDetails.vue`

  Updated the showExternal computed property to check user.selectedOrganization.admin instead of comparing
  the current user's ID to the transaction creator's ID.
```
  // Before
  const showExternal = computed(() => {
    return isLoggedInOrganization(user.selectedOrganization)
      ? user.selectedOrganization?.userId === orgTransaction.value?.creatorId
      : false;
  });

  // After
  const showExternal = computed(() => {
    return isLoggedInOrganization(user.selectedOrganization) && user.selectedOrganization.admin;
  });
```
---
  `TransactionNodeRow.vue`

  Added useUserStore and isLoggedInOrganization imports, and updated the watcher that computes isExternal to
   short-circuit to false when the user is not an admin.
```
  // Before
  watch(
    () => props.node.transactionId,
    async transactionId => {
      if (!transactionId) {
        isExternal.value = false;
        return;
      }

      const externalSignerKeys = await transactionAudit.externalSignerKeys.value;
      isExternal.value = externalSignerKeys.size > 0;
    },
    { immediate: true },
  );

  // After
  watch(
    () => props.node.transactionId,
    async transactionId => {
      if (
        !transactionId ||
        !isLoggedInOrganization(user.selectedOrganization) ||
        !user.selectedOrganization.admin
      ) {
        isExternal.value = false;
        return;
      }

      const externalSignerKeys = await transactionAudit.externalSignerKeys.value;
      isExternal.value = externalSignerKeys.size > 0;
    },
    { immediate: true },
  );
```
---
Non admin users now see:
<img width="967" height="248" alt="image" src="https://github.com/user-attachments/assets/312b7db8-011b-4270-b16f-21f442bcd23d" />

Admin user still see:
<img width="971" height="247" alt="image" src="https://github.com/user-attachments/assets/3d2b932d-a3eb-4025-8fcc-e169bc3543e7" />
