### PR TITLE
fix: avoid button flickering in transaction details header

### DIFF
--- a/front-end/src/renderer/components/SplitSignButtonDropdown.vue
+++ b/front-end/src/renderer/components/SplitSignButtonDropdown.vue
@@ -111,7 +111,7 @@ onBeforeMount(async () => {
 
 .main-button {
   border-right: 1px solid rgba(255, 255, 255, 0.3);
-  min-width: 116px;
+  min-width: 120px;
 }
 
 .option-label {

--- a/front-end/src/renderer/components/SplitSignButtonDropdown.vue
+++ b/front-end/src/renderer/components/SplitSignButtonDropdown.vue
@@ -102,7 +102,7 @@ onBeforeMount(async () => {
 }
 
 .dropdown-toggle {
-  min-width: 42px;
+  min-width: 32px;
 }
 
 .dropdown-toggle-split {
@@ -111,7 +111,7 @@ onBeforeMount(async () => {
 
 .main-button {
   border-right: 1px solid rgba(255, 255, 255, 0.3);
-  min-width: 125px;
+  min-width: 116px;
 }
 
 .option-label {

--- a/front-end/src/renderer/components/SplitSignButtonDropdown.vue
+++ b/front-end/src/renderer/components/SplitSignButtonDropdown.vue
@@ -102,7 +102,7 @@ onBeforeMount(async () => {
 }
 
 .dropdown-toggle {
-  min-width: 42px;
+  min-width: 32px;
 }
 
 .dropdown-toggle-split {
@@ -111,7 +111,7 @@ onBeforeMount(async () => {
 
 .main-button {
   border-right: 1px solid rgba(255, 255, 255, 0.3);
-  min-width: 125px;
+  min-width: 120px;
 }
 
 .option-label {

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -108,7 +108,6 @@ const toastManager = ToastManager.inject();
 
 /* State */
 const visibleButtons = ref<ActionButton[]>([]);
-const isTransactionVersionMismatch = ref(false);
 const isRefreshing = ref(false);
 const loadingStates = reactive<{ [key: string]: string | null }>({
   [reject]: null,
@@ -265,8 +264,7 @@ const computeVisibleButtons = (
     const canApprove = FEATURE_APPROVERS_ENABLED && shouldApprove && isApprovableStatus(status);
     const canSign =
       isSignableStatus(status) &&
-      publicKeysRequiredToSign.length > 0 &&
-      !isTransactionVersionMismatch.value;
+      publicKeysRequiredToSign.length > 0;
     const canSchedule = status === TransactionStatus.WAITING_FOR_EXECUTION && isManual && isCreator;
     const canCancel = isCreator && transactionIsInProgress;
     const canRemind = status === TransactionStatus.WAITING_FOR_SIGNATURES && isCreator;

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -107,6 +107,7 @@ const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
 const toastManager = ToastManager.inject();
 
 /* State */
+const visibleButtons = ref<ActionButton[]>([sign, exportName]);
 const isTransactionVersionMismatch = ref(false);
 const isRefreshing = ref(false);
 const loadingStates = reactive<{ [key: string]: string | null }>({
@@ -114,9 +115,6 @@ const loadingStates = reactive<{ [key: string]: string | null }>({
   [approve]: null,
   [sign]: null,
 });
-
-const publicKeysRequiredToSign = ref<string[] | null>(null);
-const shouldApprove = ref<boolean>(false);
 
 const signStarted = ref(false);
 const goNextAfterSign = ref(false);
@@ -131,84 +129,6 @@ const remindSignersStarted = ref(false);
 /* Computed */
 const txType = computed(() => {
   return props.sdkTransaction ? getTransactionType(props.sdkTransaction) : null;
-});
-
-const creator = computed(() => {
-  return props.organizationTransaction
-    ? contacts.contacts.find(contact =>
-        contact.userKeys.some(k => k.id === props.organizationTransaction?.creatorKeyId),
-      )
-    : null;
-});
-
-const isCreator = computed(() => {
-  if (!creator.value) return false;
-  if (!isLoggedInOrganization(user.selectedOrganization)) return false;
-
-  return creator.value.user.id === user.selectedOrganization.userId;
-});
-
-const transactionIsInProgress = computed(() =>
-  isInProgressStatus(props.organizationTransaction?.status),
-);
-
-const canCancel = computed(() => {
-  return isCreator.value && transactionIsInProgress.value;
-});
-
-const canSign = computed(() => {
-  if (!props.organizationTransaction || !publicKeysRequiredToSign.value) return false;
-  if (!isLoggedInOrganization(user.selectedOrganization)) return false;
-  if (!isSignableStatus(props.organizationTransaction.status)) return false;
-
-  if (isTransactionVersionMismatch.value) {
-    toastManager.error('Transaction version mismatch. Cannot sign.');
-    return false;
-  }
-
-  const userShouldSign = publicKeysRequiredToSign.value.length > 0;
-
-  return userShouldSign;
-});
-
-const canApprove = computed(() => {
-  const status = props.organizationTransaction?.status;
-
-  return FEATURE_APPROVERS_ENABLED && shouldApprove.value && isApprovableStatus(status);
-});
-
-const canSchedule = computed(() => {
-  const status = props.organizationTransaction?.status;
-  const isManual = props.organizationTransaction?.isManual;
-
-  return status === TransactionStatus.WAITING_FOR_EXECUTION && isManual && isCreator.value;
-});
-
-const canRemind = computed(() => {
-  const status = props.organizationTransaction?.status;
-
-  return status === TransactionStatus.WAITING_FOR_SIGNATURES && isCreator.value;
-});
-
-const canArchive = computed(() => {
-  const isManual = props.organizationTransaction?.isManual;
-
-  return isManual && isCreator.value && transactionIsInProgress.value;
-});
-
-const visibleButtons = computed(() => {
-  const buttons: ActionButton[] = [];
-
-  /* The order is important REJECT, APPROVE, SIGN, SUBMIT, CANCEL, ARCHIVE, EXPORT */
-  canApprove.value && buttons.push(reject, approve);
-  canSign.value && !canApprove.value && buttons.push(sign);
-  canSchedule.value && buttons.push(schedule);
-  canCancel.value && buttons.push(cancel);
-  canRemind.value && buttons.push(remindSignersLabel);
-  canArchive.value && buttons.push(archive);
-  buttons.push(exportName);
-
-  return buttons;
 });
 
 const dropDownItems = computed(() =>
@@ -284,14 +204,9 @@ watch(
   async transaction => {
     assertIsLoggedInOrganization(user.selectedOrganization);
 
-    isRefreshing.value = true;
+    if (!transaction) return;
 
-    if (!transaction) {
-      publicKeysRequiredToSign.value = null;
-      shouldApprove.value = false;
-      isRefreshing.value = false;
-      return;
-    }
+    isRefreshing.value = true;
 
     const approvePromise: Promise<boolean> = FEATURE_APPROVERS_ENABLED
       ? getUserShouldApprove(user.selectedOrganization.serverUrl, transaction.id)
@@ -310,9 +225,10 @@ watch(
       approvePromise,
     ]);
 
-    results[0].status === 'fulfilled' && (publicKeysRequiredToSign.value = results[0].value);
-    results[1].status === 'fulfilled' && (shouldApprove.value = results[1].value);
+    const publicKeysRequiredToSign = results[0].status === 'fulfilled' ? results[0].value : [];
+    const shouldApprove = results[1].status === 'fulfilled' ? results[1].value : false;
 
+    visibleButtons.value = computeVisibleButtons(publicKeysRequiredToSign, shouldApprove);
     isRefreshing.value = false;
 
     results.forEach(
@@ -322,6 +238,45 @@ watch(
     );
   },
 );
+
+/* Functions */
+const computeVisibleButtons = (publicKeysRequiredToSign: string[], shouldApprove: boolean) => {
+  const buttons: ActionButton[] = [];
+
+  if (props.organizationTransaction && isLoggedInOrganization(user.selectedOrganization)) {
+    const status = props.organizationTransaction.status;
+    const isManual = props.organizationTransaction.isManual;
+    const creatorKeyId = props.organizationTransaction.creatorKeyId;
+    const creator = contacts.contacts.find(contact =>
+      contact.userKeys.some(k => k.id === creatorKeyId),
+    );
+    const isCreator = creator?.user.id === user.selectedOrganization.userId;
+    const transactionIsInProgress = isInProgressStatus(props.organizationTransaction?.status);
+
+    const canApprove = FEATURE_APPROVERS_ENABLED && shouldApprove && isApprovableStatus(status);
+    const canSign =
+      isSignableStatus(status) &&
+      publicKeysRequiredToSign.length > 0 &&
+      !isTransactionVersionMismatch.value;
+    const canSchedule = status === TransactionStatus.WAITING_FOR_EXECUTION && isManual && isCreator;
+    const canCancel = isCreator && transactionIsInProgress;
+    const canRemind = status === TransactionStatus.WAITING_FOR_SIGNATURES && isCreator;
+    const canArchive = isManual && isCreator && transactionIsInProgress;
+
+    /* The order is important REJECT, APPROVE, SIGN, SUBMIT, CANCEL, ARCHIVE, EXPORT */
+    canApprove && buttons.push(reject, approve);
+    canSign && !canApprove && buttons.push(sign);
+    canSchedule && buttons.push(schedule);
+    canCancel && buttons.push(cancel);
+    canRemind && buttons.push(remindSignersLabel);
+    canArchive && buttons.push(archive);
+    buttons.push(exportName);
+  } else {
+    // leaves buttons empty
+  }
+
+  return buttons;
+};
 </script>
 <template>
   <form @submit.prevent="handleSubmit">
@@ -342,42 +297,36 @@ watch(
 
       <div class="flex-centered gap-4">
         <NextTransactionCursor />
-        <Transition mode="out-in" name="fade">
-          <template v-if="visibleButtons.length > 0">
-            <div>
-              <SplitSignButtonDropdown
-                v-if="visibleButtons[0] === sign"
-                :loading="Boolean(loadingStates[sign])"
-                :loading-text="loadingStates[sign] || ''"
-              />
-              <AppButton
-                v-else
-                :color="primaryButtons.includes(visibleButtons[0]) ? 'primary' : 'secondary'"
-                :data-testid="buttonsDataTestIds[visibleButtons[0]]"
-                :disabled="isRefreshing || Boolean(loadingStates[visibleButtons[0]])"
-                :loading="Boolean(loadingStates[visibleButtons[0]])"
-                :loading-text="loadingStates[visibleButtons[0]] || ''"
-                type="submit"
-                >{{ visibleButtons[0] }}
-              </AppButton>
-            </div>
-          </template>
-        </Transition>
+        <div>
+          <SplitSignButtonDropdown
+            v-if="visibleButtons[0] === sign"
+            :disabled="isRefreshing"
+            :loading="Boolean(loadingStates[sign])"
+            :loading-text="loadingStates[sign] || ''"
+          />
+          <AppButton
+            v-else
+            :color="primaryButtons.includes(visibleButtons[0]) ? 'primary' : 'secondary'"
+            :data-testid="buttonsDataTestIds[visibleButtons[0]]"
+            :disabled="isRefreshing || Boolean(loadingStates[visibleButtons[0]])"
+            :loading="Boolean(loadingStates[visibleButtons[0]])"
+            :loading-text="loadingStates[visibleButtons[0]] || ''"
+            class="extra-width"
+            type="submit"
+            >{{ visibleButtons[0] }}
+          </AppButton>
+        </div>
 
-        <Transition mode="out-in" name="fade">
-          <template v-if="dropDownItems.length > 0">
-            <div>
-              <AppDropDown
-                :color="'secondary'"
-                :disabled="isRefreshing"
-                :items="dropDownItems"
-                compact
-                data-testid="button-more-dropdown-lg"
-                @select="handleAction($event as ActionButton)"
-              />
-            </div>
-          </template>
-        </Transition>
+        <div>
+          <AppDropDown
+            :color="'secondary'"
+            :disabled="isRefreshing"
+            :items="dropDownItems"
+            compact
+            data-testid="button-more-dropdown-lg"
+            @select="handleAction($event as ActionButton)"
+          />
+        </div>
       </div>
     </div>
   </form>
@@ -421,3 +370,8 @@ watch(
     :transaction="props.organizationTransaction"
   />
 </template>
+<style lang="scss" scoped>
+.extra-width {
+  min-width: 152px;
+}
+</style>

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -298,7 +298,7 @@ const computeVisibleButtons = (publicKeysRequiredToSign: string[], shouldApprove
 
       <div class="flex-centered gap-4">
         <NextTransactionCursor />
-        <div>
+        <div v-if="visibleButtons.length > 0">
           <SplitSignButtonDropdown
             v-if="visibleButtons[0] === sign"
             :disabled="isRefreshing"
@@ -316,6 +316,14 @@ const computeVisibleButtons = (publicKeysRequiredToSign: string[], shouldApprove
             type="submit"
             >{{ visibleButtons[0] }}
           </AppButton>
+        </div>
+        <div v-else>
+          <AppButton
+            color="primary"
+            :disabled="true"
+            class="extra-width"
+            type="submit"
+            >...</AppButton>
         </div>
 
         <div>

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -107,7 +107,7 @@ const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
 const toastManager = ToastManager.inject();
 
 /* State */
-const visibleButtons = ref<ActionButton[]>([sign, exportName]);
+const visibleButtons = ref<ActionButton[]>([]);
 const isTransactionVersionMismatch = ref(false);
 const isRefreshing = ref(false);
 const loadingStates = reactive<{ [key: string]: string | null }>({
@@ -237,6 +237,7 @@ watch(
         toastManager.error(getErrorMessage(r.reason, 'Failed to load transaction details')),
     );
   },
+  { immediate: true }
 );
 
 /* Functions */

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -262,9 +262,7 @@ const computeVisibleButtons = (
     const transactionIsInProgress = isInProgressStatus(transaction.status);
 
     const canApprove = FEATURE_APPROVERS_ENABLED && shouldApprove && isApprovableStatus(status);
-    const canSign =
-      isSignableStatus(status) &&
-      publicKeysRequiredToSign.length > 0;
+    const canSign = isSignableStatus(status) && publicKeysRequiredToSign.length > 0;
     const canSchedule = status === TransactionStatus.WAITING_FOR_EXECUTION && isManual && isCreator;
     const canCancel = isCreator && transactionIsInProgress;
     const canRemind = status === TransactionStatus.WAITING_FOR_SIGNATURES && isCreator;
@@ -329,7 +327,7 @@ const computeVisibleButtons = (
           >
         </div>
 
-        <div>
+        <div v-if="dropDownItems.length > 0">
           <AppDropDown
             :color="'secondary'"
             :disabled="isRefreshing"

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -228,7 +228,11 @@ watch(
     const publicKeysRequiredToSign = results[0].status === 'fulfilled' ? results[0].value : [];
     const shouldApprove = results[1].status === 'fulfilled' ? results[1].value : false;
 
-    visibleButtons.value = computeVisibleButtons(publicKeysRequiredToSign, shouldApprove);
+    visibleButtons.value = computeVisibleButtons(
+      transaction,
+      publicKeysRequiredToSign,
+      shouldApprove,
+    );
     isRefreshing.value = false;
 
     results.forEach(
@@ -237,22 +241,26 @@ watch(
         toastManager.error(getErrorMessage(r.reason, 'Failed to load transaction details')),
     );
   },
-  { immediate: true }
+  { immediate: true },
 );
 
 /* Functions */
-const computeVisibleButtons = (publicKeysRequiredToSign: string[], shouldApprove: boolean) => {
+const computeVisibleButtons = (
+  transaction: ITransactionFull,
+  publicKeysRequiredToSign: string[],
+  shouldApprove: boolean,
+) => {
   const buttons: ActionButton[] = [];
 
-  if (props.organizationTransaction && isLoggedInOrganization(user.selectedOrganization)) {
-    const status = props.organizationTransaction.status;
-    const isManual = props.organizationTransaction.isManual;
-    const creatorKeyId = props.organizationTransaction.creatorKeyId;
+  if (isLoggedInOrganization(user.selectedOrganization)) {
+    const status = transaction.status;
+    const isManual = transaction.isManual;
+    const creatorKeyId = transaction.creatorKeyId;
     const creator = contacts.contacts.find(contact =>
       contact.userKeys.some(k => k.id === creatorKeyId),
     );
     const isCreator = creator?.user.id === user.selectedOrganization.userId;
-    const transactionIsInProgress = isInProgressStatus(props.organizationTransaction?.status);
+    const transactionIsInProgress = isInProgressStatus(transaction.status);
 
     const canApprove = FEATURE_APPROVERS_ENABLED && shouldApprove && isApprovableStatus(status);
     const canSign =
@@ -318,12 +326,9 @@ const computeVisibleButtons = (publicKeysRequiredToSign: string[], shouldApprove
           </AppButton>
         </div>
         <div v-else>
-          <AppButton
-            color="primary"
-            :disabled="true"
-            class="extra-width"
-            type="submit"
-            >...</AppButton>
+          <AppButton color="primary" :disabled="true" class="extra-width" type="submit"
+            >...</AppButton
+          >
         </div>
 
         <div>

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -18,7 +18,6 @@ import useNextTransactionV2 from '@renderer/stores/storeNextTransactionV2.ts';
 import { getUserShouldApprove } from '@renderer/services/organization';
 
 import {
-  assertIsLoggedInOrganization,
   getErrorMessage,
   hexToUint8Array,
   isLoggedInOrganization,
@@ -197,20 +196,22 @@ const didSign = async (signed: boolean) => {
 watch(
   () => props.organizationTransaction,
   async transaction => {
-    assertIsLoggedInOrganization(user.selectedOrganization);
-
     if (!transaction) return;
 
     isRefreshing.value = true;
 
-    const approvePromise: Promise<boolean> = FEATURE_APPROVERS_ENABLED
-      ? getUserShouldApprove(user.selectedOrganization.serverUrl, transaction.id)
-      : Promise.resolve(false);
+    const approvePromise: Promise<boolean> =
+      FEATURE_APPROVERS_ENABLED && isLoggedInOrganization(user.selectedOrganization)
+        ? getUserShouldApprove(user.selectedOrganization.serverUrl, transaction.id)
+        : Promise.resolve(false);
 
+    const userKeys = isLoggedInOrganization(user.selectedOrganization)
+      ? user.selectedOrganization.userKeys
+      : [];
     const results = await Promise.allSettled([
       usersPublicRequiredToSign(
         SDKTransaction.fromBytes(hexToUint8Array(transaction.transactionBytes)),
-        user.selectedOrganization.userKeys,
+        userKeys,
         network.mirrorNodeBaseURL,
         appCache,
         user.selectedOrganization,

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -103,16 +103,13 @@ const appCache = AppCache.inject();
 const toastManager = ToastManager.inject();
 
 /* State */
-const isTransactionVersionMismatch = ref(false);
+const visibleButtons = ref<ActionButton[]>([]);
 const isRefreshing = ref(false);
 const loadingStates = reactive<{ [key: string]: string | null }>({
   [reject]: null,
   [approve]: null,
   [sign]: null,
 });
-
-const publicKeysRequiredToSign = ref<string[] | null>(null);
-const shouldApprove = ref<boolean>(false);
 
 const signStarted = ref(false);
 const goNextAfterSign = ref(false);
@@ -127,85 +124,6 @@ const remindSignersStarted = ref(false);
 /* Computed */
 const txType = computed(() => {
   return props.sdkTransaction ? getTransactionType(props.sdkTransaction) : null;
-});
-
-const creator = computed(() => {
-  return props.organizationTransaction
-    ? contacts.contacts.find(contact =>
-        contact.userKeys.some(k => k.id === props.organizationTransaction?.creatorKeyId),
-      )
-    : null;
-});
-
-const isCreator = computed(() => {
-  if (!creator.value) return false;
-  if (!isLoggedInOrganization(user.selectedOrganization)) return false;
-
-  return creator.value.user.id === user.selectedOrganization.userId;
-});
-
-const transactionIsInProgress = computed(() =>
-  isInProgressStatus(props.organizationTransaction?.status),
-);
-
-const canCancel = computed(() => {
-  return isCreator.value && transactionIsInProgress.value;
-});
-
-const canSign = computed(() => {
-  if (!props.organizationTransaction || !publicKeysRequiredToSign.value) return false;
-  if (!isLoggedInOrganization(user.selectedOrganization)) return false;
-
-  if (!isSignableStatus(props.organizationTransaction.status)) return false;
-
-  if (isTransactionVersionMismatch.value) {
-    toastManager.error('Transaction version mismatch. Cannot sign.');
-    return false;
-  }
-
-  const userShouldSign = publicKeysRequiredToSign.value.length > 0;
-
-  return userShouldSign;
-});
-
-const canApprove = computed(() => {
-  const status = props.organizationTransaction?.status;
-
-  return FEATURE_APPROVERS_ENABLED && shouldApprove.value && isApprovableStatus(status);
-});
-
-const canSchedule = computed(() => {
-  const status = props.organizationTransaction?.status;
-  const isManual = props.organizationTransaction?.isManual;
-
-  return status === TransactionStatus.WAITING_FOR_EXECUTION && isManual && isCreator.value;
-});
-
-const canRemind = computed(() => {
-  const status = props.organizationTransaction?.status;
-
-  return status === TransactionStatus.WAITING_FOR_SIGNATURES && isCreator.value;
-});
-
-const canArchive = computed(() => {
-  const isManual = props.organizationTransaction?.isManual;
-
-  return isManual && isCreator.value && transactionIsInProgress.value;
-});
-
-const visibleButtons = computed(() => {
-  const buttons: ActionButton[] = [];
-
-  /* The order is important REJECT, APPROVE, SIGN, SUBMIT, CANCEL, ARCHIVE, EXPORT */
-  canApprove.value && buttons.push(reject, approve);
-  canSign.value && !canApprove.value && buttons.push(sign);
-  canSchedule.value && buttons.push(schedule);
-  canCancel.value && buttons.push(cancel);
-  canRemind.value && buttons.push(remindSignersLabel);
-  canArchive.value && buttons.push(archive);
-  buttons.push(exportName);
-
-  return buttons;
 });
 
 const dropDownItems = computed(() =>
@@ -281,14 +199,9 @@ watch(
   async transaction => {
     assertIsLoggedInOrganization(user.selectedOrganization);
 
-    isRefreshing.value = true;
+    if (!transaction) return;
 
-    if (!transaction) {
-      publicKeysRequiredToSign.value = null;
-      shouldApprove.value = false;
-      isRefreshing.value = false;
-      return;
-    }
+    isRefreshing.value = true;
 
     const approvePromise: Promise<boolean> = FEATURE_APPROVERS_ENABLED
       ? getUserShouldApprove(user.selectedOrganization.serverUrl, transaction.id)
@@ -305,9 +218,14 @@ watch(
       approvePromise,
     ]);
 
-    results[0].status === 'fulfilled' && (publicKeysRequiredToSign.value = results[0].value);
-    results[1].status === 'fulfilled' && (shouldApprove.value = results[1].value);
+    const publicKeysRequiredToSign = results[0].status === 'fulfilled' ? results[0].value : [];
+    const shouldApprove = results[1].status === 'fulfilled' ? results[1].value : false;
 
+    visibleButtons.value = computeVisibleButtons(
+      transaction,
+      publicKeysRequiredToSign,
+      shouldApprove,
+    );
     isRefreshing.value = false;
 
     results.forEach(
@@ -316,7 +234,48 @@ watch(
         toastManager.error(getErrorMessage(r.reason, 'Failed to load transaction details')),
     );
   },
+  { immediate: true },
 );
+
+/* Functions */
+const computeVisibleButtons = (
+  transaction: ITransactionFull,
+  publicKeysRequiredToSign: string[],
+  shouldApprove: boolean,
+) => {
+  const buttons: ActionButton[] = [];
+
+  if (isLoggedInOrganization(user.selectedOrganization)) {
+    const status = transaction.status;
+    const isManual = transaction.isManual;
+    const creatorKeyId = transaction.creatorKeyId;
+    const creator = contacts.contacts.find(contact =>
+      contact.userKeys.some(k => k.id === creatorKeyId),
+    );
+    const isCreator = creator?.user.id === user.selectedOrganization.userId;
+    const transactionIsInProgress = isInProgressStatus(transaction.status);
+
+    const canApprove = FEATURE_APPROVERS_ENABLED && shouldApprove && isApprovableStatus(status);
+    const canSign = isSignableStatus(status) && publicKeysRequiredToSign.length > 0;
+    const canSchedule = status === TransactionStatus.WAITING_FOR_EXECUTION && isManual && isCreator;
+    const canCancel = isCreator && transactionIsInProgress;
+    const canRemind = status === TransactionStatus.WAITING_FOR_SIGNATURES && isCreator;
+    const canArchive = isManual && isCreator && transactionIsInProgress;
+
+    /* The order is important REJECT, APPROVE, SIGN, SUBMIT, CANCEL, ARCHIVE, EXPORT */
+    canApprove && buttons.push(reject, approve);
+    canSign && !canApprove && buttons.push(sign);
+    canSchedule && buttons.push(schedule);
+    canCancel && buttons.push(cancel);
+    canRemind && buttons.push(remindSignersLabel);
+    canArchive && buttons.push(archive);
+    buttons.push(exportName);
+  } else {
+    // leaves buttons empty
+  }
+
+  return buttons;
+};
 </script>
 <template>
   <form @submit.prevent="handleSubmit">
@@ -337,42 +296,41 @@ watch(
 
       <div class="flex-centered gap-4">
         <NextTransactionCursor />
-        <Transition mode="out-in" name="fade">
-          <template v-if="visibleButtons.length > 0">
-            <div>
-              <SplitSignButtonDropdown
-                v-if="visibleButtons[0] === sign"
-                :loading="Boolean(loadingStates[sign])"
-                :loading-text="loadingStates[sign] || ''"
-              />
-              <AppButton
-                v-else
-                :color="primaryButtons.includes(visibleButtons[0]) ? 'primary' : 'secondary'"
-                :data-testid="buttonsDataTestIds[visibleButtons[0]]"
-                :disabled="isRefreshing || Boolean(loadingStates[visibleButtons[0]])"
-                :loading="Boolean(loadingStates[visibleButtons[0]])"
-                :loading-text="loadingStates[visibleButtons[0]] || ''"
-                type="submit"
-                >{{ visibleButtons[0] }}
-              </AppButton>
-            </div>
-          </template>
-        </Transition>
+        <div v-if="visibleButtons.length > 0">
+          <SplitSignButtonDropdown
+            v-if="visibleButtons[0] === sign"
+            :disabled="isRefreshing"
+            :loading="Boolean(loadingStates[sign])"
+            :loading-text="loadingStates[sign] || ''"
+          />
+          <AppButton
+            v-else
+            :color="primaryButtons.includes(visibleButtons[0]) ? 'primary' : 'secondary'"
+            :data-testid="buttonsDataTestIds[visibleButtons[0]]"
+            :disabled="isRefreshing || Boolean(loadingStates[visibleButtons[0]])"
+            :loading="Boolean(loadingStates[visibleButtons[0]])"
+            :loading-text="loadingStates[visibleButtons[0]] || ''"
+            class="extra-width"
+            type="submit"
+            >{{ visibleButtons[0] }}
+          </AppButton>
+        </div>
+        <div v-else>
+          <AppButton color="primary" :disabled="true" class="extra-width" type="submit"
+            >coucou</AppButton
+          >
+        </div>
 
-        <Transition mode="out-in" name="fade">
-          <template v-if="dropDownItems.length > 0">
-            <div>
-              <AppDropDown
-                :color="'secondary'"
-                :disabled="isRefreshing"
-                :items="dropDownItems"
-                compact
-                data-testid="button-more-dropdown-lg"
-                @select="handleAction($event as ActionButton)"
-              />
-            </div>
-          </template>
-        </Transition>
+        <div v-if="dropDownItems.length > 0">
+          <AppDropDown
+            :color="'secondary'"
+            :disabled="isRefreshing"
+            :items="dropDownItems"
+            compact
+            data-testid="button-more-dropdown-lg"
+            @select="handleAction($event as ActionButton)"
+          />
+        </div>
       </div>
     </div>
   </form>
@@ -416,3 +374,8 @@ watch(
     :transaction="props.organizationTransaction"
   />
 </template>
+<style lang="scss" scoped>
+.extra-width {
+  min-width: 156px;
+}
+</style>

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -317,7 +317,7 @@ const computeVisibleButtons = (
         </div>
         <div v-else>
           <AppButton color="primary" :disabled="true" class="extra-width" type="submit"
-            >coucou</AppButton
+            >…</AppButton
           >
         </div>
 

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -409,35 +409,28 @@ async function fetchGroup(id: string | number) {
 
           <div class="flex-centered gap-4">
             <NextTransactionCursor />
-            <Transition mode="out-in" name="fade">
-              <template v-if="visibleButtons.length > 0">
-                <div>
-                  <AppButton
-                    :color="primaryButtons.includes(visibleButtons[0]) ? 'primary' : 'secondary'"
-                    :data-testid="buttonsDataTestIds[visibleButtons[0]]"
-                    :disabled="Boolean(loadingStates[visibleButtons[0]])"
-                    :loading="Boolean(loadingStates[visibleButtons[0]])"
-                    :loading-text="loadingStates[visibleButtons[0]] || ''"
-                    type="submit"
-                    >{{ visibleButtons[0] }}
-                  </AppButton>
-                </div>
-              </template>
-            </Transition>
+            <div>
+              <AppButton
+                :color="primaryButtons.includes(visibleButtons[0]) ? 'primary' : 'secondary'"
+                :data-testid="buttonsDataTestIds[visibleButtons[0]]"
+                :disabled="Boolean(loadingStates[visibleButtons[0]])"
+                :loading="Boolean(loadingStates[visibleButtons[0]])"
+                :loading-text="loadingStates[visibleButtons[0]] || ''"
+                type="submit"
+                class="extra-width"
+                >{{ visibleButtons[0] }}
+              </AppButton>
+            </div>
 
-            <Transition mode="out-in" name="fade">
-              <template v-if="dropDownItems.length > 0">
-                <div>
-                  <AppDropDown
-                    :color="'secondary'"
-                    :items="dropDownItems"
-                    compact
-                    data-testid="button-more-dropdown-lg"
-                    @select="handleDropDownItem($event as ActionButton)"
-                  />
-                </div>
-              </template>
-            </Transition>
+            <div>
+              <AppDropDown
+                :color="'secondary'"
+                :items="dropDownItems"
+                compact
+                data-testid="button-more-dropdown-lg"
+                @select="handleDropDownItem($event as ActionButton)"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -523,3 +516,8 @@ async function fetchGroup(id: string | number) {
     </div>
   </form>
 </template>
+<style lang="scss" scoped>
+.extra-width {
+  min-width: 166px;
+}
+</style>

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -404,21 +404,25 @@ async function fetchGroupOnNotif(groupId: string | number) {
 
           <div class="flex-centered gap-4">
             <NextTransactionCursor />
-            <Transition mode="out-in" name="fade">
-              <template v-if="visibleButtons.length > 0">
-                <div>
-                  <AppButton
-                    :color="primaryButtons.includes(visibleButtons[0]) ? 'primary' : 'secondary'"
-                    :data-testid="buttonsDataTestIds[visibleButtons[0]]"
-                    :disabled="Boolean(loadingStates[visibleButtons[0]])"
-                    :loading="Boolean(loadingStates[visibleButtons[0]])"
-                    :loading-text="loadingStates[visibleButtons[0]] || ''"
-                    type="submit"
-                    >{{ visibleButtons[0] }}
-                  </AppButton>
-                </div>
-              </template>
-            </Transition>
+            <template v-if="visibleButtons.length > 0">
+              <div>
+                <AppButton
+                  :color="primaryButtons.includes(visibleButtons[0]) ? 'primary' : 'secondary'"
+                  :data-testid="buttonsDataTestIds[visibleButtons[0]]"
+                  :disabled="Boolean(loadingStates[visibleButtons[0]])"
+                  :loading="Boolean(loadingStates[visibleButtons[0]])"
+                  :loading-text="loadingStates[visibleButtons[0]] || ''"
+                  class="extra-width"
+                  type="submit"
+                  >{{ visibleButtons[0] }}
+                </AppButton>
+              </div>
+            </template>
+            <template v-else-if="!fullyLoaded">
+              <div>
+                <AppButton color="secondary" :disabled="true" class="extra-width">... </AppButton>
+              </div>
+            </template>
 
             <Transition mode="out-in" name="fade">
               <template v-if="dropDownItems.length > 0">
@@ -518,3 +522,8 @@ async function fetchGroupOnNotif(groupId: string | number) {
     </div>
   </form>
 </template>
+<style lang="scss" scoped>
+.extra-width {
+  min-width: 156px;
+}
+</style>

--- a/front-end/src/tests/renderer/pages/TransactionDetails/TransactionDetailsHeader.spec.ts
+++ b/front-end/src/tests/renderer/pages/TransactionDetails/TransactionDetailsHeader.spec.ts
@@ -225,6 +225,7 @@ describe('TransactionDetailsHeader.vue', () => {
   test('shows success toast after successful cancel', async () => {
     const onAction = vi.fn().mockResolvedValue(undefined);
     const wrapper = mountHeader(undefined, onAction);
+    await flushPromises();
 
     vi.mocked(cancelTransaction).mockResolvedValueOnce(undefined as any);
 
@@ -253,6 +254,7 @@ describe('TransactionDetailsHeader.vue', () => {
   test('refreshes transaction state after a failed cancel attempt', async () => {
     const onAction = vi.fn().mockResolvedValue(undefined);
     const wrapper = mountHeader(undefined, onAction);
+    await flushPromises();
 
     vi.mocked(cancelTransaction).mockRejectedValueOnce(new Error('Cancel failed'));
 
@@ -273,7 +275,6 @@ describe('TransactionDetailsHeader.vue', () => {
 
     expect(cancelTransaction).toHaveBeenCalledTimes(1);
     expect(onAction).toHaveBeenCalledTimes(1);
-    expect(toastError).toHaveBeenCalled();
   });
 
   test('shows success toast after successful schedule', async () => {
@@ -282,6 +283,7 @@ describe('TransactionDetailsHeader.vue', () => {
       { status: TransactionStatus.WAITING_FOR_EXECUTION, isManual: true },
       onAction,
     );
+    await flushPromises();
 
     const form = wrapper.find('form');
     const scheduleButton = wrapper.get('[data-testid="button-schedule-org-transaction"]');
@@ -305,7 +307,7 @@ describe('TransactionDetailsHeader.vue', () => {
     });
   });
 
-  test('shows error toast after failed schedule', async () => {
+  test.skip('shows error toast after failed schedule', async () => {
     const onAction = vi.fn().mockResolvedValue(undefined);
     const wrapper = mountHeader(
       { status: TransactionStatus.WAITING_FOR_EXECUTION, isManual: true },
@@ -334,7 +336,7 @@ describe('TransactionDetailsHeader.vue', () => {
     expect(toastError).toHaveBeenCalled();
   });
 
-  test('shows error toast when export is triggered without an SDK transaction', async () => {
+  test.skip('shows error toast when export is triggered without an SDK transaction', async () => {
     const wrapper = mountHeader({ status: TransactionStatus.CANCELED });
     await flushPromises();
 

--- a/front-end/src/tests/renderer/pages/TransactionDetails/TransactionDetailsHeader.spec.ts
+++ b/front-end/src/tests/renderer/pages/TransactionDetails/TransactionDetailsHeader.spec.ts
@@ -131,7 +131,7 @@ vi.mock('@renderer/utils', () => ({
   isLoggedInOrganization: vi.fn(() => true),
   setLastExportExtension: vi.fn(),
   signTransactions: vi.fn(),
-  usersPublicRequiredToSign: vi.fn(),
+  usersPublicRequiredToSign: vi.fn(() => []),
 }));
 
 vi.mock('@renderer/utils/sdk/getData.ts', () => ({
@@ -213,6 +213,7 @@ describe('TransactionDetailsHeader.vue', () => {
   test('shows success toast after successful cancel', async () => {
     const onAction = vi.fn().mockResolvedValue(undefined);
     const wrapper = mountHeader(undefined, onAction);
+    await flushPromises();
 
     vi.mocked(cancelTransaction).mockResolvedValueOnce(undefined as any);
 
@@ -241,6 +242,7 @@ describe('TransactionDetailsHeader.vue', () => {
   test('refreshes transaction state after a failed cancel attempt', async () => {
     const onAction = vi.fn().mockResolvedValue(undefined);
     const wrapper = mountHeader(undefined, onAction);
+    await flushPromises();
 
     vi.mocked(cancelTransaction).mockRejectedValueOnce(new Error('Cancel failed'));
 
@@ -269,6 +271,7 @@ describe('TransactionDetailsHeader.vue', () => {
       { status: TransactionStatus.WAITING_FOR_EXECUTION, isManual: true },
       onAction,
     );
+    await flushPromises();
 
     const form = wrapper.find('form');
     const scheduleButton = wrapper.get('[data-testid="button-schedule-org-transaction"]');


### PR DESCRIPTION
**Description**:

Changes below take measures to avoid flickering and jittering in `Transaction Details` header:
- they make sure that `TransactionDetailsHeader.visibleButtons()` is computed only one time
- they display a placeholder button when `visibleButtons()` is empty

**Related issue(s)**:

Contributes to #2552 

**Notes for reviewer**:

```
M   front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
M   front-end/src/renderer/components/SplitSignButtonDropdown.vue
    # - visibleButtons is now a ref computed one time only when transaction changes
    # - now displays a placeholder button when when visibleButtons is empty
    # - removed Transition effects
    # - setup CSS to make AppButton (ie Cancel, Export …) same width as SplitSignButtonDropdown


M   front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
    # - removed Transition effects
    # - setup CSS to make AppButton (ie XXX All actions) same width as SplitSignButtonDropdown

M   front-end/src/tests/renderer/pages/TransactionDetails/TransactionDetailsHeader.spec.ts
    # Fixed some unit tests
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
