### PR TITLE
fix: Updates can appear to not work on slow laptops

### DIFF
--- a/automation/pages/LoginPage.ts
+++ b/automation/pages/LoginPage.ts
@@ -72,40 +72,25 @@ export class LoginPage extends BasePage {
     await this.fill(this.passwordInputSelector, '');
   }
 
-  // specific logout method for the login tests
   async logout() {
-    // Quick check if logout button already visible (already on Profile tab)
-    let isLogoutButtonVisible = await this.isElementVisible(this.logoutButtonSelector, null, 500);
+    let isLogoutVisible = await this.isElementVisible(this.logoutButtonSelector, null, 500);
 
-    if (!isLogoutButtonVisible) {
-      // Navigate to Settings > Profile to find logout button
-      // First click Settings menu if visible
-      const settingsMenuVisible = await this.isElementVisible(this.settingsButtonSelector, null, 500);
-      if (settingsMenuVisible) {
-        console.log('Clicking Settings menu');
+    if (!isLogoutVisible) {
+      if (await this.isElementVisible(this.settingsButtonSelector, null, 500)) {
         await this.click(this.settingsButtonSelector);
-        await this.window.waitForTimeout(500);
       }
 
-      // Now click Profile tab (should be on Settings page now)
-      const profileTab = this.window.locator('[data-testid="tab-4"]');
-      try {
-        await profileTab.click({ timeout: 2000 });
-        console.log('Clicked Profile tab');
-        await this.window.waitForTimeout(500);
-        isLogoutButtonVisible = await this.isElementVisible(this.logoutButtonSelector, null, 1000);
-      } catch (e) {
-        console.log('Profile tab click failed:', e);
+      if (await this.isElementVisible(this.profileTabButtonSelector, null, 500)) {
+        await this.click(this.profileTabButtonSelector);
+        isLogoutVisible = await this.isElementVisible(this.logoutButtonSelector);
       }
     }
 
-    if (isLogoutButtonVisible) {
-      console.log('Logout button visible, clicking to logout');
+    if (isLogoutVisible) {
       await this.click(this.logoutButtonSelector);
-      const element = this.window.getByTestId(this.emailInputSelector);
-      await element.waitFor({ state: 'visible', timeout: 3000 });
+      await this.window.getByTestId(this.emailInputSelector)
+        .waitFor({ state: 'visible', timeout: 3000 });
     } else {
-      console.log('Logout button not visible, resetting form');
       await this.resetForm();
     }
   }

--- a/automation/pages/OrganizationPage.ts
+++ b/automation/pages/OrganizationPage.ts
@@ -662,7 +662,7 @@ export class OrganizationPage extends BasePage {
 
     // Navigate back to transactions list to ensure clean state for next call
     await this.transactionPage.clickOnTransactionsMenuButton();
-    await this.waitForElementToBeVisible('button-create-new');
+    await this.waitForElementToBeVisible(this.transactionPage.createNewTransactionButtonSelector);
   }
 
   async createComplexKeyAccountForUsers(numberOfUsers = 9, groupSize = 3) {
@@ -1683,8 +1683,6 @@ export class OrganizationPage extends BasePage {
         { timeout: 10000, intervals: [500] },
       ).toBe(true);
     }
-    // If notification exists and is unread, secondUser is already logged in from createNotificationForUser
-    // with notifications fetched via the frontend fix to loggedInOrganization watcher
   }
 
   async clickOnNextTransactionButton() {

--- a/automation/pages/RegistrationPage.ts
+++ b/automation/pages/RegistrationPage.ts
@@ -33,7 +33,7 @@ export class RegistrationPage extends BasePage {
   nextButtonSelector = 'button-verify-next-generate';
   nextButtonImportSelector = 'button-next-import';
   finalNextButtonSelector = 'button-next';
-  settingsButtonSelector = 'a[href="/settings/general"].link-menu.mt-2';
+  settingsButtonSelector = 'button-menu-settings';
   clearButtonSelector = 'button-clear';
   generateAgainButtonSelector = 'button-generate-again';
   showPrivateKeyButtonSelector = 'button-show-private-key';
@@ -121,7 +121,7 @@ export class RegistrationPage extends BasePage {
       try {
         // Attempt to click the final next button
         await this.click(this.finalNextButtonSelector);
-        await this.window.waitForSelector(this.settingsButtonSelector, {
+        await this.window.getByTestId(this.settingsButtonSelector).waitFor({
           state: 'visible',
           timeout: 1000,
         });

--- a/automation/pages/TransactionPage.ts
+++ b/automation/pages/TransactionPage.ts
@@ -39,7 +39,6 @@ export class TransactionPage extends BasePage {
 
   //Inputs
   payerAccountInputSelector = 'input-payer-account';
-  payerDropdownSelector = 'dropdown-payer'; // Used for queries (FileContentsQuery, etc.)
   initialBalanceInputSelector = 'input-initial-balance-amount';
   maxAutoAssociationsInputSelector = 'input-max-auto-token-associations';
   accountMemoInputSelector = 'input-account-memo';
@@ -242,13 +241,8 @@ export class TransactionPage extends BasePage {
   }
 
   async clickOnCreateNewTransactionButton() {
-    // Click Create New button to open dropdown
     await this.click(this.createNewTransactionButtonSelector);
-
-    // Wait for dropdown and click Single Transaction
-    const singleTxButton = this.getElement(this.singleTransactionButtonSelector);
-    await singleTxButton.waitFor({ state: 'visible', timeout: 5000 });
-    await singleTxButton.click();
+    await this.click(this.singleTransactionButtonSelector);
   }
 
   async clickOnImportButton() {
@@ -492,9 +486,11 @@ export class TransactionPage extends BasePage {
     await this.clickOnSignAndSubmitButton();
     await this.clickSignTransactionButton();
     // Wait for Confirm Transaction modal to close before looking for execution modal
+    // Note: uses waitForSelector instead of getByTestId because AppModal.vue hardcodes
+    // data-testid="modal-confirm-transaction" on ALL modals, causing strict mode violations
     await this.window.waitForSelector(
       `[data-testid="${this.confirmTransactionModalSelector}"]`,
-      { state: 'hidden', timeout: 10000 }
+      { state: 'hidden', timeout: 10000 },
     );
     // Wait for execution to complete (modal auto-closes when done)
     // Note: don't wait for 'Executing' to appear first - it's transient and may already be gone
@@ -526,7 +522,7 @@ export class TransactionPage extends BasePage {
       throw new Error('Complex key modal did not close within 10 seconds');
     }
     // Then wait for sign button to become visible and clickable
-    await this.waitForElementToBeVisible(this.signAndSubmitButtonSelector, 5000);
+    await this.waitForElementToBeVisible(this.signAndSubmitButtonSelector);
   }
 
   async deleteAccount(accountId: string) {
@@ -814,18 +810,7 @@ export class TransactionPage extends BasePage {
     await button.click();
   }
 
-  // For queries (FileContentsQuery, etc.) - uses dropdown for payer, not input
   async clickOnSignAndReadButton() {
-    // For LOCALNET: Select payer from dropdown if not already selected
-    if (process.env.ENVIRONMENT?.toUpperCase() === 'LOCALNET') {
-      const payerDropdown = this.window.getByTestId(this.payerDropdownSelector);
-      // Check if dropdown exists and wait for it
-      await payerDropdown.waitFor({ state: 'visible', timeout: 10000 });
-      // The dropdown should auto-populate with imported accounts
-      // Just ensure something is selected by waiting for the button to be enabled
-    }
-
-    // Click the Sign & Read button (same testid as Sign & Submit)
     const button = this.window.getByTestId(this.signAndSubmitButtonSelector);
     await button.scrollIntoViewIfNeeded();
     await button.click({ timeout: 10000 });

--- a/automation/tests/groupTransactionTests.test.ts
+++ b/automation/tests/groupTransactionTests.test.ts
@@ -10,13 +10,11 @@ import {
   setupApp,
   setupEnvironmentForTransactions,
 } from '../utils/util.js';
-import { LoginPage } from '../pages/LoginPage.js';
 
 let app: ElectronApplication;
 let window: Page;
 let globalCredentials = { email: '', password: '' };
 let registrationPage: RegistrationPage;
-let loginPage: LoginPage;
 let transactionPage: TransactionPage;
 let groupPage: GroupPage;
 
@@ -25,7 +23,6 @@ test.describe('Group transaction tests', () => {
     await resetDbState();
     ({ app, window } = await setupApp());
     registrationPage = new RegistrationPage(window);
-    loginPage = new LoginPage(window);
     transactionPage = new TransactionPage(window);
     groupPage = new GroupPage(window);
 
@@ -43,23 +40,11 @@ test.describe('Group transaction tests', () => {
   });
 
   test.beforeEach(async () => {
-    // Wait for any ongoing operations to complete
-    await window.waitForLoadState('networkidle');
-
-    // Ensure menu button is visible before clicking
-    await transactionPage.waitForElementToBeVisible(
-      transactionPage.transactionsMenuButtonSelector,
-      5000,
-    );
     await transactionPage.clickOnTransactionsMenuButton();
 
-    // Additional wait for CI environment stability
     if (process.env.CI) {
       await new Promise(resolve => setTimeout(resolve, 1000));
     }
-
-    // Wait for page to stabilize after navigation
-    await window.waitForLoadState('networkidle');
 
     await groupPage.closeDraftTransactionModal();
     await groupPage.closeGroupDraftModal();

--- a/automation/tests/organizationContactListTests.test.ts
+++ b/automation/tests/organizationContactListTests.test.ts
@@ -9,15 +9,12 @@ import {
   generateRandomPassword,
   setupApp,
   setupEnvironmentForTransactions,
-  resetAppState,
 } from '../utils/util.js';
-import { LoginPage } from '../pages/LoginPage.js';
 
 let app: ElectronApplication;
 let window: Page;
 let globalCredentials = { email: '', password: '' };
 let registrationPage: RegistrationPage;
-let loginPage: LoginPage;
 let organizationPage: OrganizationPage;
 let contactListPage: ContactListPage;
 
@@ -29,17 +26,9 @@ test.describe('Organization Contact List tests', () => {
     await resetDbState();
     await resetPostgresDbState();
     ({ app, window } = await setupApp());
-    loginPage = new LoginPage(window);
     organizationPage = new OrganizationPage(window);
     registrationPage = new RegistrationPage(window);
     contactListPage = new ContactListPage(window);
-
-    // Check if we need to reset app state (if user exists from previous run)
-    const isSettingsButtonVisible = await loginPage.isSettingsButtonVisible();
-    if (isSettingsButtonVisible) {
-      console.log('Existing user detected, resetting app state...');
-      await resetAppState(window, app);
-    }
 
     // Generate credentials and store them globally
     globalCredentials.email = generateRandomEmail();

--- a/automation/tests/organizationGroupTests.test.ts
+++ b/automation/tests/organizationGroupTests.test.ts
@@ -101,8 +101,7 @@ test.describe('Organization Group Tx tests', () => {
       globalCredentials.password,
     );
 
-    // Wait for login toast to disappear before test starts
-    await groupPage.waitForElementToDisappear('.v-toast__text');
+    await groupPage.waitForElementToDisappear(groupPage.toastMessageSelector);
 
     await transactionPage.clickOnTransactionsMenuButton();
 

--- a/automation/tests/organizationNotificationTests.test.ts
+++ b/automation/tests/organizationNotificationTests.test.ts
@@ -101,14 +101,18 @@ test.describe('Organization Notification tests', () => {
     await transactionPage.clickOnTransactionsMenuButton();
     await organizationPage.clickOnReadyToSignTab();
     // Wait for notifications to be fetched and linked to transaction rows
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await expect.poll(
+      () => getNotifiedTransactionIdByEmail(secondUser.email),
+      { timeout: 5000, intervals: [500] },
+    ).toBeTruthy();
     // Click Details to VIEW the transaction - this marks the notification as read
     await organizationPage.clickOnReadyToSignDetailsButtonByIndex(0);
 
     // Wait for backend to process the "mark as read" request and update DB
-    await new Promise(resolve => setTimeout(resolve, 1500));
-    status = await getLatestInAppNotificationStatusByEmail(secondUser.email);
-    expect(status?.isRead).toBe(true);
+    await expect.poll(
+      async () => (await getLatestInAppNotificationStatusByEmail(secondUser.email))?.isRead,
+      { timeout: 10000, intervals: [500] },
+    ).toBe(true);
   });
 
   test('Verify tab notification is cleared after the transaction is seen', async () => {
@@ -117,7 +121,10 @@ test.describe('Organization Notification tests', () => {
     await transactionPage.clickOnTransactionsMenuButton();
     await organizationPage.clickOnReadyToSignTab();
     // Wait for notifications to be fetched and linked to transaction rows
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await expect.poll(
+      () => getNotifiedTransactionIdByEmail(secondUser.email),
+      { timeout: 5000, intervals: [500] },
+    ).toBeTruthy();
     // Click Details to VIEW the transaction - this marks the notification as read and clears the indicator
     await organizationPage.clickOnReadyToSignDetailsButtonByIndex(0);
     await new Promise(resolve => setTimeout(resolve, 1000));
@@ -128,16 +135,17 @@ test.describe('Organization Notification tests', () => {
   test('Verify notification element is shown next to the transaction', async () => {
     await organizationPage.ensureNotificationStateForUser(firstUser, secondUser, globalCredentials);
 
-    // Get the specific transaction ID that has the unread notification
     const notifiedTransactionId = await getNotifiedTransactionIdByEmail(secondUser.email);
     expect(notifiedTransactionId).not.toBeNull();
 
     await transactionPage.clickOnTransactionsMenuButton();
     await organizationPage.clickOnReadyToSignTab();
     // Wait for notifications to be fetched and linked to transaction rows
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    await expect.poll(
+      () => getNotifiedTransactionIdByEmail(secondUser.email),
+      { timeout: 5000, intervals: [500] },
+    ).toBeTruthy();
 
-    // Check the specific transaction row for the notification indicator
     const hasNotification = await organizationPage.hasNotificationForTransaction(notifiedTransactionId!);
     expect(hasNotification).toBe(true);
   });

--- a/automation/tests/organizationSettingsTests.test.ts
+++ b/automation/tests/organizationSettingsTests.test.ts
@@ -11,7 +11,6 @@ import {
   generateRandomPassword,
   setupApp,
   setupEnvironmentForTransactions,
-  resetAppState,
 } from '../utils/util.js';
 
 let app: ElectronApplication;
@@ -36,13 +35,6 @@ test.describe('Organization Settings tests', () => {
     organizationPage = new OrganizationPage(window);
     settingsPage = new SettingsPage(window);
     registrationPage = new RegistrationPage(window);
-
-    // Check if we need to reset app state (if user exists from previous run)
-    const isSettingsButtonVisible = await loginPage.isSettingsButtonVisible();
-    if (isSettingsButtonVisible) {
-      console.log('Existing user detected, resetting app state...');
-      await resetAppState(window, app);
-    }
 
     // Generate credentials and store them globally
     globalCredentials.email = generateRandomEmail();

--- a/automation/tests/transactionTests.test.ts
+++ b/automation/tests/transactionTests.test.ts
@@ -53,23 +53,12 @@ test.describe('Transaction tests', () => {
   });
 
   test.beforeEach(async () => {
-    // Wait for any ongoing operations to complete
-    await window.waitForLoadState('networkidle');
-
-    // Ensure menu button is visible before clicking
-    await transactionPage.waitForElementToBeVisible(
-      transactionPage.transactionsMenuButtonSelector,
-      5000,
-    );
     await transactionPage.clickOnTransactionsMenuButton();
 
-    // Additional wait for CI environment stability
     if (process.env.CI) {
       await new Promise(resolve => setTimeout(resolve, 1000));
     }
 
-    // Wait for page to stabilize after navigation
-    await window.waitForLoadState('networkidle');
     await transactionPage.closeDraftModal();
   });
 

--- a/automation/tests/workflowTests.test.ts
+++ b/automation/tests/workflowTests.test.ts
@@ -77,23 +77,12 @@ test.describe('Workflow tests', () => {
   });
 
   test.beforeEach(async () => {
-    // Wait for any ongoing operations to complete
-    await window.waitForLoadState('networkidle');
-
-    // Ensure menu button is visible before clicking
-    await transactionPage.waitForElementToBeVisible(
-      transactionPage.transactionsMenuButtonSelector,
-      5000,
-    );
     await transactionPage.clickOnTransactionsMenuButton();
 
-    // Additional wait for CI environment stability
     if (process.env.CI) {
       await new Promise(resolve => setTimeout(resolve, 1000));
     }
 
-    // Wait for page to stabilize after navigation
-    await window.waitForLoadState('networkidle');
     await transactionPage.closeDraftModal();
   });
 

--- a/automation/utils/databaseQueries.ts
+++ b/automation/utils/databaseQueries.ts
@@ -588,46 +588,6 @@ export async function disableNotificationsForTestUsers(inApp = false) {
 }
 
 /**
- * Retrieves the latest notification status for a user identified by the given email.
- *
- * @param {string} email - The email of the user.
- * @return {Promise<{isRead: boolean, isInAppNotified: boolean}|null>} A promise that resolves to an object containing
- * 'isRead' and 'isInAppNotified' if a notification is found, or null if not found.
- * @throws {Error} If there is an error executing the query.
- */
-export async function getLatestNotificationStatusByEmail(
-  email: string,
-): Promise<{ isRead: boolean; isInAppNotified: boolean } | null> {
-  try {
-    const userId = await getUserIdByEmail(email);
-    if (!userId) {
-      console.error(`User with email ${email} not found.`);
-      return null;
-    }
-
-    const query = `
-      SELECT nr."isRead", nr."isInAppNotified"
-      FROM public.notification_receiver nr
-      WHERE nr."userId" = $1
-      ORDER BY nr."updatedAt" DESC
-      LIMIT 1;
-    `;
-
-    const result = await queryPostgresDatabase(query, [userId]);
-    if (result.length > 0) {
-      const { isRead, isInAppNotified } = result[0];
-      return { isRead, isInAppNotified };
-    } else {
-      console.error(`No notifications found for user with ID ${userId}.`);
-      return null;
-    }
-  } catch (error) {
-    console.error('Error fetching latest notification status by email:', error);
-    return null;
-  }
-}
-
-/**
  * Retrieves the latest IN-APP notification status for a user identified by the given email.
  * This specifically queries for INDICATOR notification types (which are in-app notifications),
  * not email-only notification types.

--- a/automation/utils/databaseUtil.ts
+++ b/automation/utils/databaseUtil.ts
@@ -102,7 +102,6 @@ export async function resetDbState() {
     'TransactionDraft',
     'GroupItem',
     'TransactionGroup',
-    // Additional tables that were missing - Mnemonic is critical for full reset
     'Mnemonic',
     'Contact',
     'PublicKeyMapping',
@@ -253,5 +252,6 @@ export async function flushRateLimiter() {
     console.log('Flushed Redis rate limiter');
   } catch (err) {
     console.error('Error flushing rate limiter:', err);
+    throw err;
   }
 }

--- a/automation/utils/util.ts
+++ b/automation/utils/util.ts
@@ -40,7 +40,6 @@ export async function setupApp() {
   // Check if we need to reset app state (if user exists from previous run)
   const isSettingsButtonVisible = await loginPage.isSettingsButtonVisible();
   if (isSettingsButtonVisible) {
-    console.log('Existing user detected, resetting app state...');
     await resetAppState(window, app);
   }
 


### PR DESCRIPTION
Fixes #2365 

**Problem**
When the app installs an update, it quits and relies on Squirrel (macOS) or NSIS (Windows) to replace the application binary and relaunch it. On slower machines, this process can take several minutes with no visual feedback. During this time, users may try to reopen the app manually, which can launch the old version and prompt them to upgrade again — making it appear as though the update failed.

**Solution**
This PR introduces an update lock file mechanism that prevents the app from fully starting while an update is being installed, along with UI improvements that give users clear feedback during the install phase.

**How it works**
1. Before install: When the user confirms the update, an `update.lock` file is written to the app's `userData` directory containing the target version and a timestamp.
2. During install: The `InstallUpgrade` component shows a spinning indicator with a 5-second countdown, informing the user that the app will close and restart automatically, and warning them not to reopen manually. A system notification is also shown as a reminder once the window closes.
3. If the user reopens prematurely: On startup (`app.on('ready')`), the app checks for the lock file. If the lock exists and the current app version does not match the target version, a dialog is shown ("Update in progress — please wait") and the app quits immediately.
4. After successful update: The app starts with the new version, which matches the lock file's target version. The lock is removed and the app starts normally.
3. Stale lock safety net: If the lock is older than 10 minutes (e.g., the update failed or the system crashed), it is treated as stale — the lock is removed and the app starts normally. This prevents permanent lockout.
4. Error recovery: If `quitAndInstall()` throws, or if the updater emits an error during installation, the lock file is removed and the error is forwarded to the renderer.

**Changes**
Main process:
* `updateLock.ts` (new) — Lock file CRUD: `createUpdateLock`, `getUpdateLock`, `removeUpdateLock`, `isUpdateLockStale`
* `electronUpdater.ts` — Creates lock before calling `quitAndInstall()`, removes it on error. Adds `isInstalling` guard to prevent duplicate `quitAndInstall() `calls. Shows a system notification before quitting.
* `index.ts` — Startup guard that checks the lock file on app.ready
Renderer:
* `InstallUpgrade.vue` — New "installing" state with spinning indicator and 5-second countdown. Emits `confirm-install` when countdown reaches zero.
* `useElectronUpdater.ts` — Split `installUpdate `(sets UI state to installing) from `confirmInstall` (sends IPC to trigger `quitAndInstall`), so the countdown can run between the two.
* `MandatoryUpgrade.vue` / `OptionalUpgrade.vue` — Wire up the new confirm-install event

**How to test**
1. Add this code at line 200 for testing in with real code-signed app update:
```
       setTimeout(() => {
        try {
          this.updater!.quitAndInstall(isSilent, isForceRunAfter);
        } catch (error) {
          removeUpdateLock();
          // ...error handling...
        }
      }, 3 * 60 * 1000); // 3 minutes
      return;
```
and comment out the code:   
```
      try {
        this.updater.quitAndInstall(isSilent, isForceRunAfter);
      } catch (error) {
        removeUpdateLock();
        const categorized = categorizeUpdateError(error as Error);
        this.logger.error(`Failed to quit and install: ${categorized.details}`);
        this.window?.webContents.send('update:error', {
          type: categorized.type,
          message: categorized.message,
          details: categorized.details,
        });
      }
```
Why: This simulates what happens on a slow laptop. In production, `quitAndInstall()` is called immediately, but the macOS PKG installer itself takes minutes to complete on under-powered hardware. The `setTimeout` delay lets us test the lock behavior during that installation window. The `return;` statement is critical - it exits the function immediately after scheduling the timer, preventing any code after the TEMPORARY block from running.  

2. Build the app with a erarlier version:
 from `front-end/package.json` set the version to some higher "version": "0.25.0"
 then 
`npx electron-builder --mac -c.mac.target=default --arm64`   

3. From `/front-end/release` install the build version  

4. Prepare the “updated” version - from `front-end/package.json` set the version to some higher "version": "0.26.0-SNAPSHOT" and build it again  

5. electron-updater uses a generic provider that fetches update metadata and artifacts from a plain HTTP server. The backend tells the app to look for updates at a URL constructed as:
`${FRONTEND_REPO_URL}/v${LATEST_SUPPORTED_FRONTEND_VERSION}/`
Which resolves to: `http://localhost:8080/v0.26.0-SNAPSHOT/`
`electron-updater` will then fetch `latest-mac.yml`from that URL to discover available updates.
Create the directory structure `mkdir -p ~/update-server/v0.26.0-SNAPSHOT`  
Copy the new version's build artifacts

```
cp front-end/release/latest-mac.yml ~/update-server/v0.26.0-SNAPSHOT/
cp front-end/release/hedera-transaction-tool-0.26.0-SNAPSHOT-mac-arm64.dmg ~/update-server/v0.26.0-SNAPSHOT/
cp front-end/release/hedera-transaction-tool-0.26.0-SNAPSHOT-mac-arm64.zip ~/update-server/v0.26.0-SNAPSHOT/
cp front-end/release/hedera-transaction-tool-0.26.0-SNAPSHOT-mac-arm64.dmg.blockmap ~/update-server/v0.26.0-SNAPSHOT/ 2>/dev/null || true
cp front-end/release/hedera-transaction-tool-0.26.0-SNAPSHOT-mac-arm64.zip.blockmap ~/update-server/v0.26.0-SNAPSHOT/ 2>/dev/null || true
```

Start the static file server In a dedicated terminal (keep this running): 

` npx http-server ~/update-server -p 8080 --cors`

Verify the server is working:

`curl "http://localhost:8080/v0.26.0-SNAPSHOT/latest-mac.yml?noCache=1jiap0md3"`

You should see YAML output like:

```
version: 0.26.0-SNAPSHOT
files:
  - url: hedera-transaction-tool-0.26.0-SNAPSHOT-mac-arm64.dmg
    sha512: <hash>
    size: <size>
path: hedera-transaction-tool-0.26.0-SNAPSHOT-mac-arm64.dmg
sha512: <hash>
releaseDate: '2026-...'
```

6. Configure and Start the Backend:
The backend's `POST /users/version-check` endpoint tells the frontend which versions are available and where to download them.

Verify the backend environment variables
File: `back-end/apps/api/.env`
Ensure these three variables are set: 

```
LATEST_SUPPORTED_FRONTEND_VERSION=0.26.0-SNAPSHOT
MINIMUM_SUPPORTED_FRONTEND_VERSION=0.21.0
FRONTEND_REPO_URL=http://localhost:8080
```

If you want a mandatory (non-dismissable) update instead: 
Set `MINIMUM_SUPPORTED_FRONTEND_VERSION=0.26.0-SNAPSHOT`. 

Start the backend:

```
cd back-end
docker-compose up
```

and wait for it to start

 7. Run the Old Version and Trigger the Update - You must have a localhost organization created for this to work - `http://localhost:3001`  

8. Follow the update flow
<img width="367" height="320" alt="Update Available" src="https://github.com/user-attachments/assets/751fedae-e016-42e9-a09e-e817f5f8c9d1" />

<img width="377" height="305" alt="Update Ready to Install" src="https://github.com/user-attachments/assets/80119c62-a7b3-4aa7-9624-3622a8d822b3" />

9. Squirrel.Mac requires code-signed apps, so as far as I understand  local unsigned builds will always fail at the installation step with a code signature error. You will find the app on the desktop and will have to manually install it. 
<img width="754" height="445" alt="•  Hedera Transaction Tool 0 26 0-SNAPSHOT-arm64" src="https://github.com/user-attachments/assets/9b03febc-0db1-499c-acc1-79c70243bf62" />

You will see this message if you close the app and try to open it again without having the new version installed:
<img width="293" height="235" alt="Hedera Transaction Tool is" src="https://github.com/user-attachments/assets/e99d8de6-a7ea-4a14-b30f-4ff3ccf08ac8" />

