### PR TITLE
fix: app menu highlighting

### DIFF
--- a/front-end/src/renderer/components/Menu.vue
+++ b/front-end/src/renderer/components/Menu.vue
@@ -96,6 +96,7 @@ const organizationOnly = ['/contact-list'];
         class="link-menu mt-2"
         to="/settings/general"
         :class="{ active: $route.path.startsWith('/settings') }"
+        @click="router.appMenuItem = 'settings'"
         draggable="false"
         data-testid="button-menu-settings"
         ><i class="bi bi-gear"></i><span>Settings</span></RouterLink


### PR DESCRIPTION
**Description**:

One-line fix to make sure router.appMenuItem is updated when user selects Settings.

Fixes #2612 