### PR TITLE
chore: adding test cases which verifies that key pair existence is checked before signing / sharing

### DIFF
--- a/automation/pages/SettingsPage.ts
+++ b/automation/pages/SettingsPage.ts
@@ -49,6 +49,7 @@ export class SettingsPage extends BasePage {
   decryptMainPrivateKeyButtonSelector = 'span-show-modal-0';
   deleteKeyPairButton = 'button-delete-keypair';
   deleteKeyButtonPrefix = 'button-delete-key-';
+  deleteKeyAllButton = 'button-delete-key-all';
   changePasswordButtonSelector = 'button-change-password';
   confirmChangePasswordButtonSelector = 'button-confirm-change-password';
   closeButtonSelector = 'button-close';
@@ -57,6 +58,9 @@ export class SettingsPage extends BasePage {
 
   // Text
   decryptedPrivateKeySelector = 'span-private-key-0';
+
+  // Input
+  selectAllKeysCheckboxSelector = 'checkbox-select-all-keys';
 
   // Prefixes
   indexCellSelectorPrefix = 'cell-index-';
@@ -160,6 +164,10 @@ export class SettingsPage extends BasePage {
     await this.click(this.continueButtonSelector, null, 25000);
   }
 
+  async clickOnDeleteKeyAllButton(): Promise<void> {
+    await this.click(this.deleteKeyAllButton)
+  }
+
   async fillInIndex(index = 1): Promise<void> {
     await this.fill(this.indexInputSelector, index.toString());
   }
@@ -206,6 +214,10 @@ export class SettingsPage extends BasePage {
 
   async clickOnED25519DropDown(): Promise<void> {
     await this.click(this.ed25519ImportLinkSelector);
+  }
+
+  async clickOnSelectAllKeys(): Promise<void> {
+    await this.click(this.selectAllKeysCheckboxSelector);
   }
 
   async fillInMirrorNodeBaseURL(mirrorNodeBaseURL: string): Promise<void> {

--- a/automation/pages/TransactionPage.ts
+++ b/automation/pages/TransactionPage.ts
@@ -120,6 +120,9 @@ export class TransactionPage extends BasePage {
   moreDropdownButtonSelector = 'button-more-dropdown-lg';
   importButtonSelector = 'button-transaction-page-import';
   confirmImportButtonSelector = 'button-import-files-public';
+  saveGotoSettingsButtonSelector = 'button-save-goto-settings';
+  gotoSettingsButtonSelector = 'button-goto-settings';
+
   //Other
   confirmTransactionModalSelector = 'modal-confirm-transaction';
   spanCreateNewComplexKeyButtonSelector = 'span-create-new-complex-key';
@@ -885,6 +888,14 @@ export class TransactionPage extends BasePage {
 
   async clickOnDoneButtonForComplexKeyCreation() {
     await this.click(this.doneComplexKeyButtonSelector, 0);
+  }
+
+  async clickOnSaveGotoSettings() {
+    await this.click(this.saveGotoSettingsButtonSelector);
+  }
+
+  async clickOnGotoSettings() {
+    await this.click(this.gotoSettingsButtonSelector);
   }
 
   /**

--- a/automation/tests/organizationSettingsTests.test.ts
+++ b/automation/tests/organizationSettingsTests.test.ts
@@ -228,4 +228,43 @@ test.describe('Organization Settings tests', () => {
     const isDeletedFromDb = await organizationPage.verifyOrganizationExists(orgName);
     expect(isDeletedFromDb).toBe(false);
   });
+
+  test('Verify that deleting all keys prevent to sign and execute a draft transaction', async () => {
+    // This test is a copy of transactionTests.test.ts 'Verify that deleting all keys prevent to sign and execute a draft transaction'
+    // If you fix something here, you probably want to do the same in transactionTests.test.ts
+
+    // Go to Settings / Keys and delete all keys
+    const settingsPage = new SettingsPage(window);
+    await settingsPage.clickOnSettingsButton();
+    await settingsPage.clickOnKeysTab();
+    await settingsPage.clickOnSelectAllKeys();
+    await settingsPage.clickOnDeleteKeyAllButton();
+    await settingsPage.clickOnDeleteKeyPairButton();
+
+    // Go to Transactions and fill a new Account Update transaction
+    await transactionPage.clickOnTransactionsMenuButton();
+    await transactionPage.clickOnCreateNewTransactionButton();
+    await transactionPage.clickOnUpdateAccountTransaction();
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    await transactionPage.fillInPayerAccountId('0.0.1002');
+    await transactionPage.fillInMaxAutoAssociations('0'); // Workaround for -1 bug in maxAutoAssociations
+    await transactionPage.fillInUpdatedAccountId('0.0.1002'); // Called last because it waits for sign and submit activation
+
+    // Click Sign and Execute, Save and Goto Settings and check Settings tab is displayed
+    await transactionPage.clickOnSignAndSubmitButton();
+    await transactionPage.clickOnSaveGotoSettings();
+    await settingsPage.verifySettingsElements();
+
+    // Go back to Transactions / Drafs
+    await transactionPage.clickOnTransactionsMenuButton();
+    await transactionPage.clickOnDraftsMenuButton();
+
+    // Click Continue to edit draft transaction
+    await transactionPage.clickOnFirstDraftContinueButton();
+
+    // Click Sign and Execute, Save and Goto Settings and check Settings tab is displayed
+    await transactionPage.clickOnSignAndSubmitButton();
+    await transactionPage.clickOnGotoSettings();
+    await settingsPage.verifySettingsElements();
+  });
 });

--- a/automation/tests/transactionTests.test.ts
+++ b/automation/tests/transactionTests.test.ts
@@ -12,6 +12,7 @@ import {
   setupEnvironmentForTransactions,
 } from '../utils/util.js';
 import { Transaction } from '../../front-end/src/shared/interfaces/index.js';
+import { SettingsPage } from '../pages/SettingsPage.js';
 
 let app: ElectronApplication;
 let window: Page;
@@ -736,5 +737,44 @@ test.describe('Transaction tests', () => {
 
     await transactionPage.navigateToDrafts();
     await transactionPage.deleteFirstDraft();
+  });
+
+  test('Verify that deleting all keys prevent to sign and execute a draft transaction', async () => {
+    // This test is a copy of organizationSettingsTests.test.ts 'Verify that deleting all keys prevent to sign and execute a draft transaction'
+    // If you fix something here, you probably want to do the same in organizationSettingsTests.test.ts
+
+    // Go to Settings / Keys and delete all keys
+    const settingsPage = new SettingsPage(window);
+    await settingsPage.clickOnSettingsButton();
+    await settingsPage.clickOnKeysTab();
+    await settingsPage.clickOnSelectAllKeys();
+    await settingsPage.clickOnDeleteKeyAllButton();
+    await settingsPage.clickOnDeleteKeyPairButton();
+
+    // Go to Transactions and fill a new Account Update transaction
+    await transactionPage.clickOnTransactionsMenuButton();
+    await transactionPage.clickOnCreateNewTransactionButton();
+    await transactionPage.clickOnUpdateAccountTransaction();
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    await transactionPage.fillInPayerAccountId('0.0.1002');
+    await transactionPage.fillInMaxAutoAssociations('0'); // Workaround for -1 bug in maxAutoAssociations
+    await transactionPage.fillInUpdatedAccountId('0.0.1002'); // Called last because it waits for sign and submit activation
+
+    // Click Sign and Execute, Save and Goto Settings and check Settings tab is displayed
+    await transactionPage.clickOnSignAndSubmitButton();
+    await transactionPage.clickOnSaveGotoSettings();
+    await settingsPage.verifySettingsElements();
+
+    // Go back to Transactions / Drafs
+    await transactionPage.clickOnTransactionsMenuButton();
+    await transactionPage.clickOnDraftsMenuButton();
+
+    // Click Continue to edit draft transaction
+    await transactionPage.clickOnFirstDraftContinueButton();
+
+    // Click Sign and Execute, Save and Goto Settings and check Settings tab is displayed
+    await transactionPage.clickOnSignAndSubmitButton();
+    await transactionPage.clickOnGotoSettings();
+    await settingsPage.verifySettingsElements();
   });
 });

--- a/front-end/src/renderer/components/Transaction/TransactionProcessor/components/CheckKeySettingHandler.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionProcessor/components/CheckKeySettingHandler.vue
@@ -120,6 +120,7 @@ defineExpose({
           <AppButton
             color="primary"
             type="submit"
+            :data-testid="props.hasDataChanged ? 'button-save-goto-settings' : 'button-goto-settings'"
             :loading="saving"
             loading-text="Saving Draft…"
             :disabled="saving"


### PR DESCRIPTION
**Description**:
Changes below add two test cases to automation tests.

The same test is added in two different contexts:
1) `Personal` mode (is `transactionTests.test.ts`)
2) `Organization` mode (ie `organizationTransactionTests.test.ts`)

**Related issue(s)**:

Fixes #2257
Fixes #2211

**Notes for reviewer**:

Test scenario:
1) Goto `Settings / Keys` tab
2) Delete all keys
3) Goto `Transactions` tab
4) Create an `Account Update` transaction
5) `Sign and Execute` (or `Create and Share`)
     => check that `Save Draft and Goto Settings` dialog is displayed
6) click `Save Draft and Goto Settings`
     => check that `Settings` tab is displayed
7) Go back to `Transactions` tab
8) Edit draft (created at step 6)
9) click `Sign and Execute` (or `Create and Share`)
    => check that `Goto Settings` dialog is displayed (no `Save Draft`)
10) click `Goto Settings`
    => check that `Settings` tab is displayed

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
