### PR TITLE
fix(frontend): replace commonRequestHandler with try/catch to return …

### DIFF
--- a/front-end/src/renderer/services/organization/errorMessages.ts
+++ b/front-end/src/renderer/services/organization/errorMessages.ts
@@ -1,0 +1,21 @@
+export const SESSION_EXPIRED_MESSAGE =
+  'Your session may have expired. Try refreshing the page and signing in again.';
+
+export const PUBLIC_KEY_OWNER_DEFAULT_MESSAGE =
+  'Failed to get owner of the public key';
+
+export const TRANSACTION_NODE_DEFAULT_MESSAGE =
+  'Something went wrong while fetching transaction nodes. Please try again.';
+
+export const PUBLIC_KEY_OWNER_STATUS_MESSAGES: Partial<Record<number, string>> = {
+  401: SESSION_EXPIRED_MESSAGE,
+  403: 'You don\'t have permission to look up the owner of this public key.',
+  404: 'Could not find the owner of the public key.',
+  500: 'The server ran into a problem looking up the public key owner. Try again in a moment.',
+};
+
+export const TRANSACTION_NODE_STATUS_MESSAGES: Partial<Record<number, string>> = {
+  404: 'Could not retrieve transactions. The server may be outdated — please contact your administrator for help.',
+  403: "You don't have permission to view transactions for this network.",
+  500: 'The server ran into a problem fetching transactions. Try again in a moment.',
+};

--- a/front-end/src/renderer/services/organization/transactionNode.ts
+++ b/front-end/src/renderer/services/organization/transactionNode.ts
@@ -5,6 +5,11 @@ import {
   TransactionNodeCollection,
 } from '../../../../../shared/src/ITransactionNode';
 import { BackEndTransactionType, type Network, TransactionStatus } from '@shared/interfaces';
+import {
+  TRANSACTION_NODE_DEFAULT_MESSAGE,
+  TRANSACTION_NODE_STATUS_MESSAGES,
+  SESSION_EXPIRED_MESSAGE,
+} from './errorMessages';
 
 export const getTransactionNodes = async (
   serverUrl: string,
@@ -31,11 +36,7 @@ export const getTransactionNodes = async (
 
     return r.data;
   },
-    'Something went wrong while fetching transaction nodes. Please try again.',
-    'Your session may have expired. Try refreshing the page and signing in again.',
-    {
-      404: `Could not retrieve transactions. The server may be outdated — please contact your administrator for help.`,
-      403: `You don't have permission to view transactions for this network.`,
-      500: `The server ran into a problem fetching transactions. Try again in a moment.`,
-    },
+    TRANSACTION_NODE_DEFAULT_MESSAGE,
+    SESSION_EXPIRED_MESSAGE,
+    TRANSACTION_NODE_STATUS_MESSAGES,
   );

--- a/front-end/src/renderer/services/organization/user.ts
+++ b/front-end/src/renderer/services/organization/user.ts
@@ -1,10 +1,10 @@
 import type { IUser, IUserKey } from '@shared/interfaces';
 
-import axios from 'axios';
-
 import { axiosWithCredentials, commonRequestHandler } from '@renderer/utils';
 
 import { getUserKeys } from './userKeys';
+
+import { PUBLIC_KEY_OWNER_DEFAULT_MESSAGE, PUBLIC_KEY_OWNER_STATUS_MESSAGES } from './errorMessages';
 
 /* User service for organization */
 const controller = 'users';
@@ -73,16 +73,20 @@ export const deleteUser = (organizationServerUrl: string, id: number) =>
     return response.data;
   }, 'Failed to delete user');
 
-export const getPublicKeyOwner = async (organizationServerUrl: string, publicKey: string): Promise<string | null> => {
-  try {
-    const response = await axiosWithCredentials.get(
-      `${organizationServerUrl}/${controller}/public-owner/${publicKey}`,
-    );
-    return response.data === "" ? null : response.data;
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      return null;
-    }
-    throw error;
-  }
+export const getPublicKeyOwner = async (
+  organizationServerUrl: string,
+  publicKey: string,
+): Promise<string | null> => {
+  return commonRequestHandler(
+    async () => {
+      const response = await axiosWithCredentials.get(
+        `${organizationServerUrl}/${controller}/public-owner/${publicKey}`,
+      );
+      // response.data == "" when there is no matching user => fixing
+      return response.data === "" ? null : response.data;
+    },
+    PUBLIC_KEY_OWNER_DEFAULT_MESSAGE,
+    PUBLIC_KEY_OWNER_STATUS_MESSAGES[401],
+    PUBLIC_KEY_OWNER_STATUS_MESSAGES,
+  );
 };

--- a/front-end/src/tests/renderer/services/organization/user.spec.ts
+++ b/front-end/src/tests/renderer/services/organization/user.spec.ts
@@ -3,22 +3,67 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { getPublicKeyOwner } from '@renderer/services/organization/user';
 import { axiosWithCredentials } from '@renderer/utils';
-import { AxiosError } from 'axios';
+import { AxiosError, type AxiosResponse } from 'axios';
 
+import {
+  PUBLIC_KEY_OWNER_DEFAULT_MESSAGE,
+  PUBLIC_KEY_OWNER_STATUS_MESSAGES,
+  SESSION_EXPIRED_MESSAGE,
+} from '@renderer/services/organization/errorMessages';
+
+// Replicate the real commonRequestHandler logic so we test the actual behavior
+// of getPublicKeyOwner with its messageOn401 and statusMessages params
 vi.mock('@renderer/utils', () => ({
   axiosWithCredentials: {
     get: vi.fn(),
   },
   commonRequestHandler: vi.fn(
-    async <T>(callback: () => Promise<T>, defaultMessage: string): Promise<T> => {
+    async <T>(
+      callback: () => Promise<T>,
+      defaultMessage: string = 'Failed to send request',
+      messageOn401?: string,
+      statusMessages?: Partial<Record<number, string>>,
+    ): Promise<T> => {
       try {
         return await callback();
-      } catch {
-        throw new Error(defaultMessage);
+      } catch (error) {
+        let message = defaultMessage;
+
+        if (error instanceof AxiosError) {
+          if (!error.response) {
+            throw new Error('Failed to connect to the server');
+          }
+
+          const status = error.response.status;
+
+          if (statusMessages?.[status]) {
+            message = statusMessages[status]!;
+          } else if (status === 401 && messageOn401) {
+            message = messageOn401.trim() || error.response.data?.message;
+          } else if (status === 429) {
+            message = 'Too many requests. Please try again later.';
+          }
+        }
+        throw new Error(message);
       }
     },
   ),
 }));
+
+const createAxiosError = (
+  message: string,
+  code: string,
+  status: number,
+  data: Record<string, unknown> = {},
+): AxiosError => {
+  return new AxiosError(message, code, undefined, undefined, {
+    status,
+    data,
+    statusText: message,
+    headers: {},
+    config: {} as any,
+  } as AxiosResponse);
+};
 
 describe('getPublicKeyOwner', () => {
   const serverUrl = 'https://org.example.com';
@@ -27,6 +72,8 @@ describe('getPublicKeyOwner', () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
+
+  // --- Happy path ---
 
   test('returns email when user owns the public key', async () => {
     vi.mocked(axiosWithCredentials.get).mockResolvedValueOnce({
@@ -51,73 +98,81 @@ describe('getPublicKeyOwner', () => {
     expect(result).toBeNull();
   });
 
-  test('returns null on 401 Unauthorized (expired JWT)', async () => {
-    const axiosError = new AxiosError('Unauthorized', '401', undefined, undefined, {
-      status: 401,
-      data: { message: 'Unauthorized', statusCode: 401 },
-      statusText: 'Unauthorized',
-      headers: {},
-      config: {} as any,
-    });
-    vi.mocked(axiosWithCredentials.get).mockRejectedValueOnce(axiosError);
+  // --- 401: throws session-expired message via messageOn401 (the fix for #2411) ---
 
-    const result = await getPublicKeyOwner(serverUrl, publicKey);
+  test('throws session-expired message on 401 Unauthorized instead of generic error', async () => {
+    vi.mocked(axiosWithCredentials.get).mockRejectedValueOnce(
+      createAxiosError('Unauthorized', '401', 401, {
+        message: 'Unauthorized',
+        statusCode: 401,
+      }),
+    );
 
-    expect(result).toBeNull();
+    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+      SESSION_EXPIRED_MESSAGE,
+    );
   });
 
-  test('returns null on 429 Too Many Requests', async () => {
-    const axiosError = new AxiosError('Too Many Requests', '429', undefined, undefined, {
-      status: 429,
-      data: { message: 'Too Many Requests' },
-      statusText: 'Too Many Requests',
-      headers: {},
-      config: {} as any,
-    });
-    vi.mocked(axiosWithCredentials.get).mockRejectedValueOnce(axiosError);
+  // --- Status codes with custom messages via statusMessages ---
 
-    const result = await getPublicKeyOwner(serverUrl, publicKey);
+  test('throws custom message on 403 Forbidden', async () => {
+    vi.mocked(axiosWithCredentials.get).mockRejectedValueOnce(
+      createAxiosError('Forbidden', '403', 403),
+    );
 
-    expect(result).toBeNull();
+    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+      PUBLIC_KEY_OWNER_STATUS_MESSAGES[403],
+    );
   });
 
-  test('returns null on 500 Internal Server Error', async () => {
-    const axiosError = new AxiosError('Server Error', '500', undefined, undefined, {
-      status: 500,
-      data: {},
-      statusText: 'Internal Server Error',
-      headers: {},
-      config: {} as any,
-    });
-    vi.mocked(axiosWithCredentials.get).mockRejectedValueOnce(axiosError);
+  test('throws custom message on 404 Not Found', async () => {
+    vi.mocked(axiosWithCredentials.get).mockRejectedValueOnce(
+      createAxiosError('Not Found', '404', 404),
+    );
 
-    const result = await getPublicKeyOwner(serverUrl, publicKey);
-
-    expect(result).toBeNull();
+    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+      PUBLIC_KEY_OWNER_STATUS_MESSAGES[404],
+    );
   });
 
-  test('returns null on network error (no response from server)', async () => {
+  test('throws custom message on 500 Internal Server Error', async () => {
+    vi.mocked(axiosWithCredentials.get).mockRejectedValueOnce(
+      createAxiosError('Server Error', '500', 500),
+    );
+
+    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+      PUBLIC_KEY_OWNER_STATUS_MESSAGES[500],
+    );
+  });
+
+  // --- Other errors ---
+
+  test('throws rate-limit message on 429 Too Many Requests', async () => {
+    vi.mocked(axiosWithCredentials.get).mockRejectedValueOnce(
+      createAxiosError('Too Many Requests', '429', 429),
+    );
+
+    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+      'Too many requests. Please try again later.',
+    );
+  });
+
+  test('throws default message on unhandled status code (e.g. 418)', async () => {
+    vi.mocked(axiosWithCredentials.get).mockRejectedValueOnce(
+      createAxiosError('Teapot', '418', 418),
+    );
+
+    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+      PUBLIC_KEY_OWNER_DEFAULT_MESSAGE,
+    );
+  });
+
+  test('throws connection error when server is unreachable', async () => {
     const axiosError = new AxiosError('Network Error', 'ERR_NETWORK');
     vi.mocked(axiosWithCredentials.get).mockRejectedValueOnce(axiosError);
 
-    const result = await getPublicKeyOwner(serverUrl, publicKey);
-
-    expect(result).toBeNull();
-  });
-
-  test('throws non-Axios errors (unexpected runtime bugs)', async () => {
-    vi.mocked(axiosWithCredentials.get).mockRejectedValueOnce(
-      new TypeError('Cannot read properties of undefined'),
+    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+      'Failed to connect to the server',
     );
-
-    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(TypeError);
-  });
-
-  test('throws RangeError instead of swallowing it', async () => {
-    vi.mocked(axiosWithCredentials.get).mockRejectedValueOnce(
-      new RangeError('Invalid array length'),
-    );
-
-    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(RangeError);
   });
 });


### PR DESCRIPTION
Fixes [#2411](https://github.com/hashgraph/hedera-transaction-tool/issues/2411)

**Description**:
Users report repeated "Failed to get owner of the public key" errors.

**Debug**
The issue description suggested two database-level causes:

- "Deleted users whose public keys remain in the system" (orphaned keys)
- "Deleted keys included in queries where the user is deleted"

I tested all database scenarios.

Scenario | User State | Key State | API Response | Error?
-- | -- | -- | -- | --
Both exist | alive | alive | 200 + email | No
Both soft-deleted (normal removeUser flow) | deleted | deleted | 200 + empty | No
Scenario 1: User deleted, key alive (orphan) | deleted | alive | 200 + empty | No
Scenario 2: User alive, key deleted | alive | deleted | 200 + empty | No

Both `User` and `UserKey` entities use TypeORM's `@DeleteDateColumn()`. TypeORM automatically appends `WHERE "deletedAt" IS NULL `to all queries, so soft-deleted records are invisible to `findOne()`. The query always returns either a valid user email or `null` — never an error.

I tested the HTTP error path by blacklisting the JWT token in Redis to simulate session expiry:

> docker exec cache redis-cli SET "<jwt_token>" "blacklisted" EX 300

This caused all authenticated requests to return 401 Unauthorized. Results:
Those errors appeared: 
- "Failed to get owner of the public key" 
- "Your session may have expired. Try refreshing the page and signing in again." 

**Solution**:
Replace commonRequestHandler with try/catch in getPublicKeyOwner() to
return null on any HTTP error instead of throwing a generic error message.

The root cause was that getPublicKeyOwner() passed no messageOn401 or
statusMessages to commonRequestHandler, so 401 responses (expired JWT,
blacklisted token) fell through to a generic error. The PublicKeyOwnerCache
(4.5s TTL) did not store rejected promises, causing an infinite retry loop
that spammed users with unhelpful "Failed to get owner of the public key"
toasts every 4.5 seconds.