### PR TITLE
feat: support playwright attach mode

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -10,8 +10,11 @@ Before you begin, ensure you have the following installed on your system:
 
 - Node.js: `20.17.0`
 
-Additionally, you should have the Hedera Transaction Tool executable installed and know its path, as it will be required
-to run the tests.
+Additionally, you should either:
+
+- have the Hedera Transaction Tool executable installed and know its path, or
+- run the front-end Electron app in dev mode with remote debugging enabled if you want to attach to an existing app
+  instance.
 
 ## Setup
 
@@ -34,10 +37,12 @@ to run the tests.
    pnpm approve-builds # if required by pnpm install
    ```
 
-4. **Configure the environment variables** by creating a `.env` file in the root of the project and setting the path to
-   the Hedera Transaction Tool executable. For example:
+4. **Configure the environment variables** by creating a `.env` file in the root of the project.
+
+   Launch mode example:
 
    ```env
+   ELECTRON_APP_MODE='launch'
    EXECUTABLE_PATH='/path/to/Hedera Transaction Tool'
    PRIVATE_KEY='your_private_key_here'
    ENVIRONMENT='LOCALNET'
@@ -48,6 +53,21 @@ to run the tests.
    POSTGRES_DATABASE: Name of your PostgreSQL database
    POSTGRES_USERNAME: Username for your PostgreSQL database
    POSTGRES_PASSWORD: Password for your PostgreSQL database
+   ```
+
+   Attach mode example:
+
+   ```env
+   ELECTRON_APP_MODE='attach'
+   ELECTRON_ATTACH_URL='http://127.0.0.1:9222'
+   PRIVATE_KEY='your_private_key_here'
+   ENVIRONMENT='LOCALNET'
+   ```
+
+   If you use attach mode, start the front-end first from `front-end/`:
+
+   ```bash
+   PLAYWRIGHT_TEST=true ELECTRON_REMOTE_DEBUGGING_PORT=9222 pnpm dev
    ```
 
    Replace `ENVIRONMENT` with variable that can be set to `TESTNET`, `PREVIEWNET` or `LOCALNET`.

--- a/automation/example.env
+++ b/automation/example.env
@@ -1,4 +1,10 @@
+ELECTRON_APP_MODE='launch'
 EXECUTABLE_PATH='/Applications/Hedera Transaction Tool.app/Contents/MacOS/Hedera Transaction Tool'
+# Attach mode options:
+# ELECTRON_APP_MODE='attach'
+# ELECTRON_ATTACH_URL='http://127.0.0.1:9222'
+# ELECTRON_REMOTE_DEBUGGING_PORT='9222'
+# ELECTRON_ATTACH_TIMEOUT_MS='30000'
 ORGANIZATION_URL='https://localhost:3001'
 
 PRIVATE_KEY= # hex encoded

--- a/automation/pages/SettingsPage.ts
+++ b/automation/pages/SettingsPage.ts
@@ -137,16 +137,10 @@ export class SettingsPage extends BasePage {
 
     while (attempt < maxRetries) {
       await this.click(this.restoreButtonSelector);
-      try {
-        await this.waitForElementToBeVisible(
-          this.continuePhraseButtonSelector,
-          this.LONG_TIMEOUT,
-        );
+      if (await this.isElementVisible(this.continuePhraseButtonSelector)) {
         return;
-      } catch {
-        attempt++;
-        await new Promise(resolve => setTimeout(resolve, this.SHORT_TIMEOUT / 2));
       }
+      attempt++;
     }
 
     throw new Error(

--- a/automation/services/AppBootstrapper.ts
+++ b/automation/services/AppBootstrapper.ts
@@ -1,5 +1,9 @@
-import { ElectronApplication, Page } from '@playwright/test';
-import { launchHederaTransactionTool as defaultLaunchHederaTransactionTool } from '../utils/electronAppLauncher.js';
+import { Page } from '@playwright/test';
+import {
+  launchHederaTransactionTool as defaultLaunchHederaTransactionTool,
+  type LaunchHederaTransactionToolOptions,
+  type TransactionToolApp,
+} from '../utils/electronAppLauncher.js';
 import { migrationDataExists as defaultMigrationDataExists } from '../utils/oldTools.js';
 import { LoginPage as DefaultLoginPage } from '../pages/LoginPage.js';
 
@@ -24,9 +28,11 @@ interface AppBootstrapperDependencies {
 }
 
 export interface SetupAppResult {
-  app: ElectronApplication;
+  app: TransactionToolApp;
   window: Page;
 }
+
+export interface SetupAppOptions extends LaunchHederaTransactionToolOptions {}
 
 export class AppBootstrapper {
   private readonly launchApp: typeof defaultLaunchHederaTransactionTool;
@@ -43,11 +49,11 @@ export class AppBootstrapper {
     this.LoginPageClass = LoginPage;
   }
 
-  async setupApp(): Promise<SetupAppResult> {
+  async setupApp(options: SetupAppOptions = {}): Promise<SetupAppResult> {
     console.log(asciiArt);
 
-    console.log('[setupApp] Launching Hedera Transaction Tool...');
-    const app = await this.launchApp();
+    console.log('[setupApp] Initializing Hedera Transaction Tool session...');
+    const app = await this.launchApp(options);
 
     const window = await app.firstWindow();
     await window.waitForLoadState('domcontentloaded');
@@ -63,7 +69,7 @@ export class AppBootstrapper {
     console.log('[setupApp] Handling startup modals...');
     await loginPage.closeImportantNoteModal();
 
-    const canMigrate = await this.canMigrateData(app);
+    const canMigrate = await this.canMigrateData(window);
     console.log(`[setupApp] migrationDataExists: ${canMigrate}`);
 
     if (canMigrate) {
@@ -89,16 +95,20 @@ export class AppBootstrapper {
     return { app, window };
   }
 
-  async resetAppState(window: Page, app: ElectronApplication): Promise<void> {
+  async resetAppState(window: Page, _app: TransactionToolApp): Promise<void> {
     const loginPage = this.createLoginPage(window);
     await loginPage.resetState();
-    const canMigrate = await this.canMigrateData(app);
+    const canMigrate = await this.canMigrateData(window);
     if (canMigrate) {
       await loginPage.closeMigrationModal();
     }
   }
 
-  async closeApp(app: ElectronApplication): Promise<void> {
+  async closeApp(app?: TransactionToolApp | null): Promise<void> {
+    if (!app) {
+      return;
+    }
+
     await app.close();
   }
 

--- a/automation/tests/groupTransactionTests.test.ts
+++ b/automation/tests/groupTransactionTests.test.ts
@@ -1,4 +1,4 @@
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { RegistrationPage } from '../pages/RegistrationPage.js';
 import { TransactionPage } from '../pages/TransactionPage.js';
 import { GroupPage } from '../pages/GroupPage.js';
@@ -11,7 +11,7 @@ import {
   setupEnvironmentForTransactions,
 } from '../utils/automationSupport.js';
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let globalCredentials = { email: '', password: '' };
 let registrationPage: RegistrationPage;

--- a/automation/tests/loginTests.test.ts
+++ b/automation/tests/loginTests.test.ts
@@ -1,4 +1,4 @@
-import { ElectronApplication, Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { test, expect } from '@playwright/test';
 import {
   setupApp,
@@ -11,7 +11,7 @@ import { RegistrationPage } from '../pages/RegistrationPage.js';
 import { LoginPage } from '../pages/LoginPage.js';
 import { resetDbState } from '../utils/databaseUtil.js';
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 const globalCredentials = { email: '', password: '' };
 let registrationPage: RegistrationPage;

--- a/automation/tests/organizationContactListTests.test.ts
+++ b/automation/tests/organizationContactListTests.test.ts
@@ -1,4 +1,4 @@
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { RegistrationPage } from '../pages/RegistrationPage.js';
 import { OrganizationPage, UserDetails } from '../pages/OrganizationPage.js';
 import { ContactListPage } from '../pages/ContactListPage.js';
@@ -11,7 +11,7 @@ import {
   setupEnvironmentForTransactions,
 } from '../utils/automationSupport.js';
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let globalCredentials = { email: '', password: '' };
 let registrationPage: RegistrationPage;

--- a/automation/tests/organizationGroupTests.test.ts
+++ b/automation/tests/organizationGroupTests.test.ts
@@ -1,4 +1,4 @@
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { RegistrationPage } from '../pages/RegistrationPage.js';
 import { OrganizationPage, UserDetails } from '../pages/OrganizationPage.js';
 import { LoginPage } from '../pages/LoginPage.js';
@@ -14,7 +14,7 @@ import {
 } from '../utils/automationSupport.js';
 import { disableNotificationsForTestUsers } from '../utils/databaseQueries.js';
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let globalCredentials = { email: '', password: '' };
 let loginPage: LoginPage;

--- a/automation/tests/organizationNotificationTests.test.ts
+++ b/automation/tests/organizationNotificationTests.test.ts
@@ -1,4 +1,4 @@
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { RegistrationPage } from '../pages/RegistrationPage.js';
 import { TransactionPage } from '../pages/TransactionPage.js';
 import { OrganizationPage, UserDetails } from '../pages/OrganizationPage.js';
@@ -17,7 +17,7 @@ import {
   getNotifiedTransactionIdByEmail,
 } from '../utils/databaseQueries.js';
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let globalCredentials = { email: '', password: '' };
 

--- a/automation/tests/organizationRegressionTests.test.ts
+++ b/automation/tests/organizationRegressionTests.test.ts
@@ -1,4 +1,4 @@
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { RegistrationPage } from '../pages/RegistrationPage.js';
 import { TransactionPage } from '../pages/TransactionPage.js';
 import { OrganizationPage, UserDetails } from '../pages/OrganizationPage.js';
@@ -15,7 +15,7 @@ import {
 } from '../utils/automationSupport.js';
 import { disableNotificationsForTestUsers } from '../utils/databaseQueries.js';
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let globalCredentials = { email: '', password: '' };
 

--- a/automation/tests/organizationSettingsTests.test.ts
+++ b/automation/tests/organizationSettingsTests.test.ts
@@ -1,4 +1,4 @@
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { RegistrationPage } from '../pages/RegistrationPage.js';
 import { LoginPage } from '../pages/LoginPage.js';
 import { TransactionPage } from '../pages/TransactionPage.js';
@@ -13,7 +13,7 @@ import {
   setupEnvironmentForTransactions,
 } from '../utils/automationSupport.js';
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let globalCredentials = { email: '', password: '' };
 

--- a/automation/tests/organizationTransactionTests.test.ts
+++ b/automation/tests/organizationTransactionTests.test.ts
@@ -1,4 +1,4 @@
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { OrganizationPage, UserDetails } from '../pages/OrganizationPage.js';
 import { RegistrationPage } from '../pages/RegistrationPage.js';
 import { TransactionPage } from '../pages/TransactionPage.js';
@@ -8,6 +8,7 @@ import {
   closeApp,
   generateRandomEmail,
   generateRandomPassword,
+  setDialogMockState,
   setupApp,
   setupEnvironmentForTransactions,
   waitAndReadFile,
@@ -19,7 +20,7 @@ import * as path from 'node:path';
 import * as fsp from 'fs/promises';
 import JSZip from 'jszip';
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let globalCredentials = { email: '', password: '' };
 
@@ -92,25 +93,12 @@ test.describe('Organization Transaction tests', () => {
     complexKeyAccountId = organizationPage.getComplexAccountId();
     await transactionPage.clickOnTransactionsMenuButton();
     await organizationPage.logoutFromOrganization();
-
-    await app.evaluate(({ dialog }) => {
-      (dialog as unknown as { _savePath: string | null })._savePath = null;
-      (dialog as unknown as { _openPaths: string[] })._openPaths = [];
-
-      dialog.showSaveDialog = async () => ({
-        canceled: false,
-        filePath: (dialog as unknown as { _savePath: string | null })?._savePath ?? '',
-      });
-      dialog.showOpenDialog = async () => ({
-        canceled: false,
-        filePaths: (dialog as unknown as { _openPaths: string[] })?._openPaths ?? [],
-      });
-    });
   });
 
   test.beforeEach(async () => {
     // Flush rate limiter before each test to prevent "too many requests" errors
     await flushRateLimiter();
+    await setDialogMockState(window, { savePath: null, openPaths: [] });
 
     await organizationPage.signInOrganization(
       firstUser.email,
@@ -602,12 +590,7 @@ test.describe('Organization Transaction tests', () => {
       await fsp.rm(exportDir, { recursive: true, force: true });
       await fsp.mkdir(exportDir, { recursive: true });
 
-      await app.evaluate(
-        ({ dialog }, { savePath }) => {
-          (dialog as unknown as { _savePath: string })._savePath = savePath;
-        },
-        { savePath },
-      );
+      await setDialogMockState(window, { savePath });
     });
 
     test.afterEach(async () => {
@@ -651,12 +634,7 @@ test.describe('Organization Transaction tests', () => {
       }
 
       // import signatures
-      await app.evaluate(
-        ({ dialog }, { openPaths }) => {
-          (dialog as unknown as { _openPaths: string[] })._openPaths = openPaths;
-        },
-        { openPaths },
-      );
+      await setDialogMockState(window, { openPaths });
       await transactionPage.importV1Signatures();
 
       // Wait for the transaction to execute
@@ -707,12 +685,7 @@ test.describe('Organization Transaction tests', () => {
       await organizationPage.clickOnSignTransactionButton();
 
       // import signatures
-      await app.evaluate(
-        ({ dialog }, { openPaths }) => {
-          (dialog as unknown as { _openPaths: string[] })._openPaths = openPaths;
-        },
-        { openPaths },
-      );
+      await setDialogMockState(window, { openPaths });
       await transactionPage.importV1Signatures();
 
       // Wait for the transaction to execute
@@ -769,12 +742,7 @@ test.describe('Organization Transaction tests', () => {
       );
 
       // import signatures
-      await app.evaluate(
-        ({ dialog }, { openPaths }) => {
-          (dialog as unknown as { _openPaths: string[] })._openPaths = openPaths;
-        },
-        { openPaths },
-      );
+      await setDialogMockState(window, { openPaths });
       await transactionPage.clickOnTransactionsMenuButton();
       await transactionPage.clickOnImportButton();
       //expect import button is disabled

--- a/automation/tests/registrationTests.test.ts
+++ b/automation/tests/registrationTests.test.ts
@@ -1,9 +1,9 @@
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { resetDbState } from '../utils/databaseUtil.js';
 import { closeApp, generateRandomEmail, generateRandomPassword, setupApp } from '../utils/automationSupport.js';
 import { RegistrationPage } from '../pages/RegistrationPage.js';
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let globalCredentials = { email: '', password: '' };
 let registrationPage: RegistrationPage;

--- a/automation/tests/settingsTests.test.ts
+++ b/automation/tests/settingsTests.test.ts
@@ -1,4 +1,4 @@
-import { ElectronApplication, Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { test, expect } from '@playwright/test';
 import { RegistrationPage } from '../pages/RegistrationPage.js';
 import { LoginPage } from '../pages/LoginPage.js';
@@ -13,7 +13,7 @@ import {
 } from '../utils/automationSupport.js';
 import { generateECDSAKeyPair, generateEd25519KeyPair } from '../utils/keyUtil.js';
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 const globalCredentials = { email: '', password: '' };
 let registrationPage: RegistrationPage;

--- a/automation/tests/transactionTests.test.ts
+++ b/automation/tests/transactionTests.test.ts
@@ -1,4 +1,4 @@
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { RegistrationPage } from '../pages/RegistrationPage.js';
 import { LoginPage } from '../pages/LoginPage.js';
 import { TransactionPage } from '../pages/TransactionPage.js';
@@ -14,7 +14,7 @@ import {
 import { Transaction } from '../../front-end/src/shared/interfaces/index.js';
 import { SettingsPage } from '../pages/SettingsPage.js';
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 const globalCredentials = { email: '', password: '' };
 let registrationPage: RegistrationPage;

--- a/automation/tests/ui-performance/accountsPerformance.test.ts
+++ b/automation/tests/ui-performance/accountsPerformance.test.ts
@@ -7,7 +7,7 @@
  * Note: UI paginates at max 50 items per page.
  */
 
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { closeApp, setupApp } from '../../utils/automationSupport.js';
 import { resetDbState } from '../../utils/databaseUtil.js';
 import { RegistrationPage } from '../../pages/RegistrationPage.js';
@@ -27,7 +27,7 @@ import { SELECTORS } from './selectors.js';
 const DB_ITEM_COUNT = DATA_VOLUMES.ACCOUNTS;
 const MIN_ROWS = 50; // Strict: require at least 50 rows rendered
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let registrationPage: RegistrationPage;
 let testEmail: string;

--- a/automation/tests/ui-performance/contactsPerformance.test.ts
+++ b/automation/tests/ui-performance/contactsPerformance.test.ts
@@ -5,7 +5,7 @@
  * Data source: Backend PostgreSQL (org users appear as contacts)
  */
 
-import { test, expect, ElectronApplication, Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import * as dotenv from 'dotenv';
 import { setupApp, closeApp } from '../../utils/automationSupport.js';
 import { resetDbState, resetPostgresDbState } from '../../utils/databaseUtil.js';
@@ -29,7 +29,7 @@ dotenv.config();
 const DB_ITEM_COUNT = DATA_VOLUMES.CONTACTS;
 const MIN_CONTACTS = 50; // Strict: require at least 50 contacts rendered
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let registrationPage: RegistrationPage;
 let organizationPage: OrganizationPage;

--- a/automation/tests/ui-performance/draftsPerformance.test.ts
+++ b/automation/tests/ui-performance/draftsPerformance.test.ts
@@ -7,7 +7,7 @@
  * Note: UI paginates at max 50 items per page.
  */
 
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { closeApp, setupApp } from '../../utils/automationSupport.js';
 import { resetDbState } from '../../utils/databaseUtil.js';
 import { RegistrationPage } from '../../pages/RegistrationPage.js';
@@ -30,7 +30,7 @@ import { SELECTORS } from './selectors.js';
 const DB_ITEM_COUNT = DATA_VOLUMES.DRAFTS;
 const REQUIRED_TOTAL = DATA_VOLUMES.DRAFTS;
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let registrationPage: RegistrationPage;
 let testEmail: string;

--- a/automation/tests/ui-performance/filesPerformance.test.ts
+++ b/automation/tests/ui-performance/filesPerformance.test.ts
@@ -7,7 +7,7 @@
  * Note: UI paginates at max 50 items per page.
  */
 
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { closeApp, setupApp } from '../../utils/automationSupport.js';
 import { resetDbState } from '../../utils/databaseUtil.js';
 import { RegistrationPage } from '../../pages/RegistrationPage.js';
@@ -27,7 +27,7 @@ import { SELECTORS } from './selectors.js';
 const DB_ITEM_COUNT = DATA_VOLUMES.FILES;
 const MIN_ROWS = 50; // Strict: require at least 50 rows rendered
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let registrationPage: RegistrationPage;
 let testEmail: string;

--- a/automation/tests/ui-performance/historyPerformance.test.ts
+++ b/automation/tests/ui-performance/historyPerformance.test.ts
@@ -12,7 +12,7 @@
  * If pagination is used, it verifies at least the first page loads quickly.
  */
 
-import { test, expect, ElectronApplication, Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import * as dotenv from 'dotenv';
 import { setupApp, closeApp } from '../../utils/automationSupport.js';
 import { resetDbState } from '../../utils/databaseUtil.js';
@@ -35,7 +35,7 @@ dotenv.config();
 // Volume requirement from k6 constants (SSOT)
 const REQUIRED_TOTAL = DATA_VOLUMES.HISTORY;
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let registrationPage: RegistrationPage;
 let organizationPage: OrganizationPage;

--- a/automation/tests/ui-performance/historyPerformanceLocal.test.ts
+++ b/automation/tests/ui-performance/historyPerformanceLocal.test.ts
@@ -11,7 +11,7 @@
  * - NO backend required (local SQLite only)
  */
 
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { closeApp, setupApp } from '../../utils/automationSupport.js';
 import { resetDbState } from '../../utils/databaseUtil.js';
 import { RegistrationPage } from '../../pages/RegistrationPage.js';
@@ -32,7 +32,7 @@ import { SELECTORS } from './selectors.js';
 const DB_ITEM_COUNT = DATA_VOLUMES.HISTORY;
 const MIN_ROWS = 10; // Minimum rows to verify rendering
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let registrationPage: RegistrationPage;
 let testEmail: string;

--- a/automation/tests/ui-performance/inProgressPerformance.test.ts
+++ b/automation/tests/ui-performance/inProgressPerformance.test.ts
@@ -12,7 +12,7 @@
  * - Run: npm run k6:seed:all
  */
 
-import { test, expect, ElectronApplication, Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import * as dotenv from 'dotenv';
 import { setupApp, closeApp } from '../../utils/automationSupport.js';
 import { resetDbState } from '../../utils/databaseUtil.js';
@@ -35,7 +35,7 @@ dotenv.config();
 // In Progress shows WAITING_FOR_SIGNATURES transactions (same as Ready to Sign)
 const REQUIRED_TOTAL = DATA_VOLUMES.READY_TO_SIGN;
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let registrationPage: RegistrationPage;
 let organizationPage: OrganizationPage;

--- a/automation/tests/ui-performance/readyForExecutionPerformance.test.ts
+++ b/automation/tests/ui-performance/readyForExecutionPerformance.test.ts
@@ -12,7 +12,7 @@
  * - Run: npm run k6:seed:all
  */
 
-import { test, expect, ElectronApplication, Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import * as dotenv from 'dotenv';
 import { setupApp, closeApp } from '../../utils/automationSupport.js';
 import { resetDbState } from '../../utils/databaseUtil.js';
@@ -35,7 +35,7 @@ dotenv.config();
 // Volume requirement from k6 constants (SSOT)
 const REQUIRED_TOTAL = DATA_VOLUMES.READY_FOR_EXECUTION;
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let registrationPage: RegistrationPage;
 let organizationPage: OrganizationPage;

--- a/automation/tests/ui-performance/readyForReviewPerformance.test.ts
+++ b/automation/tests/ui-performance/readyForReviewPerformance.test.ts
@@ -9,7 +9,7 @@
  * - Run: npm run k6:seed:all
  */
 
-import { test, expect, ElectronApplication, Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import * as dotenv from 'dotenv';
 import { setupApp, closeApp } from '../../utils/automationSupport.js';
 import { resetDbState } from '../../utils/databaseUtil.js';
@@ -32,7 +32,7 @@ dotenv.config();
 // Volume requirement from k6 constants (SSOT)
 const REQUIRED_TOTAL = DATA_VOLUMES.READY_FOR_REVIEW;
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let registrationPage: RegistrationPage;
 let organizationPage: OrganizationPage;

--- a/automation/tests/ui-performance/readyToSignPerformance.test.ts
+++ b/automation/tests/ui-performance/readyToSignPerformance.test.ts
@@ -9,7 +9,7 @@
  * - Run: npm run k6:seed:all
  */
 
-import { test, expect, ElectronApplication, Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import * as dotenv from 'dotenv';
 import { setupApp, closeApp } from '../../utils/automationSupport.js';
 import { resetDbState } from '../../utils/databaseUtil.js';
@@ -33,7 +33,7 @@ dotenv.config();
 // Volume requirement from k6 constants (SSOT)
 const REQUIRED_TOTAL = DATA_VOLUMES.READY_TO_SIGN;
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let registrationPage: RegistrationPage;
 let organizationPage: OrganizationPage;

--- a/automation/tests/ui-performance/signAllComplexKeyPerformance.test.ts
+++ b/automation/tests/ui-performance/signAllComplexKeyPerformance.test.ts
@@ -10,7 +10,7 @@
  * - We can seed 17+ keys directly into user_key table
  */
 
-import { test, expect, ElectronApplication, Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import * as dotenv from 'dotenv';
 import { setupApp, closeApp } from '../../utils/automationSupport.js';
 import { resetDbState, resetPostgresDbState } from '../../utils/databaseUtil.js';
@@ -65,7 +65,7 @@ function validateStagingConfig(): void {
   console.log(`Staging mode: Using pre-created account ${process.env.COMPLEX_KEY_ACCOUNT_ID}`);
 }
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let registrationPage: RegistrationPage;
 let organizationPage: OrganizationPage;

--- a/automation/tests/ui-performance/signAllPerformance.test.ts
+++ b/automation/tests/ui-performance/signAllPerformance.test.ts
@@ -18,7 +18,7 @@
  * - Backend processing speed
  */
 
-import { test, expect, ElectronApplication, Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import * as dotenv from 'dotenv';
 import { setupApp, closeApp } from '../../utils/automationSupport.js';
 import { resetDbState } from '../../utils/databaseUtil.js';
@@ -44,7 +44,7 @@ dotenv.config();
 const SIGN_ALL_THRESHOLD_MS = THRESHOLDS.SIGN_ALL_MS;
 const MIN_GROUP_SIZE = DATA_VOLUMES.GROUP_SIZE;
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 let registrationPage: RegistrationPage;
 let organizationPage: OrganizationPage;

--- a/automation/tests/workflowTests.test.ts
+++ b/automation/tests/workflowTests.test.ts
@@ -16,7 +16,7 @@ const DetailsPage = require('../pages/DetailsPage');
 const { resetDbState } = require('../utils/databaseUtil');
 */
 
-import { ElectronApplication, expect, Page, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { RegistrationPage } from '../pages/RegistrationPage.js';
 import { LoginPage } from '../pages/LoginPage.js';
 import { TransactionPage } from '../pages/TransactionPage.js';
@@ -32,7 +32,7 @@ import { AccountPage } from '../pages/AccountPage.js';
 import { FilePage } from '../pages/FilePage.js';
 import { DetailsPage } from '../pages/DetailsPage.js';
 
-let app: ElectronApplication;
+let app: Awaited<ReturnType<typeof setupApp>>['app'];
 let window: Page;
 const globalCredentials = { email: '', password: '' };
 let registrationPage: RegistrationPage;

--- a/automation/utils/automationSupport.ts
+++ b/automation/utils/automationSupport.ts
@@ -1,11 +1,21 @@
-import { ElectronApplication, Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 import * as fsp from 'fs/promises';
 import _ from 'lodash';
 import Diff from 'deep-diff';
 import { AppBootstrapper } from '../services/AppBootstrapper.js';
+import type { SetupAppOptions } from '../services/AppBootstrapper.js';
 import { TransactionEnvironmentConfig } from '../services/TransactionEnvironmentConfig.js';
 import { TransactionEnvironmentService } from '../services/TransactionEnvironmentService.js';
 import { ENVIRONMENT_ENV_VAR } from '../constants/index.js';
+import type { TransactionToolApp } from './electronAppLauncher.js';
+export { clearDialogMockState, setDialogMockState } from './dialogMocks.js';
+export type { DialogMockState } from './dialogMocks.js';
+export type { SetupAppOptions } from '../services/AppBootstrapper.js';
+export type {
+  LaunchHederaTransactionToolOptions,
+  TransactionToolApp,
+  TransactionToolAppMode,
+} from './electronAppLauncher.js';
 
 export { asciiArt, AppBootstrapper } from '../services/AppBootstrapper.js';
 export { TransactionEnvironmentConfig } from '../services/TransactionEnvironmentConfig.js';
@@ -23,15 +33,15 @@ export * from '../constants/index.js';
 const defaultAppBootstrapper = new AppBootstrapper();
 const defaultTransactionEnvironmentConfig = new TransactionEnvironmentConfig();
 
-export async function setupApp() {
-  return defaultAppBootstrapper.setupApp();
+export async function setupApp(options: SetupAppOptions = {}) {
+  return defaultAppBootstrapper.setupApp(options);
 }
 
-export async function resetAppState(window: Page, app: ElectronApplication) {
+export async function resetAppState(window: Page, app: TransactionToolApp) {
   await defaultAppBootstrapper.resetAppState(window, app);
 }
 
-export async function closeApp(app: ElectronApplication) {
+export async function closeApp(app?: TransactionToolApp | null) {
   await defaultAppBootstrapper.closeApp(app);
 }
 

--- a/automation/utils/dialogMocks.ts
+++ b/automation/utils/dialogMocks.ts
@@ -1,0 +1,32 @@
+import { Page } from '@playwright/test';
+
+export interface DialogMockState {
+  savePath?: string | null;
+  openPaths?: string[];
+}
+
+type RendererElectronAPI = typeof globalThis & {
+  electronAPI: {
+    local: {
+      utils: {
+        clearDialogMockState: () => Promise<void>;
+        setDialogMockState: (state: DialogMockState) => Promise<void>;
+      };
+    };
+  };
+};
+
+export async function clearDialogMockState(window: Page): Promise<void> {
+  await window.evaluate(async () => {
+    await (globalThis as RendererElectronAPI).electronAPI.local.utils.clearDialogMockState();
+  });
+}
+
+export async function setDialogMockState(
+  window: Page,
+  dialogMockState: DialogMockState,
+): Promise<void> {
+  await window.evaluate(async state => {
+    await (globalThis as RendererElectronAPI).electronAPI.local.utils.setDialogMockState(state);
+  }, dialogMockState);
+}

--- a/automation/utils/electronAppLauncher.ts
+++ b/automation/utils/electronAppLauncher.ts
@@ -1,9 +1,83 @@
-import { _electron as electron, type ElectronApplication } from '@playwright/test';
+import {
+  _electron as electron,
+  chromium,
+  type Browser,
+  type ElectronApplication,
+  type Page,
+} from '@playwright/test';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
 
-export async function launchHederaTransactionTool(): Promise<ElectronApplication> {
+const DEFAULT_ATTACH_URL = 'http://127.0.0.1:9222';
+const DEFAULT_ATTACH_TIMEOUT_MS = 30_000;
+const WINDOW_POLL_INTERVAL_MS = 250;
+
+export type TransactionToolAppMode = 'launch' | 'attach';
+
+export interface TransactionToolApp {
+  readonly mode: TransactionToolAppMode;
+  firstWindow(): Promise<Page>;
+  close(): Promise<void>;
+}
+
+export interface LaunchHederaTransactionToolOptions {
+  mode?: TransactionToolAppMode;
+}
+
+class LaunchedTransactionToolApp implements TransactionToolApp {
+  readonly mode = 'launch';
+
+  constructor(private readonly app: ElectronApplication) {}
+
+  async firstWindow(): Promise<Page> {
+    return await this.app.firstWindow();
+  }
+
+  async close(): Promise<void> {
+    await this.app.close();
+  }
+}
+
+class AttachedTransactionToolApp implements TransactionToolApp {
+  readonly mode = 'attach';
+
+  constructor(private readonly browser: Browser) {}
+
+  async firstWindow(): Promise<Page> {
+    return await waitForAttachedWindow(this.browser, getAttachTimeoutMs());
+  }
+
+  async close(): Promise<void> {
+    console.log('[ElectronLauncher] Leaving attached Electron app running.');
+  }
+}
+
+let attachedAppPromise: Promise<TransactionToolApp> | null = null;
+
+export async function launchHederaTransactionTool(
+  { mode = getLaunchMode() }: LaunchHederaTransactionToolOptions = {},
+): Promise<TransactionToolApp> {
+  if (mode === 'attach') {
+    return await attachToHederaTransactionTool();
+  }
+
+  return await launchNewHederaTransactionTool();
+}
+
+function getLaunchMode(): TransactionToolAppMode {
+  const mode = process.env.ELECTRON_APP_MODE?.trim() ?? 'launch';
+
+  if (mode === 'launch' || mode === 'attach') {
+    return mode;
+  }
+
+  throw new Error(
+    `Invalid ELECTRON_APP_MODE "${mode}". Expected "launch" or "attach".`,
+  );
+}
+
+async function launchNewHederaTransactionTool(): Promise<TransactionToolApp> {
   const executablePath = process.env.EXECUTABLE_PATH;
 
   if (!executablePath) {
@@ -18,6 +92,10 @@ export async function launchHederaTransactionTool(): Promise<ElectronApplication
 
   const app = await electron.launch({
     executablePath,
+    env: {
+      ...process.env,
+      PLAYWRIGHT_TEST: 'true',
+    },
     // These args are passed to Electron/Chromium. Crucial for CI when using mkcert/self-signed TLS.
     args: [
       '--ignore-certificate-errors',
@@ -26,17 +104,120 @@ export async function launchHederaTransactionTool(): Promise<ElectronApplication
       '--disable-dev-shm-usage',
     ],
   });
+  const wrappedApp = new LaunchedTransactionToolApp(app);
 
   const launchTime = Date.now() - launchStart;
   console.log(`[ElectronLauncher] Electron process launched in ${launchTime} ms`);
 
   const windowStart = Date.now();
 
-  const firstWindow = await app.firstWindow();
+  const firstWindow = await wrappedApp.firstWindow();
   await firstWindow.waitForLoadState('domcontentloaded');
 
   const windowTime = Date.now() - windowStart;
   console.log(`[ElectronLauncher] First window ready in ${windowTime} ms`);
 
-  return app;
+  return wrappedApp;
+}
+
+async function attachToHederaTransactionTool(): Promise<TransactionToolApp> {
+  if (!attachedAppPromise) {
+    attachedAppPromise = createAttachedTransactionToolApp().catch(error => {
+      attachedAppPromise = null;
+      throw error;
+    });
+  }
+
+  return await attachedAppPromise;
+}
+
+async function createAttachedTransactionToolApp(): Promise<TransactionToolApp> {
+  const endpointURL = getAttachEndpointURL();
+  const timeout = getAttachTimeoutMs();
+
+  console.log('[ElectronLauncher] Attaching to an existing Hedera Transaction Tool instance...');
+  console.log(`[ElectronLauncher] CDP endpoint: ${endpointURL}`);
+
+  const attachStart = Date.now();
+  const browser = await chromium.connectOverCDP(endpointURL, { timeout });
+  const wrappedApp = new AttachedTransactionToolApp(browser);
+
+  const attachTime = Date.now() - attachStart;
+  console.log(`[ElectronLauncher] Attached to Electron in ${attachTime} ms`);
+
+  const windowStart = Date.now();
+  const firstWindow = await wrappedApp.firstWindow();
+  await firstWindow.waitForLoadState('domcontentloaded');
+
+  const windowTime = Date.now() - windowStart;
+  console.log(`[ElectronLauncher] Attached window ready in ${windowTime} ms`);
+
+  return wrappedApp;
+}
+
+function getAttachEndpointURL(): string {
+  const attachURL = process.env.ELECTRON_ATTACH_URL?.trim();
+  if (attachURL) {
+    return attachURL;
+  }
+
+  const remoteDebuggingPort = process.env.ELECTRON_REMOTE_DEBUGGING_PORT?.trim();
+  if (remoteDebuggingPort) {
+    return `http://127.0.0.1:${remoteDebuggingPort}`;
+  }
+
+  return DEFAULT_ATTACH_URL;
+}
+
+function getAttachTimeoutMs(): number {
+  const rawTimeout = process.env.ELECTRON_ATTACH_TIMEOUT_MS?.trim();
+  if (!rawTimeout) {
+    return DEFAULT_ATTACH_TIMEOUT_MS;
+  }
+
+  const timeout = Number(rawTimeout);
+  if (!Number.isFinite(timeout) || timeout <= 0) {
+    throw new Error(
+      `Invalid ELECTRON_ATTACH_TIMEOUT_MS "${rawTimeout}". Expected a positive number.`,
+    );
+  }
+
+  return timeout;
+}
+
+async function waitForAttachedWindow(browser: Browser, timeoutMs: number): Promise<Page> {
+  const startedAt = Date.now();
+  let lastSeenUrls: string[] = [];
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const pages = browser
+      .contexts()
+      .flatMap(context => context.pages());
+
+    lastSeenUrls = pages.map(page => page.url());
+
+    const firstWindow = pages.find(isAppWindow);
+    if (firstWindow) {
+      await firstWindow.bringToFront();
+      return firstWindow;
+    }
+
+    await new Promise(resolve => setTimeout(resolve, WINDOW_POLL_INTERVAL_MS));
+  }
+
+  const details =
+    lastSeenUrls.length > 0
+      ? ` Seen targets: ${lastSeenUrls.join(', ')}`
+      : ' No attachable page targets were discovered.';
+
+  throw new Error(`[ElectronLauncher] Timed out waiting for an Electron window.${details}`);
+}
+
+function isAppWindow(page: Page): boolean {
+  if (page.isClosed()) {
+    return false;
+  }
+
+  const url = page.url();
+  return !url.startsWith('devtools://') && !url.startsWith('chrome-extension://');
 }

--- a/automation/utils/oldTools.ts
+++ b/automation/utils/oldTools.ts
@@ -1,40 +1,17 @@
-import { ElectronApplication } from '@playwright/test';
-import * as path from 'path';
-import * as fs from 'fs';
+import { Page } from '@playwright/test';
 
-/* Old Tools Constants */
-const DEFAULT_FOLDER_NAME = 'TransactionTools';
-const FILES = 'Files';
-const USER_PROPERTIES = 'user.properties';
-const RECOVERY_FILE_PARENT_FOLDER = '.System';
-const RECOVERY_FILE = 'recovery.aes';
+type RendererElectronAPI = typeof globalThis & {
+  electronAPI: {
+    local: {
+      dataMigration: {
+        locateDataMigrationFiles: () => Promise<boolean>;
+      };
+    };
+  };
+};
 
-/**
- * Finds the base path for the data migration files
- * @returns {string} - The path of the migration files
- */
-export async function getBasePath(app: ElectronApplication): Promise<string> {
-  const documents = await app.evaluate(async ({ app }) => {
-    return app.getPath('documents');
+export async function migrationDataExists(window: Page): Promise<boolean> {
+  return await window.evaluate(async () => {
+    return await (globalThis as RendererElectronAPI).electronAPI.local.dataMigration.locateDataMigrationFiles();
   });
-
-  return path.join(documents, DEFAULT_FOLDER_NAME);
-}
-
-/**
- * Check if the data migration files exist
- * @param {import('playwright').ElectronApplication} app - Electron app object
- * @returns {boolean} - True if the files exist, false otherwise
- */
-export async function migrationDataExists(app: ElectronApplication): Promise<boolean> {
-  try {
-    const basePath = await getBasePath(app);
-
-    const propertiesPath = path.join(basePath, FILES, USER_PROPERTIES);
-    const mnemonicPath = path.join(basePath, FILES, RECOVERY_FILE_PARENT_FOLDER, RECOVERY_FILE);
-
-    return fs.existsSync(basePath) && fs.existsSync(propertiesPath) && fs.existsSync(mnemonicPath);
-  } catch {
-    return false;
-  }
 }

--- a/front-end/src/main/index.ts
+++ b/front-end/src/main/index.ts
@@ -18,6 +18,19 @@ import { initializeUpdaterService } from '@main/services/electronUpdater';
 let mainWindow: BrowserWindow | null = null;
 let mainWindowInit: Promise<void> | null = null;
 
+function configureAutomationCommandLineSwitches() {
+  const isPlaywrightTest = process.env.PLAYWRIGHT_TEST === 'true';
+  const remoteDebuggingPort = process.env.ELECTRON_REMOTE_DEBUGGING_PORT?.trim();
+
+  if (isPlaywrightTest && remoteDebuggingPort) {
+    app.commandLine.appendSwitch('remote-debugging-port', remoteDebuggingPort);
+  }
+
+  if (isPlaywrightTest) {
+    app.commandLine.appendSwitch('ignore-certificate-errors');
+  }
+}
+
 async function run() {
   await initDatabase();
 
@@ -106,6 +119,7 @@ function setupDeepLink() {
 }
 
 initLogger();
+configureAutomationCommandLineSwitches();
 
 const gotTheLock = app.requestSingleInstanceLock();
 

--- a/front-end/src/main/modules/ipcHandlers/utils.ts
+++ b/front-end/src/main/modules/ipcHandlers/utils.ts
@@ -1,6 +1,15 @@
 import fs from 'fs';
 
-import { BrowserWindow, app, dialog, ipcMain, shell, FileFilter } from 'electron';
+import {
+  BrowserWindow,
+  app,
+  dialog,
+  ipcMain,
+  shell,
+  FileFilter,
+  OpenDialogReturnValue,
+  SaveDialogReturnValue,
+} from 'electron';
 
 import { createHash, X509Certificate } from 'crypto';
 
@@ -9,6 +18,55 @@ import { dualCompareHash, hash } from '@main/utils/crypto';
 
 const createChannelName = (...props: string[]) => ['utils', ...props].join(':');
 let bounceId: number | null = null;
+
+interface DialogMockState {
+  savePath: string | null;
+  openPaths: string[];
+}
+
+const defaultDialogMockState = (): DialogMockState => ({
+  savePath: null,
+  openPaths: [],
+});
+
+const normalizeSavePath = (
+  value: unknown,
+  fallback: string | null,
+): string | null => {
+  if (value === undefined) return fallback;
+
+  return typeof value === 'string' || value === null ? value : fallback;
+};
+
+const normalizeOpenPaths = (
+  value: unknown,
+  fallback: string[],
+): string[] => {
+  if (value === undefined || !Array.isArray(value)) return [...fallback];
+
+  const next: string[] = [];
+  for (const item of value) {
+    if (typeof item === 'string') {
+      next.push(item);
+    }
+  }
+
+  return next;
+};
+
+let dialogMockState = defaultDialogMockState();
+
+const isPlaywrightTestSession = () => process.env.PLAYWRIGHT_TEST === 'true';
+
+const getMockedSaveDialogResult = (): SaveDialogReturnValue => ({
+  canceled: false,
+  filePath: dialogMockState.savePath ?? '',
+});
+
+const getMockedOpenDialogResult = (): OpenDialogReturnValue => ({
+  canceled: false,
+  filePaths: [...dialogMockState.openPaths],
+});
 
 export default () => {
   ipcMain.on(createChannelName('setDockBounce'), (_e, bounce: boolean) => {
@@ -30,6 +88,20 @@ export default () => {
   ipcMain.on(createChannelName('openExternal'), (_e, url: string) => shell.openExternal(url));
 
   ipcMain.on(createChannelName('openPath'), (_e, path: string) => shell.openPath(path));
+
+  ipcMain.handle(
+    createChannelName('test', 'setDialogMockState'),
+    (_e, state: Partial<DialogMockState>): void => {
+      dialogMockState = {
+        savePath: normalizeSavePath(state.savePath, dialogMockState.savePath),
+        openPaths: normalizeOpenPaths(state.openPaths, dialogMockState.openPaths),
+      };
+    },
+  );
+
+  ipcMain.handle(createChannelName('test', 'clearDialogMockState'), async (): Promise<void> => {
+    dialogMockState = defaultDialogMockState();
+  });
 
   ipcMain.handle(
     createChannelName('hash'),
@@ -63,9 +135,11 @@ export default () => {
     if (windows.length === 0) return;
 
     try {
-      const { filePath, canceled } = await dialog.showSaveDialog(windows[0], {
-        defaultPath: app.getPath('documents'),
-      });
+      const { filePath, canceled } = isPlaywrightTestSession()
+        ? getMockedSaveDialogResult()
+        : await dialog.showSaveDialog(windows[0], {
+            defaultPath: app.getPath('documents'),
+          });
       if (!filePath.trim() || canceled) return;
 
       const content = Buffer.from(getNumberArrayFromString(uint8ArrayString));
@@ -113,6 +187,10 @@ export default () => {
       const windows = BrowserWindow.getAllWindows();
       if (windows.length === 0) return;
 
+      if (isPlaywrightTestSession()) {
+        return getMockedOpenDialogResult();
+      }
+
       return await dialog.showOpenDialog(windows[0], {
         title,
         buttonLabel,
@@ -135,6 +213,10 @@ export default () => {
     ) => {
       const windows = BrowserWindow.getAllWindows();
       if (windows.length === 0) return;
+
+      if (isPlaywrightTestSession()) {
+        return getMockedSaveDialogResult();
+      }
 
       return await dialog.showSaveDialog(windows[0], {
         title,

--- a/front-end/src/preload/localUser/utils.ts
+++ b/front-end/src/preload/localUser/utils.ts
@@ -35,6 +35,14 @@ export default {
       filePath: string,
     ): Promise<void> =>
       ipcRenderer.invoke('utils:saveFileToPath', data, filePath),
+    setDialogMockState: (
+      state: {
+        savePath?: string | null;
+        openPaths?: string[];
+      },
+    ): Promise<void> => ipcRenderer.invoke('utils:test:setDialogMockState', state),
+    clearDialogMockState: (): Promise<void> =>
+      ipcRenderer.invoke('utils:test:clearDialogMockState'),
     sha384: (str: string): Promise<string> => ipcRenderer.invoke('utils:sha384', str),
     x509BytesFromPem: (
       pem: string | Uint8Array,

--- a/front-end/src/tests/main/index.spec.ts
+++ b/front-end/src/tests/main/index.spec.ts
@@ -37,6 +37,32 @@ vi.mock('@main/services/electronUpdater', () => ({
   initializeUpdaterService: vi.fn(),
 }));
 
+const mockIndexDependenciesForImport = (requestSingleInstanceLock: boolean) => {
+  vi.doMock('electron', () => {
+    const mocked = mockDeep<typeof import('electron')>();
+    mocked.app.requestSingleInstanceLock.mockReturnValue(requestSingleInstanceLock);
+    mocked.app.whenReady.mockResolvedValue();
+    return mocked;
+  });
+
+  vi.doMock('path', () => mockDeep());
+  vi.doMock('@electron-toolkit/utils', () => mockDeep());
+  vi.doMock('@main/db/init', () => mockDeep());
+  vi.doMock('@main/services/localUser', () => mockDeep());
+  vi.doMock('@main/modules/logger', () => mockDeep());
+  vi.doMock('@main/modules/menu', () => mockDeep());
+  vi.doMock('@main/modules/deepLink', () => ({
+    default: vi.fn(),
+    PROTOCOL_NAME: 'test-protocol',
+  }));
+  vi.doMock('@main/modules/ipcHandlers', () => mockDeep());
+  vi.doMock('@main/windows/mainWindow', () => mockDeep());
+  vi.doMock('@main/services/electronUpdater', () => ({
+    getUpdaterService: vi.fn(() => null),
+    initializeUpdaterService: vi.fn(),
+  }));
+};
+
 describe('Electron entry file', async () => {
   const processOnSpy = vi.spyOn(process, 'on');
   await import('@main/index');
@@ -313,5 +339,77 @@ describe('Electron entry file - single instance lock not acquired', async () => 
   test('Should not set up app event handlers when lock is not acquired', () => {
     expect(freshApp.on).not.toHaveBeenCalledWith('ready', expect.any(Function));
     expect(freshApp.on).not.toHaveBeenCalledWith('second-instance', expect.any(Function));
+  });
+});
+
+describe('configureAutomationCommandLineSwitches', () => {
+  const originalPlaywrightTest = process.env.PLAYWRIGHT_TEST;
+  const originalRemoteDebuggingPort = process.env.ELECTRON_REMOTE_DEBUGGING_PORT;
+
+  afterEach(() => {
+    vi.resetModules();
+
+    if (originalPlaywrightTest === undefined) {
+      delete process.env.PLAYWRIGHT_TEST;
+    } else {
+      process.env.PLAYWRIGHT_TEST = originalPlaywrightTest;
+    }
+
+    if (originalRemoteDebuggingPort === undefined) {
+      delete process.env.ELECTRON_REMOTE_DEBUGGING_PORT;
+    } else {
+      process.env.ELECTRON_REMOTE_DEBUGGING_PORT = originalRemoteDebuggingPort;
+    }
+  });
+
+  test('Should append automation switches when Playwright env vars are set', async () => {
+    vi.resetModules();
+    process.env.PLAYWRIGHT_TEST = 'true';
+    process.env.ELECTRON_REMOTE_DEBUGGING_PORT = ' 9333 ';
+
+    mockIndexDependenciesForImport(false);
+
+    const { app: freshApp } = await import('electron');
+    await import('@main/index');
+
+    expect(freshApp.commandLine.appendSwitch).toHaveBeenCalledWith(
+      'remote-debugging-port',
+      '9333',
+    );
+    expect(freshApp.commandLine.appendSwitch).toHaveBeenCalledWith(
+      'ignore-certificate-errors',
+    );
+  });
+
+  test('Should skip automation switches when Playwright env vars are unset', async () => {
+    vi.resetModules();
+    delete process.env.PLAYWRIGHT_TEST;
+    process.env.ELECTRON_REMOTE_DEBUGGING_PORT = '   ';
+
+    mockIndexDependenciesForImport(false);
+
+    const { app: freshApp } = await import('electron');
+    await import('@main/index');
+
+    expect(freshApp.commandLine.appendSwitch).not.toHaveBeenCalled();
+  });
+
+  test('Should not append remote debugging port outside Playwright sessions', async () => {
+    vi.resetModules();
+    delete process.env.PLAYWRIGHT_TEST;
+    process.env.ELECTRON_REMOTE_DEBUGGING_PORT = '9222';
+
+    mockIndexDependenciesForImport(false);
+
+    const { app: freshApp } = await import('electron');
+    await import('@main/index');
+
+    expect(freshApp.commandLine.appendSwitch).not.toHaveBeenCalledWith(
+      'remote-debugging-port',
+      '9222',
+    );
+    expect(freshApp.commandLine.appendSwitch).not.toHaveBeenCalledWith(
+      'ignore-certificate-errors',
+    );
   });
 });

--- a/front-end/src/tests/main/modules/ipcHandlers/utils.spec.ts
+++ b/front-end/src/tests/main/modules/ipcHandlers/utils.spec.ts
@@ -42,9 +42,11 @@ describe('createChannelName', () => {
 });
 
 describe('registerUtilsListeners', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.resetAllMocks();
+    delete process.env.PLAYWRIGHT_TEST;
     registerUtilsListeners();
+    await invokeIPCHandler('utils:test:clearDialogMockState');
   });
 
   test('Should register handlers for each util', () => {
@@ -55,10 +57,13 @@ describe('registerUtilsListeners', () => {
       'compareDataToHashes',
       'saveFile',
       'showOpenDialog',
+      'showSaveDialog',
       'saveFileToPath',
       'sha384',
       'x509BytesFromPem',
       'quit',
+      'test:setDialogMockState',
+      'test:clearDialogMockState',
     ];
 
     expect(eventListeners.every(util => getIPCListener(`utils:${util}`))).toBe(true);
@@ -126,6 +131,25 @@ describe('registerUtilsListeners', () => {
     expect(fs.promises.writeFile).not.toHaveBeenCalled();
     await invokeIPCHandler('utils:saveFile', uint8ArrayString);
     expect(fs.promises.writeFile).not.toHaveBeenCalled();
+  });
+
+  test('Should use mocked dialog state in Playwright util:saveFile', async () => {
+    const windows = [{}];
+    const uint8ArrayString = 'testString';
+    const numberArray = [1, 2, 3];
+    const mockedSavePath = '/tmp/playwright-save.bin';
+    const content = Uint8Array.from(numberArray);
+
+    process.env.PLAYWRIGHT_TEST = 'true';
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue(windows as unknown as BrowserWindow[]);
+    vi.mocked(getNumberArrayFromString).mockReturnValue(numberArray);
+
+    await invokeIPCHandler('utils:test:setDialogMockState', { savePath: mockedSavePath });
+    await invokeIPCHandler('utils:saveFile', uint8ArrayString);
+
+    expect(dialog.showSaveDialog).not.toHaveBeenCalled();
+    expect(app.getPath).not.toHaveBeenCalled();
+    expect(fs.promises.writeFile).toHaveBeenCalledWith(mockedSavePath, content);
   });
 
   test('Should show error in dialog if fail to write in util:saveFile', async () => {
@@ -291,6 +315,33 @@ describe('registerUtilsListeners', () => {
     expect(result).toBe(dialogReturnValue);
   });
 
+  test('Should use mocked dialog state in Playwright util:showOpenDialog', async () => {
+    const windows = [{}];
+    const title = 'Open File';
+    const buttonLabel = 'Open';
+    const filters = [{ name: 'Text Files', extensions: ['txt'] }];
+    const properties = ['openFile'];
+    const message = 'Select a file to open';
+    const filePaths = ['/tmp/first.txt', '/tmp/second.txt'];
+
+    process.env.PLAYWRIGHT_TEST = 'true';
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue(windows as unknown as BrowserWindow[]);
+
+    await invokeIPCHandler('utils:test:setDialogMockState', { openPaths: filePaths });
+
+    const result = await invokeIPCHandler(
+      'utils:showOpenDialog',
+      title,
+      buttonLabel,
+      filters,
+      properties,
+      message,
+    );
+
+    expect(dialog.showOpenDialog).not.toHaveBeenCalled();
+    expect(result).toEqual({ canceled: false, filePaths });
+  });
+
   test('Should save file to a path in util:saveFileToPath', async () => {
     const data = new Uint8Array([1, 2, 3, 4]);
     const filePath = '/path/to/test.txt';
@@ -325,6 +376,46 @@ describe('registerUtilsListeners', () => {
   test('Should invoke app.quit in util:quit', async () => {
     await invokeIPCHandler('utils:quit');
     expect(app.quit).toHaveBeenCalled();
+  });
+
+  test('Should use and clear mocked dialog state in Playwright util:showSaveDialog', async () => {
+    const windows = [{}];
+    const name = 'test.txt';
+    const title = 'Save File';
+    const buttonLabel = 'Save';
+    const filters = [{ name: 'Text Files', extensions: ['txt'] }];
+    const message = 'Select a file to save';
+    const mockedSavePath = '/tmp/playwright-dialog.txt';
+
+    process.env.PLAYWRIGHT_TEST = 'true';
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue(windows as unknown as BrowserWindow[]);
+
+    await invokeIPCHandler('utils:test:setDialogMockState', { savePath: mockedSavePath });
+
+    const mockedResult = await invokeIPCHandler(
+      'utils:showSaveDialog',
+      name,
+      title,
+      buttonLabel,
+      filters,
+      message,
+    );
+
+    expect(dialog.showSaveDialog).not.toHaveBeenCalled();
+    expect(mockedResult).toEqual({ canceled: false, filePath: mockedSavePath });
+
+    await invokeIPCHandler('utils:test:clearDialogMockState');
+
+    const clearedResult = await invokeIPCHandler(
+      'utils:showSaveDialog',
+      name,
+      title,
+      buttonLabel,
+      filters,
+      message,
+    );
+
+    expect(clearedResult).toEqual({ canceled: false, filePath: '' });
   });
 
   test('Should hash the data in util:sha384', async () => {


### PR DESCRIPTION
**Description**:
This PR adds support for running Playwright against an already running Electron dev instance and for deterministically mocking native file dialogs during E2E tests. It is needed because remote debugging and native dialogs are controlled in the Electron app, not from Playwright alone.

* Add `launch` and `attach` modes to the Electron automation bootstrapper
* Connect to a running Electron app over CDP when attach mode is enabled
* Gate remote debugging and certificate-related Electron switches behind automation env vars
* Add test-only IPC and preload hooks for mocking `showOpenDialog` and `showSaveDialog`
* Replace inline dialog monkey-patching in tests with shared dialog mock helpers
* Update automation docs and example env configuration for both launch and attach flows

**Related issue(s)**:

Fixes #2472

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

For attach mode, start the app from `front-end/` with:

```bash
PLAYWRIGHT_TEST=true ELECTRON_REMOTE_DEBUGGING_PORT=9222 pnpm dev
```

All Electron app-side changes are env-gated and should not affect normal user or production flows unless the automation flags are explicitly enabled.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
