### PR TITLE
chore: 0.25.0-SNAPSHOT version bump

### DIFF
--- a/back-end/apps/api/example.env
+++ b/back-end/apps/api/example.env
@@ -47,6 +47,6 @@ PGADMIN_DEFAULT_PASSWORD=pgadmin4
 NODE_ENV=development
 
 # Frontend version control (optional)
-LATEST_SUPPORTED_FRONTEND_VERSION=0.23.1
+LATEST_SUPPORTED_FRONTEND_VERSION=0.24.0
 MINIMUM_SUPPORTED_FRONTEND_VERSION=0.23.0
 FRONTEND_REPO_URL=https://github.com/hashgraph/hedera-transaction-tool/releases/download

--- a/back-end/apps/api/package.json
+++ b/back-end/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/api",
-  "version": "0.23.1",
+  "version": "0.25.0-SNAPSHOT",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/chain/package.json
+++ b/back-end/apps/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/chain",
-  "version": "0.23.1",
+  "version": "0.25.0-SNAPSHOT",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/notifications/package.json
+++ b/back-end/apps/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/notifications",
-  "version": "0.23.1",
+  "version": "0.25.0-SNAPSHOT",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/k8s/dev/deployments/api-deployment.yaml
+++ b/back-end/k8s/dev/deployments/api-deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - name: GLOBAL_SECOND_LIMIT
               value: '1000'
             - name: LATEST_SUPPORTED_FRONTEND_VERSION
-              value: '0.23.1'
+              value: '0.24.0'
             - name: MINIMUM_SUPPORTED_FRONTEND_VERSION
               value: '0.23.0'
             - name: FRONTEND_REPO_URL

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "back-end",
-  "version": "0.23.1",
+  "version": "0.25.0-SNAPSHOT",
   "description": "",
   "author": "",
   "private": true,

--- a/back-end/typeorm/package.json
+++ b/back-end/typeorm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.23.1",
+  "version": "0.25.0-SNAPSHOT",
   "private": true,
   "scripts": {
     "build": "tsc",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-transaction-tool",
-  "version": "0.23.1",
+  "version": "0.25.0-SNAPSHOT",
   "description": "Transaction tool application",
   "author": {
     "name": "Hedera",


### PR DESCRIPTION
**Description**:
In order to better adhere to the release strategy, the main branch should have the version labeled with the SNAPSHOT pre-release identifier.