### PR TITLE
chore: bump version to 0.26.1-beta.1 

### DIFF
--- a/back-end/apps/api/package.json
+++ b/back-end/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/api",
-  "version": "0.26.0",
+  "version": "0.26.1-beta.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/chain/package.json
+++ b/back-end/apps/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/chain",
-  "version": "0.26.0",
+  "version": "0.26.1-beta.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/apps/notifications/package.json
+++ b/back-end/apps/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@back-end/notifications",
-  "version": "0.26.0",
+  "version": "0.26.1-beta.1",
   "description": "",
   "author": "",
   "main": "index.js",

--- a/back-end/k8s/dev/deployments/api-deployment.yaml
+++ b/back-end/k8s/dev/deployments/api-deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - name: GLOBAL_SECOND_LIMIT
               value: '1000'
             - name: LATEST_SUPPORTED_FRONTEND_VERSION
-              value: '0.26.0'
+              value: '0.26.1-beta.1'
             - name: MINIMUM_SUPPORTED_FRONTEND_VERSION
               value: '0.23.0'
             - name: FRONTEND_REPO_URL

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "back-end",
-  "version": "0.26.0",
+  "version": "0.26.1-beta.1",
   "description": "",
   "author": "",
   "private": true,

--- a/back-end/typeorm/package.json
+++ b/back-end/typeorm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.26.0",
+  "version": "0.26.1-beta.1",
   "private": true,
   "scripts": {
     "build": "tsc",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-transaction-tool",
-  "version": "0.26.0",
+  "version": "0.26.1-beta.1",
   "description": "Transaction tool application",
   "author": {
     "name": "Hedera",


### PR DESCRIPTION
**Description**:
This pull request updates the version numbers across both the back-end and front-end packages to `0.26.1-beta.1`. It also updates the Kubernetes deployment configuration to require the new frontend version for compatibility.
