### PR TITLE
feat: InstallUpgrade vue now invites user to wait for app restart.

### DIFF
--- a/front-end/src/renderer/components/GlobalAppProcesses/components/InstallUpgrade.vue
+++ b/front-end/src/renderer/components/GlobalAppProcesses/components/InstallUpgrade.vue
@@ -27,6 +27,12 @@ const handleInstall = () => emit('install');
       Version {{ version }} has been downloaded.<br />
       The application will restart to install the update.
     </p>
+    <div class="alert alert-info mt-3" role="alert">
+      <p class="text-small mb-0">
+        Installing update may take several minutes.<br />
+        Please <b>wait</b> until application restarts.<br />
+      </p>
+    </div>
     <hr class="separator my-4" />
     <div class="d-flex gap-4 justify-content-center">
       <AppButton


### PR DESCRIPTION
**Description**:

Changes below update message displayed by `InstallUpgrade` view.
New message now prominently invites user to wait for application restart.

**Related issue(s)**:

Fixes #2365

**Notes for reviewer**:

Before

<img width="393" height="299" alt="image" src="https://github.com/user-attachments/assets/3e0a2547-8f5f-4d87-96d0-f4d511b82baa" />


After

<img width="398" height="443" alt="image" src="https://github.com/user-attachments/assets/0244059f-789d-4216-8c6b-9169bfb49090" />


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
