### PR TITLE
fix: Current Password and New Password fields are now reset after change

### DIFF
--- a/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
@@ -113,6 +113,8 @@ const handleChangePassword = async () => {
     toastManager.error(getErrorMessage(error, 'Failed to change password'));
   } finally {
     isChangingPassword.value = false;
+    currentPassword.value = '';
+    newPassword.value = '';
   }
 };
 


### PR DESCRIPTION
**Description**:
Changes below update ProfileTab view so that it resets Current Password and New Password fields after change.

**Related issue(s)**:

Fixes #2384 

**Notes for reviewer**:

```
M    front-end/src/renderer/pages/Settings/components/ProfileTab.vue
     // ProfileTab.handleChangePassword() now resets currentPassword and newPassword after completion
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
