### PR TITLE
fix: flaky unit tests in main process

### DIFF
--- a/front-end/src/tests/main/services/localUser/transactions.spec.ts
+++ b/front-end/src/tests/main/services/localUser/transactions.spec.ts
@@ -429,17 +429,15 @@ describe('Services Local User Transactions', () => {
   });
 
   describe('executeQuery', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
+      vi.resetAllMocks();
+
       vi.spyOn(SDK.Client, 'forName').mockReturnValue({
         close: vi.fn(),
         setOperator: vi.fn(),
       } as any);
 
       await setClient('testnet');
-    });
-
-    beforeEach(() => {
-      vi.resetAllMocks();
     });
 
     test('Should execute the query and return the response', async () => {
@@ -651,7 +649,10 @@ describe('Services Local User Transactions', () => {
         'Invalid key type',
       );
 
-      expect(getClient()._operator).toBeNull();
+      // In real world scenario, the operator should be null. We test for undefined here because the actual
+      // code's intent is to leave the client's operator untouched, so in the case of this mock,
+      // that means it will be left as undefined.
+      expect(getClient()._operator).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
**Description**:
This pull request updates the unit tests for the local user transactions service to improve test isolation and clarify expectations around the client operator state. The most important changes are:

**Test Setup Improvements:**

* Moved setup code from `beforeAll` to `beforeEach` in the `executeQuery` test suite to ensure each test has a fresh setup and mocks are reset, preventing state leakage between tests.

**Test Expectation Clarification:**

* Updated an assertion to check for `undefined` instead of `null` for the `_operator` property in the mock client, with comments explaining the reasoning based on the mock's behavior and the code's intent.

**Related issue(s)**:

Fixes #2315 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
