### PR TITLE
chore: pin solo version to 0.64.0 in the frontend CI workflow

### DIFF
--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -140,7 +140,7 @@ jobs:
         if: ${{ matrix.test-suite.soloRequired }}
         run: |
           set -euo pipefail
-          npm install -g @hashgraph/solo
+          npm install -g @hashgraph/solo@0.64.0
           solo --version
           kind --version
 


### PR DESCRIPTION
**Description**:

Require solo v0.64.0 in `test-frontend.yaml` CI workflow (instead of latest).

**Related issue(s)**:

Fixes #2557
