### PR TITLE
fix: user cannot sign transaction in WAITING_FOR_EXECUTION status

### DIFF
--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -196,9 +196,7 @@ const canSign = computed(() => {
 
   const userShouldSign = publicKeysRequiredToSign.value.length > 0;
 
-  return (
-    userShouldSign
-  );
+  return userShouldSign;
 });
 
 const canExecute = computed(() => {


### PR DESCRIPTION
**Description**:

This pull request makes a minor change to the computed property `canSign` in `TransactionDetailsHeader.vue`. The condition for allowing a user to sign a transaction has been simplified by removing the requirement that the transaction status must be `WAITING_FOR_SIGNATURES`.

**Related issue(s)**:

Fixes #2357 

**Checklist**

- [x] Tested (unit, integration, etc.)
