### PR TITLE
chore: bump frontend version to 0.27.0-SNAPSHOT in configuration files

### DIFF
--- a/back-end/apps/api/package.json
+++ b/back-end/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/api",
-  "version": "0.26.0-SNAPSHOT",
+  "version": "0.27.0-SNAPSHOT",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/chain/package.json
+++ b/back-end/apps/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/chain",
-  "version": "0.26.0-SNAPSHOT",
+  "version": "0.27.0-SNAPSHOT",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/notifications/package.json
+++ b/back-end/apps/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/notifications",
-  "version": "0.26.0-SNAPSHOT",
+  "version": "0.27.0-SNAPSHOT",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/k8s/dev/deployments/api-deployment.yaml
+++ b/back-end/k8s/dev/deployments/api-deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - name: GLOBAL_SECOND_LIMIT
               value: '1000'
             - name: LATEST_SUPPORTED_FRONTEND_VERSION
-              value: '0.26.0-SNAPSHOT'
+              value: '0.27.0-SNAPSHOT'
             - name: MINIMUM_SUPPORTED_FRONTEND_VERSION
               value: '0.23.0'
             - name: FRONTEND_REPO_URL

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "back-end",
-  "version": "0.26.0-SNAPSHOT",
+  "version": "0.27.0-SNAPSHOT",
   "description": "",
   "author": "",
   "private": true,

--- a/back-end/typeorm/package.json
+++ b/back-end/typeorm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.26.0-SNAPSHOT",
+  "version": "0.27.0-SNAPSHOT",
   "private": true,
   "scripts": {
     "build": "tsc",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-transaction-tool",
-  "version": "0.26.0-SNAPSHOT",
+  "version": "0.27.0-SNAPSHOT",
   "description": "Transaction tool application",
   "author": {
     "name": "Hedera",


### PR DESCRIPTION
**Description**:
This pull request updates the project version across multiple packages and deployment configuration files from `0.26.0-SNAPSHOT` to `0.27.0-SNAPSHOT`. This is a routine version bump to indicate new development changes and ensure consistency across the codebase.

Version updates:

* Updated the version field to `0.27.0-SNAPSHOT` in `back-end/package.json`, `back-end/apps/api/package.json`, `back-end/apps/chain/package.json`, `back-end/apps/notifications/package.json`, `back-end/typeorm/package.json`, and `front-end/package.json`. [[1]](diffhunk://#diff-d1c5d2322c31c65053bc0b5356afe6821cc44aa37a8733f5c0227e0f3c053e35L3-R3) [[2]](diffhunk://#diff-99b1c8b2f8265809468bda8592450aee836bcc51d4a1f2f2cd716e49c6fe58c3L3-R3) [[3]](diffhunk://#diff-2ad1bc17da00af17ba969215f351a7981db8c4920aa70ca37c8545607c59dfb6L3-R3) [[4]](diffhunk://#diff-df4fdc006a9461f8a8131afed679b1fb80743c91216998c32bf0b4679f675973L3-R3) [[5]](diffhunk://#diff-734f8b0d49eec4ad207e761f0eaefdbc8187c6ab63ee39c343b2661d5b065fbbL3-R3) [[6]](diffhunk://#diff-f573261b8354834cb5d2110af3a0e0e20157fa2fe40af594186b2a715a306ea0L3-R3)

Deployment configuration update:

* Updated the `LATEST_SUPPORTED_FRONTEND_VERSION` environment variable in `back-end/k8s/dev/deployments/api-deployment.yaml` to `0.27.0-SNAPSHOT`.
