### PR TITLE
chore: do not use GH secrets to configure PRIVATE_KEY and OPERATOR_KEY in CI

### DIFF
--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -395,8 +395,6 @@ jobs:
       - name: Run Automation
         env:
           EXECUTABLE_PATH: ../front-end/release/linux-unpacked/hedera-transaction-tool
-          PRIVATE_KEY: ${{ secrets.SOLO_PRIVATE_KEY }}
-          OPERATOR_KEY: ${{ secrets.OPERATOR_KEY }}
           ENVIRONMENT: LOCALNET
           ORGANIZATION_URL: ${{ matrix.test-suite.backendRequired && 'https://localhost:3001' || '' }}
           POSTGRES_HOST: ${{ matrix.test-suite.backendRequired && 'localhost' || '' }}


### PR DESCRIPTION
**Description**:

Do not use GitHub secrets to configure PRIVATE_KEY and OPERATOR_KEY environment variables but instead rely on the default behaviour of automation tests which use the solo genesis account key as OPERATOR_KEY and start by creating an  account which will further be used as payer for all created transactions.
