### PR TITLE
chore: bump version to 0.25.0-beta.1

### DIFF
--- a/back-end/apps/api/package.json
+++ b/back-end/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/api",
-  "version": "0.25.0-SNAPSHOT",
+  "version": "0.25.0-beta.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/chain/package.json
+++ b/back-end/apps/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/chain",
-  "version": "0.25.0-SNAPSHOT",
+  "version": "0.25.0-beta.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/notifications/package.json
+++ b/back-end/apps/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/notifications",
-  "version": "0.25.0-SNAPSHOT",
+  "version": "0.25.0-beta.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/k8s/dev/deployments/api-deployment.yaml
+++ b/back-end/k8s/dev/deployments/api-deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - name: GLOBAL_SECOND_LIMIT
               value: '1000'
             - name: LATEST_SUPPORTED_FRONTEND_VERSION
-              value: '0.24.0'
+              value: '0.25.0-beta.1'
             - name: MINIMUM_SUPPORTED_FRONTEND_VERSION
               value: '0.23.0'
             - name: FRONTEND_REPO_URL

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "back-end",
-  "version": "0.25.0-SNAPSHOT",
+  "version": "0.25.0-beta.1",
   "description": "",
   "author": "",
   "private": true,

--- a/back-end/typeorm/package.json
+++ b/back-end/typeorm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.25.0-SNAPSHOT",
+  "version": "0.25.0-beta.1",
   "private": true,
   "scripts": {
     "build": "tsc",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-transaction-tool",
-  "version": "0.25.0-SNAPSHOT",
+  "version": "0.25.0-beta.1",
   "description": "Transaction tool application",
   "author": {
     "name": "Hedera",


### PR DESCRIPTION
**Description**:

* Updated the `version` field from `0.25.0-SNAPSHOT` to `0.25.0-beta.1` in the following `package.json` files: `back-end`, `back-end/apps/api`, `back-end/apps/chain`, `back-end/apps/notifications`, `back-end/typeorm`, and `front-end` (`hedera-transaction-tool`). [[1]](diffhunk://#diff-d1c5d2322c31c65053bc0b5356afe6821cc44aa37a8733f5c0227e0f3c053e35L3-R3) [[2]](diffhunk://#diff-99b1c8b2f8265809468bda8592450aee836bcc51d4a1f2f2cd716e49c6fe58c3L3-R3) [[3]](diffhunk://#diff-2ad1bc17da00af17ba969215f351a7981db8c4920aa70ca37c8545607c59dfb6L3-R3) [[4]](diffhunk://#diff-df4fdc006a9461f8a8131afed679b1fb80743c91216998c32bf0b4679f675973L3-R3) [[5]](diffhunk://#diff-734f8b0d49eec4ad207e761f0eaefdbc8187c6ab63ee39c343b2661d5b065fbbL3-R3) [[6]](diffhunk://#diff-f573261b8354834cb5d2110af3a0e0e20157fa2fe40af594186b2a715a306ea0L3-R3)

**Deployment configuration:**

* Updated the `LATEST_SUPPORTED_FRONTEND_VERSION` environment variable in `back-end/k8s/dev/deployments/api-deployment.yaml` from `0.24.0` to `0.25.0-beta.1` to match the new frontend version.

