### PR TITLE
fix: adding missing await in main/index.ts

### DIFF
--- a/front-end/src/main/index.ts
+++ b/front-end/src/main/index.ts
@@ -125,7 +125,7 @@ if (!gotTheLock) {
     mainWindow.focus();
   });
 
-  run();
+  await run();
 
   attachAppEvents();
   setupDeepLink();


### PR DESCRIPTION
**Description**:
One-line change which adds a missing `await` operator in `front-end/src/main/index.ts`.
This code is the starting sequence of TT : missing `await` like this might be cause of flakiness.

**Notes for reviewer**:

Interesting notes in electronjs doc:
https://www.electronjs.org/docs/latest/tutorial/esm#caveats

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
