### PR TITLE
fix(test): fix TransactionPage.clickOnCancelTransaction

### DIFF
--- a/automation/pages/TransactionPage.ts
+++ b/automation/pages/TransactionPage.ts
@@ -841,7 +841,10 @@ export class TransactionPage extends BasePage {
   }
 
   async clickOnCancelTransaction() {
-    await this.click(this.buttonCancelTransactionSelector);
+    const modalSelector = `[data-testid="${this.confirmTransactionModalSelector}"][style*="display: block"]`;
+    const cancelButtonSelector = `${modalSelector} [data-testid="${this.buttonCancelTransactionSelector}"]`;
+    await this.window.waitForSelector(cancelButtonSelector, { state: 'visible', timeout: 15000 });
+    await this.window.click(cancelButtonSelector);
   }
 
   async clickAddButton(depth: string) {


### PR DESCRIPTION
**Description**:

Fix `TransactionPage.clickOnCancelTransaction()` to properly scope the Cancel button in the confirmation modal.
Not sure this will help passing on CI but this was consistently breaking things for me when running `transactionTests` locally...
