### PR TITLE
test: another attempt to fix flaky test in transactions.spec.ts.

### DIFF
--- a/front-end/src/tests/main/services/localUser/transactions.spec.ts
+++ b/front-end/src/tests/main/services/localUser/transactions.spec.ts
@@ -487,7 +487,9 @@ describe('Services Local User Transactions', () => {
       },
     );
 
-    test('Should write response to file without fileId and show in folder if response is a large buffer', async () => {
+    test('Should write response to file without fileId and show in folder if response is a large buffer',
+      { timeout: 20 * 1_000 },
+      async () => {
       const queryBytes = new Uint8Array([1, 2, 3]);
       const accountId = '0.0.1234';
       const privateKey = '302e020100300506032b657004220420';


### PR DESCRIPTION
**Description**:

Another attempt to fix flaky unit test in `transactions.spec.ts`:
```
Should write response to file without fileId and show in folder if response is a large buffer
```
This test is preceded by a very similar test which is not flaky. One difference is the timeout:
- 20s for the non flaky
- default for the flaky

Changes below update timeout of the flaky test to `20s`.

**Related issue(s)**:

None

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
