### PR TITLE
chore: pin solo to version 0.63.0 in frontend CI workflow

### DIFF
--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -160,7 +160,7 @@ jobs:
         if: ${{ matrix.test-suite.soloRequired }}
         run: |
           set -euo pipefail
-          npm install -g @hashgraph/solo
+          npm install -g @hashgraph/solo@0.63.0
           solo --version
           kind --version
 


### PR DESCRIPTION
**Description**:
Updated the installation command for `@hashgraph/solo` in `.github/workflows/test-frontend.yaml` to use a specific version (`0.63.0`) instead of the latest, which helps prevent unexpected issues due to upstream changes.

**Related issue(s)**:

Fixes #2557 
