### PR TITLE
fix: update transaction validStart time handling in tests for flaky test

### DIFF
--- a/back-end/apps/chain/src/transaction-scheduler/transaction-scheduler.service.spec.ts
+++ b/back-end/apps/chain/src/transaction-scheduler/transaction-scheduler.service.spec.ts
@@ -1035,14 +1035,18 @@ describe('TransactionStatusService', () => {
     let timeToValidStart: number;
 
     beforeEach(() => {
+      jest.useFakeTimers();
+
+      const fixedNow = Date.now();
+      jest.setSystemTime(fixedNow);
+
       transaction = {
         id: 1,
-        validStart: new Date(Date.now() + 1000),
+        validStart: new Date(fixedNow + 1000),
       } as Transaction;
       name = `execution_timeout_${transaction.id}`;
-      timeToValidStart = transaction.validStart.getTime() - Date.now();
+      timeToValidStart = transaction.validStart.getTime() - fixedNow;
 
-      jest.useFakeTimers();
       jest.spyOn(global, 'setTimeout');
       jest.spyOn(schedulerRegistry, 'doesExist').mockReturnValue(false);
       jest.spyOn(schedulerRegistry, 'addTimeout');
@@ -1051,6 +1055,7 @@ describe('TransactionStatusService', () => {
     });
 
     afterEach(() => {
+      jest.setSystemTime(new Date());
       jest.useRealTimers();
     });
 


### PR DESCRIPTION
**Description**:
This pull request makes improvements to the test setup for the `TransactionStatusService` by ensuring that time-dependent logic is more reliable and deterministic. The main changes involve controlling the system time in Jest tests to avoid flakiness and ensure accurate calculations.

**Test reliability and determinism improvements:**

* Updated the test setup in `transaction-scheduler.service.spec.ts` to use a fixed system time with `jest.setSystemTime`, ensuring that all time calculations are based on a consistent reference point. This prevents issues caused by the actual current time changing during test execution.
* Added a cleanup step in the test teardown to reset the system time to the real current time using `jest.setSystemTime(new Date())`, ensuring no side effects for other tests.

**Checklist**

- [x] Tested (unit, integration, etc.)
