### PR TITLE
feat: removing debouncing mechanism from ToastManager.

### DIFF
--- a/front-end/src/renderer/utils/ToastManager.ts
+++ b/front-end/src/renderer/utils/ToastManager.ts
@@ -5,10 +5,8 @@ export class ToastManager {
   private static readonly injectKey = Symbol();
 
   private readonly toast = useToast();
-  private readonly timers = new Map<string, number>();
-  private readonly duplicateTimeout = 700; // If two same errors occurred during that time, second is a duplicate
+  private readonly displayedErrors = new Set<string>();
   private readonly maxDisplayedErrorCount = 4;
-  private displayedErrorCount = 0;
 
   //
   // Public
@@ -33,15 +31,15 @@ export class ToastManager {
   }
 
   public error(message: string) {
-    if (this.isDuplicate(message) || this.displayedErrorCount >= this.maxDisplayedErrorCount) {
+    if (this.displayedErrors.has(message) || this.displayedErrors.size >= this.maxDisplayedErrorCount) {
       // We display message in console
       console.log('Hidden error message: "' + message + '"');
     } else {
-      this.displayedErrorCount++;
+      this.displayedErrors.add(message);
       this.toast.error(message, {
         duration: 0,
         onDismiss: () => {
-          this.displayedErrorCount--;
+          this.displayedErrors.delete(message);
         },
       });
     }
@@ -58,26 +56,5 @@ export class ToastManager {
   public static inject(): ToastManager {
     const defaultFactory = () => new ToastManager();
     return inject<ToastManager>(ToastManager.injectKey, defaultFactory, true);
-  }
-
-  //
-  // Private
-  //
-
-  private isDuplicate(message: string): boolean {
-    let result: boolean;
-    const tid = this.timers.get(message);
-    if (tid !== undefined) {
-      // message is a duplicate
-      result = true;
-      clearTimeout(tid);
-    } else {
-      result = false;
-    }
-    const newTID = window.setTimeout(() => {
-      this.timers.delete(message);
-    }, this.duplicateTimeout);
-    this.timers.set(message, newTID);
-    return result;
   }
 }

--- a/front-end/src/tests/renderer/utils/ToastManager.spec.ts
+++ b/front-end/src/tests/renderer/utils/ToastManager.spec.ts
@@ -53,12 +53,11 @@ describe('ToastManager', () => {
     const toastManager = new ToastManager();
     toastManager.error('Nice error message');
     expect(toastErrorSpy).toHaveBeenCalledTimes(1);
-    vi.advanceTimersByTime(200);
     toastManager.error('Nice error message');
     expect(toastErrorSpy).toHaveBeenCalledTimes(1);
     vi.advanceTimersByTime(800);
     toastManager.error('Nice error message');
-    expect(toastErrorSpy).toHaveBeenCalledTimes(2);
+    expect(toastErrorSpy).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
**Description**:

Changes removed debouncing mechanism from `ToastManager`.
When a given error message is displayed in a toast, it is never displayed in another toast (until first toast is dismissed).

**Related issue(s)**:

Fixes #2523

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
