### PR TITLE
feat: add missing notification opt-out options for transaction events

### DIFF
--- a/front-end/src/renderer/pages/Settings/components/NotificationsTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/NotificationsTab.vue
@@ -23,51 +23,158 @@ const handlePreferenceChange = (type: NotificationType, email: boolean) => {
   <div>
     <div class="fill-remaining border border-2 rounded-3 p-4">
       <p>Email notifications</p>
-      <div class="mt-4">
-        <AppSwitch
-          :checked="
-            notifications.notificationsPreferences[NotificationType.TRANSACTION_READY_FOR_EXECUTION]
-          "
-          @update:checked="
-            handlePreferenceChange(NotificationType.TRANSACTION_READY_FOR_EXECUTION, $event)
-          "
-          name="threshold-reached"
-          label="Transaction Threshold Reached"
-        />
-        <p class="text-small text-secondary mt-2">
-          You will be notified when a transaction you are a Creator in has collected enough
-          signature to satisfy the threshold.
-        </p>
-      </div>
-      <div class="mt-6">
-        <AppSwitch
-          :checked="
-            notifications.notificationsPreferences[
-              NotificationType.TRANSACTION_WAITING_FOR_SIGNATURES
-            ]
-          "
-          @update:checked="
-            handlePreferenceChange(NotificationType.TRANSACTION_WAITING_FOR_SIGNATURES, $event)
-          "
-          name="required-signatures"
-          label="Required Signature"
-        />
-        <p class="text-small text-secondary mt-2">
-          You will be notified whenever a transaction, which requires your signature, has been
-          created.
-        </p>
-      </div>
-      <div class="mt-6">
-        <AppSwitch
-          :checked="notifications.notificationsPreferences[NotificationType.TRANSACTION_CANCELLED]"
-          @update:checked="handlePreferenceChange(NotificationType.TRANSACTION_CANCELLED, $event)"
-          name="transaction-cancelled"
-          label="Transaction Cancelled"
-        />
-        <p class="text-small text-secondary mt-2">
-          You will be notified whenever a transaction, which you have signed, approved or observe,
-          has been cancelled.
-        </p>
+      <p class="text-small text-secondary ms-1 mb-3">
+        Get emails about transactions you're involved in for:
+      </p>
+
+      <!-- Indented options -->
+      <div class="ms-3">
+
+        <!-- Ready to execute -->
+        <div class="mt-3">
+          <div class="d-flex justify-content-between align-items-center">
+            <div class="me-3">
+              <div class="fs-6">Ready to execute</div>
+            </div>
+            <div class="notification-toggle">
+              <AppSwitch
+                :checked="
+                  notifications.notificationsPreferences[
+                    NotificationType.TRANSACTION_READY_FOR_EXECUTION
+                  ]
+                "
+                @update:checked="
+                  handlePreferenceChange(
+                    NotificationType.TRANSACTION_READY_FOR_EXECUTION,
+                    $event
+                  )
+                "
+                name="threshold-reached"
+                aria-label="Email me when a transaction is ready to execute"
+              />
+            </div>
+          </div>
+          <p class="text-small text-secondary mt-1">
+            The transaction has enough signatures and can be executed.
+          </p>
+        </div>
+
+        <!-- Signature required -->
+        <div class="mt-4">
+          <div class="d-flex justify-content-between align-items-center">
+            <div class="me-3">
+              <div class="fs-6">Signature required</div>
+            </div>
+            <div class="notification-toggle">
+              <AppSwitch
+                :checked="
+                  notifications.notificationsPreferences[
+                    NotificationType.TRANSACTION_WAITING_FOR_SIGNATURES
+                  ]
+                "
+                @update:checked="
+                  handlePreferenceChange(
+                    NotificationType.TRANSACTION_WAITING_FOR_SIGNATURES,
+                    $event
+                  )
+                "
+                name="required-signatures"
+                aria-label="Email me when my signature is required"
+              />
+            </div>
+          </div>
+          <p class="text-small text-secondary mt-1">
+            A new transaction needs your signature.
+          </p>
+        </div>
+
+        <!-- Cancelled -->
+        <div class="mt-4">
+          <div class="d-flex justify-content-between align-items-center">
+            <div class="me-3">
+              <div class="fs-6">Cancelled</div>
+            </div>
+            <div class="notification-toggle">
+              <AppSwitch
+                :checked="
+                  notifications.notificationsPreferences[
+                    NotificationType.TRANSACTION_CANCELLED
+                  ]
+                "
+                @update:checked="
+                  handlePreferenceChange(
+                    NotificationType.TRANSACTION_CANCELLED,
+                    $event
+                  )
+                "
+                name="transaction-cancelled"
+                aria-label="Email me when a transaction is cancelled"
+              />
+            </div>
+          </div>
+          <p class="text-small text-secondary mt-1">
+            The transaction is cancelled and will not be executed.
+          </p>
+        </div>
+
+        <!-- Executed -->
+        <div class="mt-4">
+          <div class="d-flex justify-content-between align-items-center">
+            <div class="me-3">
+              <div class="fs-6">Executed</div>
+            </div>
+            <div class="notification-toggle">
+              <AppSwitch
+                :checked="
+                  notifications.notificationsPreferences[
+                    NotificationType.TRANSACTION_EXECUTED
+                  ]
+                "
+                @update:checked="
+                  handlePreferenceChange(
+                    NotificationType.TRANSACTION_EXECUTED,
+                    $event
+                  )
+                "
+                name="transaction-executed"
+                aria-label="Email me when a transaction is executed"
+              />
+            </div>
+          </div>
+          <p class="text-small text-secondary mt-1">
+            The transaction has been executed successfully.
+          </p>
+        </div>
+
+        <!-- Expired -->
+        <div class="mt-4">
+          <div class="d-flex justify-content-between align-items-center">
+            <div class="me-3">
+              <div class="fs-6">Expired</div>
+            </div>
+            <div class="notification-toggle">
+              <AppSwitch
+                :checked="
+                  notifications.notificationsPreferences[
+                    NotificationType.TRANSACTION_EXPIRED
+                  ]
+                "
+                @update:checked="
+                  handlePreferenceChange(
+                    NotificationType.TRANSACTION_EXPIRED,
+                    $event
+                  )
+                "
+                name="transaction-expired"
+                aria-label="Email me when a transaction expires"
+              />
+            </div>
+          </div>
+          <p class="text-small text-secondary mt-1">
+            The transaction has expired and can no longer be executed.
+          </p>
+        </div>
+
       </div>
     </div>
   </div>

--- a/front-end/src/renderer/stores/storeNotifications.ts
+++ b/front-end/src/renderer/stores/storeNotifications.ts
@@ -35,6 +35,8 @@ const useNotificationsStore = defineStore('notifications', () => {
     [NotificationType.TRANSACTION_READY_FOR_EXECUTION]: true,
     [NotificationType.TRANSACTION_WAITING_FOR_SIGNATURES]: true,
     [NotificationType.TRANSACTION_CANCELLED]: true,
+    [NotificationType.TRANSACTION_EXPIRED]: true,
+    [NotificationType.TRANSACTION_EXECUTED]: true,
   });
   const notifications = ref<{ [serverUrl: string]: INotificationReceiver[] }>({});
 


### PR DESCRIPTION
**Description**:
This pull request enhances the email notification settings in the user interface by expanding the types of transaction-related notifications users can opt into and improving the clarity and usability of the notifications tab. The main changes include adding new notification options for executed and expired transactions, updating the UI for better organization, and ensuring these new preferences are enabled by default.

**Notification Settings Enhancements:**

* Added two new notification types—`TRANSACTION_EXECUTED` and `TRANSACTION_EXPIRED`—to the default notification preferences in the `useNotificationsStore`.

**User Interface Improvements:**

* Refactored the Notifications tab UI in `NotificationsTab.vue` to:
  - Organize notification options in an indented, grouped layout for better readability.
  - Add descriptive labels and help text for each notification type, clarifying when users will be notified.
  - Include toggles for the new "Executed" and "Expired" notification types, allowing users to enable or disable these notifications from the UI.

**Related issue(s)**:

Fixes #2479 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
