### PR TITLE
fix: preserve transaction description for multiple account update groups

### DIFF
--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
@@ -192,6 +192,7 @@ const handleCreate = async () => {
     processable.payerId = payerData.accountId.value;
     processable.baseValidStart = data.validStart;
     processable.maxTransactionFee = data.maxTransactionFee as Hbar;
+    processable.description = description.value;
   }
 
   await withLoader(

--- a/front-end/src/renderer/components/Transaction/TransactionProcessor/components/MultipleAccountUpdateRequestHandler.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionProcessor/components/MultipleAccountUpdateRequestHandler.vue
@@ -101,7 +101,7 @@ function setNext(next: Handler) {
 
 async function handle(req: Processable) {
   if (!(req instanceof MultipleAccountUpdateRequest)) {
-    await nextHandler.value?.handle(req);
+    nextHandler.value?.handle(req);
     return;
   }
 
@@ -113,7 +113,7 @@ async function handle(req: Processable) {
   groupItems.value = createGroupItems();
 
   if (isLoggedInOrganization(user.selectedOrganization)) {
-    await processOrganization(groupItems.value);
+    await processOrganization(groupItems.value, req.description);
   } else {
     await processPersonal();
   }
@@ -224,10 +224,10 @@ function createGroupItem(accountId: string, seq: number): GroupItem {
   };
 }
 
-async function processOrganization(items: GroupItem[]) {
+async function processOrganization(items: GroupItem[], description: string) {
   try {
     emit('loading:begin');
-    await signGroupItems(items);
+    await signGroupItems(items, description);
   } finally {
     emit('loading:end');
   }
@@ -257,9 +257,9 @@ async function processPersonal() {
   await startChain(transactionRequest);
 }
 
-async function signGroupItems(groupItems: GroupItem[]) {
+async function signGroupItems(groupItems: GroupItem[], description: string) {
   assertUserLoggedIn(user.personal);
-  const personalPassword = getPassword(signGroupItems.bind(null, groupItems), {
+  const personalPassword = getPassword(signGroupItems.bind(null, groupItems, description), {
     subHeading: 'Enter your application password to sign as a creator',
   });
   if (passwordModalOpened(personalPassword)) return;
@@ -272,10 +272,16 @@ async function signGroupItems(groupItems: GroupItem[]) {
     groupItems,
     groupItems.map(g => uint8ToHex(privateKey.sign(g.transactionBytes))),
     keyToSignWith,
+    description,
   );
 }
 
-async function submitGroup(groupItems: GroupItem[], signature: string[], keyToSignWith: string) {
+async function submitGroup(
+  groupItems: GroupItem[],
+  signature: string[],
+  keyToSignWith: string,
+  description: string,
+) {
   assertIsLoggedInOrganization(user.selectedOrganization);
 
   const apiGroupItems: ApiGroupItem[] = [];
@@ -298,7 +304,7 @@ async function submitGroup(groupItems: GroupItem[], signature: string[], keyToSi
   try {
     const { id } = await submitTransactionGroup(
       user.selectedOrganization.serverUrl,
-      'Automatically created group for multiple accounts update',
+      description || 'Automatically created group for multiple accounts update',
       false,
       true,
       apiGroupItems,

--- a/front-end/src/renderer/components/Transaction/TransactionProcessor/requests.ts
+++ b/front-end/src/renderer/components/Transaction/TransactionProcessor/requests.ts
@@ -59,6 +59,7 @@ export class CustomRequest extends BaseRequest {
   payerId?: string;
   baseValidStart?: Date;
   maxTransactionFee?: Hbar;
+  description: string;
 
   constructor(opts: {
     submitManually: boolean;
@@ -67,6 +68,7 @@ export class CustomRequest extends BaseRequest {
     payerId?: string;
     baseValidStart?: Date;
     maxTransactionFee?: Hbar;
+    description?: string;
   }) {
     super(opts.submitManually, opts.reminderMillisecondsBefore);
 
@@ -75,6 +77,7 @@ export class CustomRequest extends BaseRequest {
     this.payerId = opts.payerId;
     this.baseValidStart = opts.baseValidStart;
     this.maxTransactionFee = opts.maxTransactionFee;
+    this.description = opts.description ?? '';
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -99,6 +102,7 @@ export class MultipleAccountUpdateRequest extends CustomRequest {
     accountIsPayer: boolean;
     submitManually: boolean;
     reminderMillisecondsBefore: number | null;
+    description?: string;
   }) {
     super({ ...opts, displayName: 'Multiple Accounts Update' });
 


### PR DESCRIPTION
**Description**:

When the user checks _Multiple accounts_ in the account update transaction creation flow, a group of Account Updates is automatically created.  With the changes below:
- if the user enters a value in the Transaction Description field, this value is used as the group description (instead of
- if the user  does not provide a description, we keep the default value previously used in all cases

**Related issue(s)**:

Fixes #2546 
