### PR TITLE
fix: avoid unneeded request of application password

### DIFF
--- a/front-end/src/renderer/pages/UserLogin/components/EmailLoginForm.vue
+++ b/front-end/src/renderer/pages/UserLogin/components/EmailLoginForm.vue
@@ -109,12 +109,11 @@ const handleOnFormSubmit = async () => {
 
     user.setAccountSetupStarted(true);
     await user.login(id, email, false);
-    await user.refetchOrganizations();
-    await setupStores();
-
     if (isUserLoggedIn(user.personal)) {
       user.setPassword(inputPassword.value);
     }
+    await user.refetchOrganizations();
+    await setupStores();
 
     await router.push({ name: 'accountSetup' });
   } else if (!props.shouldRegister) {
@@ -141,12 +140,11 @@ const handleOnFormSubmit = async () => {
       try {
         globalModalLoaderRef?.value?.open();
         await user.login(userData.id, userData.email.trim(), false);
-        await user.refetchOrganizations();
-        await setupStores();
-
         if (isUserLoggedIn(user.personal)) {
           user.setPassword(inputPassword.value);
         }
+        await user.refetchOrganizations();
+        await setupStores();
 
         if (user.secretHashes.length === 0) {
           await router.push({ name: 'accountSetup' });


### PR DESCRIPTION
**Description**:

Changes below fix `EmailLoginForm.handleOnFormSubmit()`.

Root cause of the issue is the sequencing below:
```
    user.setAccountSetupStarted(true);
    await user.login(id, email, false);
    await user.refetchOrganizations();                   // Must be called after user.setPassword()
    await setupStores();

    if (isUserLoggedIn(user.personal)) {
      user.setPassword(inputPassword.value);             // Called too late
    }
```

Call to `user.setPassword()` must be done before `user.refetchOrganizations()`.


**Related issue(s)**:

Fixes #2416

**Notes for reviewer**:


See #2416 for testing scenario.

```
M       front-end/src/renderer/pages/UserLogin/components/EmailLoginForm.vue
        # Moves call to user.setPassword() before user.refreshOrganizations()
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
