### PR TITLE
feat: disable external badges on transactions based on feature flag

### DIFF
--- a/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
@@ -11,7 +11,7 @@ import { computed, onBeforeMount, ref, watch, type Ref } from 'vue';
 import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router';
 
 import { Transaction as SDKTransaction } from '@hashgraph/sdk';
-import { FEATURE_APPROVERS_ENABLED, TRANSACTION_ACTION } from '@shared/constants';
+import { FEATURE_APPROVERS_ENABLED, FEATURE_EXTERNAL_BADGE_ENABLED, TRANSACTION_ACTION } from '@shared/constants';
 import { CommonNetwork } from '@shared/enums';
 
 import useUserStore from '@renderer/stores/storeUser';
@@ -102,7 +102,7 @@ const creator = computed(() => {
 });
 
 const showExternal = computed(() => {
-  return isLoggedInOrganization(user.selectedOrganization) && user.selectedOrganization.admin;
+  return FEATURE_EXTERNAL_BADGE_ENABLED &&  isLoggedInOrganization(user.selectedOrganization) && user.selectedOrganization.admin;
 });
 
 const transactionIsInProgress = computed(

--- a/front-end/src/renderer/pages/Transactions/components/TransactionNodeRow.vue
+++ b/front-end/src/renderer/pages/Transactions/components/TransactionNodeRow.vue
@@ -22,6 +22,7 @@ import {
 import { NotificationType, TransactionStatus } from '@shared/interfaces';
 import useCreateTooltips from '@renderer/composables/useCreateTooltips';
 import Tooltip from 'bootstrap/js/dist/tooltip';
+import { FEATURE_EXTERNAL_BADGE_ENABLED } from '@shared/constants';
 
 /* Props */
 const props = defineProps<{
@@ -242,7 +243,7 @@ watch(
     }
 
     const externalSignerKeys = await transactionAudit.externalSignerKeys.value;
-    isExternal.value = externalSignerKeys.size > 0;
+    isExternal.value = FEATURE_EXTERNAL_BADGE_ENABLED && externalSignerKeys.size > 0;
   },
   { immediate: true },
 );

--- a/front-end/src/shared/constants/featureFlags.ts
+++ b/front-end/src/shared/constants/featureFlags.ts
@@ -1,1 +1,2 @@
 export const FEATURE_APPROVERS_ENABLED = false;
+export const FEATURE_EXTERNAL_BADGE_ENABLED = false;


### PR DESCRIPTION
**Description**:
This pull request introduces a new feature flag, `FEATURE_EXTERNAL_BADGE_ENABLED`, to control the display of the "external badge" across the application. The flag is integrated into relevant components to ensure that the external badge is only shown when the feature is enabled, providing a centralized way to toggle this functionality.

Feature flag introduction:

* Added a new constant `FEATURE_EXTERNAL_BADGE_ENABLED` (default: `false`) to `front-end/src/shared/constants/featureFlags.ts` to control the availability of the external badge feature.

Feature flag integration:

* Updated `TransactionDetails.vue` to check `FEATURE_EXTERNAL_BADGE_ENABLED` before showing the external badge for organization admins. [[1]](diffhunk://#diff-c401ef22a0144c34436962f52b4560dbf28ffc9522005aa0ef73ddf6e77bb881L14-R14) [[2]](diffhunk://#diff-c401ef22a0144c34436962f52b4560dbf28ffc9522005aa0ef73ddf6e77bb881L105-R105)
* Updated `TransactionNodeRow.vue` to conditionally set the `isExternal` value based on `FEATURE_EXTERNAL_BADGE_ENABLED`, ensuring the badge is only shown when the feature is enabled and external signer keys exist. [[1]](diffhunk://#diff-bcd22789c7c11313f2fab68765b804f11f579ade8c0f653c405488084a059e7bR25) [[2]](diffhunk://#diff-bcd22789c7c11313f2fab68765b804f11f579ade8c0f653c405488084a059e7bL245-R246)

**Related issue(s)**:

Fixes #2474 
