### PR TITLE
fix: update transaction signing events mark notifications as read

### DIFF
--- a/front-end/src/renderer/pages/Transactions/components/SignGroupButton.vue
+++ b/front-end/src/renderer/pages/Transactions/components/SignGroupButton.vue
@@ -18,7 +18,7 @@ const props = defineProps<{
 
 /* Emits */
 const emit = defineEmits<{
-  (event: 'transactionGroupSigned', groupId: number): void;
+  (event: 'transactionGroupSigned', payload: { groupId: number, signed: boolean}): void;
 }>();
 
 /* Stores */
@@ -62,7 +62,7 @@ const handleSign = async (personalPassword: string|null) => {
       nodeByIdCache,
     );
 
-    emit('transactionGroupSigned', props.groupId);
+    emit('transactionGroupSigned', { groupId: props.groupId, signed });
     if (signed) {
       toast.success('Transaction group signed successfully', successToastOptions);
     } else {

--- a/front-end/src/renderer/pages/Transactions/components/SignSingleButton.vue
+++ b/front-end/src/renderer/pages/Transactions/components/SignSingleButton.vue
@@ -17,7 +17,7 @@ const props = defineProps<{
 
 /* Emits */
 const emit = defineEmits<{
-  (event: 'transactionSigned', transactionId: number): void;
+  (event: 'transactionSigned', payload: { transactionId: number, signed: boolean}): void;
 }>();
 
 /* Stores */
@@ -60,7 +60,7 @@ const handleSign = async (personalPassword: string|null) => {
       nodeByIdCache,
     );
 
-    emit('transactionSigned', props.transactionId);
+    emit('transactionSigned', { transactionId: props.transactionId, signed });
     if (signed) {
       toast.success('Transaction signed successfully', successToastOptions);
     } else {

--- a/front-end/src/renderer/pages/Transactions/components/TransactionNodeRow.vue
+++ b/front-end/src/renderer/pages/Transactions/components/TransactionNodeRow.vue
@@ -186,6 +186,27 @@ const isDangerStatus = computed(() => {
 });
 
 /* Handlers */
+const handleTransactionSigned = async (payload: { transactionId: number; signed: boolean }) => {
+  if (payload.signed) {
+    if (notificationMonitor.filteredNotificationIds.value.length > 0) {
+      await notifications.markAsReadIds(notificationMonitor.filteredNotificationIds.value);
+    }
+  }
+
+  // then pass only the id up (or the whole payload if you prefer)
+  emit('transactionSigned', payload.transactionId);
+};
+
+const handleTransactionGroupSigned = async (payload: { groupId: number; signed: boolean }) => {
+  if (payload.signed) {
+    if (notificationMonitor.filteredNotificationIds.value.length > 0) {
+      await notifications.markAsReadIds(notificationMonitor.filteredNotificationIds.value);
+    }
+  }
+
+  emit('transactionGroupSigned', payload.groupId);
+};
+
 const handleDetails = async () => {
   if (notificationMonitor.filteredNotificationIds.value.length > 0) {
     await notifications.markAsReadIds(notificationMonitor.filteredNotificationIds.value);
@@ -323,13 +344,13 @@ watch(
             v-if="props.node.transactionId"
             :data-testid="`button-transaction-node-sign-${index}`"
             :transactionId="props.node.transactionId"
-            @transactionSigned="(tid: number) => emit('transactionSigned', tid)"
+            @transactionSigned="handleTransactionSigned"
           />
           <SignGroupButton
             v-if="props.node.groupId"
             :data-testid="`button-transaction-node-sign-${index}`"
             :group-id="props.node.groupId"
-            @transactionGroupSigned="(gid: number) => emit('transactionGroupSigned', gid)"
+            @transactionGroupSigned="handleTransactionGroupSigned"
           />
         </template>
         <AppButton


### PR DESCRIPTION
**Description**:
This pull request updates the way sign events are emitted from the `SignSingleButton` and `SignGroupButton` components, so that they now include both the ID and the sign status (`signed: boolean`) in their payloads. Additionally, the parent `TransactionNodeRow` component is updated to handle these new payload structures, process notifications accordingly, and then emit only the ID upwards. This improves event handling clarity and allows for richer event data.

**Event Payload Structure Updates:**

- Changed the emitted payloads for the `transactionSigned` and `transactionGroupSigned` events in both `SignSingleButton.vue` and `SignGroupButton.vue` to include both the relevant ID and a `signed` boolean, instead of just the ID. [[1]](diffhunk://#diff-7e69ce8c6eccb28cac6573514167e79719498d722c3e86a1fa4badd56d2daff2L20-R20) [[2]](diffhunk://#diff-657fdc9ec16b11ecd9ccfcd7be28eac905ed50bde88bad4200bfb88d07d44e46L21-R21)

- Updated the emit calls in the sign handlers to use the new payload structure. [[1]](diffhunk://#diff-7e69ce8c6eccb28cac6573514167e79719498d722c3e86a1fa4badd56d2daff2L63-R63) [[2]](diffhunk://#diff-657fdc9ec16b11ecd9ccfcd7be28eac905ed50bde88bad4200bfb88d07d44e46L65-R65)

**Parent Component Event Handling:**

- Added `handleTransactionSigned` and `handleTransactionGroupSigned` methods to `TransactionNodeRow.vue` to process the new event payloads, mark notifications as read when appropriate, and then emit just the ID upwards.

- Updated the template in `TransactionNodeRow.vue` to use the new handler methods for the `transactionSigned` and `transactionGroupSigned` events.

**Related issue(s)**:

Fixes #2319 