### PR TITLE
chore: add build:mac:arm64 target

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -21,6 +21,7 @@
     "postinstall": "electron-builder install-app-deps && prisma generate && node ../notice-gen/index.js",
     "build:win": "pnpm run build && electron-builder --win --config",
     "build:mac": "pnpm run build && electron-builder --mac",
+    "build:mac:arm64": "pnpm run build && electron-builder --mac default --arm64",
     "build:linux": "pnpm run build && electron-builder --linux --config",
     "publish": "pnpm run build && electron-builder -m -p 'onTagOrDraft'",
     "test": "pnpm run test:main && pnpm run test:renderer && pnpm run test:shared",


### PR DESCRIPTION
**Description**:

One line change to `package.json` to add the build target `build:mac:arm64` -- to build only for arm64 architecture in development since the full electron-build is painfully slow.