### PR TITLE
fix: user cannot sign transaction in WAITING_FOR_EXECUTION status

### DIFF
--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -196,10 +196,7 @@ const canSign = computed(() => {
 
   const userShouldSign = publicKeysRequiredToSign.value.length > 0;
 
-  return (
-    userShouldSign &&
-    props.organizationTransaction.status === TransactionStatus.WAITING_FOR_SIGNATURES
-  );
+  return userShouldSign;
 });
 
 const canExecute = computed(() => {


### PR DESCRIPTION
**Description**:

Once a transaction was in 'WAITING_FOR_EXECUTION' state, the user was unable to sign the transaction.

Cherry pick of #2358 
