### PR TITLE
chore: increasing strictness during vue compilation

### DIFF
--- a/front-end/tsconfig.web.json
+++ b/front-end/tsconfig.web.json
@@ -35,5 +35,14 @@
     "noUncheckedIndexedAccess": false,
 
     "preserveSymlinks": true
+  },
+  "vueCompilerOptions": {
+    "strictVModel": true,
+    "strictCssModules": true,
+    "checkUnknownProps": false,
+    "checkUnknownEvents": true,
+    "checkUnknownDirectives": true,
+    "checkUnknownComponents": true,
+    "checkUnknownDirectives": true
   }
 }


### PR DESCRIPTION
**Description**:

Changes below update `tsconfig.web.json` and add vue compiler flags for stricter checking:
```
 "vueCompilerOptions": {
    "strictVModel": true,
    "strictCssModules": true,
    "checkUnknownProps": false,
    "checkUnknownEvents": true,
    "checkUnknownDirectives": true,
    "checkUnknownComponents": true,
    "checkUnknownDirectives": true
  }
```

`checkUnknownProps` flag remains to `false` because TT code highly relies on implicit props usage (when set to `true`, vue compiler reports 344 errors).


**Related issue(s)**:

_None_

**Notes for reviewer**:

No code change. Only build factory change.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
