### PR TITLE
test: adding missing await in front of expect

### DIFF
--- a/front-end/src/tests/main/services/localUser/transactions.spec.ts
+++ b/front-end/src/tests/main/services/localUser/transactions.spec.ts
@@ -689,7 +689,7 @@ describe('Services Local User Transactions', () => {
         throw new Error('Failed to store transaction');
       });
 
-      expect(
+      await expect(
         async () => await storeTransaction({} as Prisma.TransactionUncheckedCreateInput),
       ).rejects.toThrow('Failed to store transaction');
     });
@@ -699,7 +699,7 @@ describe('Services Local User Transactions', () => {
         throw '';
       });
 
-      expect(
+      await expect(
         async () => await storeTransaction({} as Prisma.TransactionUncheckedCreateInput),
       ).rejects.toThrow('Failed to store transaction');
     });


### PR DESCRIPTION
**Description**:

Changes below add `await` operator in front of some calls to `expect()` in `transactions.spec.ts`.
They fix the two `vitest` warnings below:

```
stderr | src/tests/main/services/localUser/transactions.spec.ts > Services Local User Transactions > storeTransaction > Should throw if storing transaction fails
Promise returned by `expect(actual).rejects.toThrow(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
    at /home/runner/_work/hedera-transaction-tool/hedera-transaction-tool/front-end/src/tests/main/services/localUser/transactions.spec.ts:694:7
```
```
stderr | src/tests/main/services/localUser/transactions.spec.ts > Services Local User Transactions > storeTransaction > Should throw if storing transaction fails
Promise returned by `expect(actual).rejects.toThrow(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
    at /home/runner/_work/hedera-transaction-tool/hedera-transaction-tool/front-end/src/tests/main/services/localUser/transactions.spec.ts:704:7
```

**Related issue(s)**:

Might fix #2315 …

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
