### PR TITLE
fix: caching  GET /transactions/{transactionId} (addendum)

### DIFF
--- a/front-end/src/renderer/caches/base/EntityCache.ts
+++ b/front-end/src/renderer/caches/base/EntityCache.ts
@@ -28,9 +28,15 @@ export abstract class EntityCache<K extends string | number, E> {
     return result;
   }
 
-  public forget(key: K, mirrorNodeUrl: string): void {
+  public forget(key: K, mirrorNodeUrl: string, strict = true): void {
     const recordKey = this.makeRecordKey(key, mirrorNodeUrl);
-    this.records.delete(recordKey);
+    const currentRecord = this.records.get(recordKey);
+    if (currentRecord) {
+      // When strict is off, we forget only if data is 1s old (help for notification mgt)
+      if (strict || currentRecord.age() > 1000) {
+        this.records.delete(recordKey);
+      }
+    }
   }
 
   // public clear(): void {

--- a/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
@@ -71,11 +71,11 @@ const notifications = useNotificationsStore();
 const router = useRouter();
 useWebsocketSubscription(TRANSACTION_ACTION, async (payload?: unknown) => {
   const parsed = parseTransactionActionPayload(payload);
-  if (!parsed) { await fetchTransaction(); return; } // Legacy fallback
+  if (!parsed) { await fetchTransactionOnNotif(); return; } // Legacy fallback
 
   // If initial fetch hasn't completed yet, fall back to a full refetch
   if (!orgTransaction.value && !localTransaction.value) {
-    await fetchTransaction();
+    await fetchTransactionOnNotif();
     return;
   }
 
@@ -83,7 +83,7 @@ useWebsocketSubscription(TRANSACTION_ACTION, async (payload?: unknown) => {
   const currentGroupId = orgTransaction.value?.groupItem?.groupId;
   if (parsed.transactionIds.includes(currentId) ||
       (currentGroupId && parsed.groupIds.includes(currentGroupId))) {
-    await fetchTransaction();
+    await fetchTransactionOnNotif();
   }
 });
 useSetDynamicLayout(LOGGED_IN_LAYOUT);
@@ -238,6 +238,17 @@ async function fetchTransaction() {
   }
 
   feePayer.value = getTransactionPayerId(sdkTransaction.value);
+}
+
+async function fetchTransactionOnNotif(): Promise<void> {
+  // 1) Before calling fetchTransaction(), we clear transaction cache
+  const id = Number(formattedId.value);
+  if (isLoggedInOrganization(user.selectedOrganization) && !isNaN(id)) {
+    // We clear cache with strict==false to keep young data
+    transactionCache.forget(id, user.selectedOrganization.serverUrl, false);
+  }
+  // 2) Now fetch transaction
+  await fetchTransaction();
 }
 
 /* Hooks */

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -51,6 +51,7 @@ import SignAllController from '@renderer/pages/TransactionGroupDetails/SignAllCo
 import CancelAllController from '@renderer/pages/TransactionGroupDetails/CancelAllController.vue';
 import ExportAllController from '@renderer/pages/TransactionGroupDetails/ExportAllController.vue';
 import ApproveAllController from '@renderer/pages/TransactionGroupDetails/ApproveAllController.vue';
+import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache';
 
 /* Types */
 type ActionButton = 'Reject All' | 'Approve All' | 'Sign All' | 'Cancel All' | 'Export All';
@@ -73,6 +74,9 @@ const buttonsDataTestIds: { [key: string]: string } = {
   [exportName]: 'button-export-group',
 };
 
+/* Injected */
+const transactionCache = BackendTransactionCache.inject();
+
 /* Stores */
 const user = useUserStore();
 const network = useNetwork();
@@ -87,13 +91,13 @@ useWebsocketSubscription(TRANSACTION_ACTION, async (payload?: unknown) => {
   const id = router.currentRoute.value.params.id;
   const groupId = Number(Array.isArray(id) ? id[0] : id);
   if (!parsed) {
-    await fetchGroup(groupId);
+    await fetchGroupOnNotif(groupId);
     return;
   } // Legacy fallback
 
   // If initial fetch hasn't completed yet, fall back to a full refetch
   if (!group.value) {
-    await fetchGroup(groupId);
+    await fetchGroupOnNotif(groupId);
     return;
   }
 
@@ -101,7 +105,7 @@ useWebsocketSubscription(TRANSACTION_ACTION, async (payload?: unknown) => {
     parsed.groupIds.includes(groupId) ||
     (group.value.groupItems?.some(item => parsed.transactionIds.includes(item.transactionId)) ??
       false);
-  if (isAffected) await fetchGroup(groupId);
+  if (isAffected) await fetchGroupOnNotif(groupId);
 });
 useSetDynamicLayout(LOGGED_IN_LAYOUT);
 const createTooltips = useCreateTooltips();
@@ -387,6 +391,19 @@ async function fetchGroup(id: string | number) {
   } else {
     logger.info('Not logged into org');
   }
+}
+
+async function fetchGroupOnNotif(groupId: string | number) {
+  // 1) Before calling fetchGroup(), we clear transaction cache
+  if (isLoggedInOrganization(user.selectedOrganization) && group.value !== null) {
+    const serverUrl = user.selectedOrganization.serverUrl;
+    for (const item of group.value.groupItems) {
+      // We clear cache with strict==false to keep young data
+      transactionCache.forget(item.transactionId, serverUrl, false);
+    }
+  }
+  // 2) Now fetch group
+  await fetchGroup(groupId);
 }
 </script>
 <template>

--- a/front-end/src/renderer/pages/Transactions/components/History.vue
+++ b/front-end/src/renderer/pages/Transactions/components/History.vue
@@ -63,6 +63,10 @@ const LOCAL_TO_ORG_SORT: Record<string, keyof ITransaction> = {
   executed_at: 'executedAt',
 };
 import { TransactionNodeCollection } from '../../../../../../shared/src/ITransactionNode.ts';
+import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
+
+/* Injected */
+const transactionCache = BackendTransactionCache.inject();
 
 /* Stores */
 const user = useUserStore();
@@ -75,9 +79,9 @@ const { recentlyUpdatedTxIds, highlightAndFetch } = useTransactionLiveHighlight(
 
 useWebsocketSubscription(TRANSACTION_ACTION, async (payload?: unknown) => {
   const parsed = parseTransactionActionPayload(payload);
-  if (!parsed) { await fetchTransactions(); return; } // Legacy fallback
+  if (!parsed) { await fetchTransactionsOnNotif(); return; } // Legacy fallback
 
-  const silentFetch = () => fetchTransactions({ silent: true });
+  const silentFetch = () => fetchTransactionsOnNotif({ silent: true });
 
   // Status updates can move transactions into History — always refetch
   if (parsed.eventType === TRANSACTION_EVENT_TYPE.STATUS_UPDATE) {
@@ -260,6 +264,19 @@ async function fetchTransactions(options?: { silent?: boolean }) {
   } finally {
     isLoading.value = false;
   }
+}
+
+async function fetchTransactionsOnNotif(options?: { silent?: boolean }) {
+  // 1) Before calling fetchTransactions(), we clear transaction cache
+  if (isLoggedInOrganization(user.selectedOrganization)) {
+    const serverUrl = user.selectedOrganization.serverUrl;
+    for (const t of organizationTransactions.value) {
+      // We clear cache with strict==false to keep young data
+      transactionCache.forget(t.transactionRaw.transactionId, serverUrl, false);
+    }
+  }
+  // 2) Now fetch group
+  await fetchTransactions(options);
 }
 
 /**

--- a/front-end/src/renderer/pages/Transactions/components/TransactionNodeTable.vue
+++ b/front-end/src/renderer/pages/Transactions/components/TransactionNodeTable.vue
@@ -33,6 +33,7 @@ import { parseTransactionActionPayload } from '@renderer/utils/parseTransactionA
 import { useTransactionLiveHighlight } from '@renderer/composables/useTransactionLiveHighlight';
 import { useRouter } from 'vue-router';
 import useTableQueryState from '@renderer/composables/useTableQueryState.ts';
+import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
 
 const NOTIFICATION_TYPES_BY_COLLECTION: Record<TransactionNodeCollection, NotificationType[]> = {
   [TransactionNodeCollection.READY_FOR_REVIEW]: [],
@@ -61,6 +62,9 @@ const emit = defineEmits<{
   (event: 'nodesFetched', value: ITransactionNode[]): void;
 }>();
 
+/* Injected */
+const transactionCache = BackendTransactionCache.inject();
+
 /* Stores */
 const user = useUserStore();
 const network = useNetworkStore();
@@ -75,11 +79,11 @@ const { recentlyUpdatedTxIds, recentlyUpdatedGroupIds, highlightAndFetch } = use
 useWebsocketSubscription(TRANSACTION_ACTION, async (payload?: unknown) => {
   const parsed = parseTransactionActionPayload(payload);
   if (!parsed) {
-    await fetchNodes();
+    await fetchNodesOnNotif();
     return;
   }
 
-  const silentFetch = () => fetchNodes({ silent: true });
+  const silentFetch = () => fetchNodesOnNotif({ silent: true });
 
   // Status updates can move items between collections — always refetch
   if (parsed.eventType === TRANSACTION_EVENT_TYPE.STATUS_UPDATE) {
@@ -258,6 +262,21 @@ function clampPage(): void {
   if (currentPage.value > totalPages) {
     currentPage.value = totalPages;
   }
+}
+
+async function fetchNodesOnNotif(options?: { silent?: boolean }): Promise<void> {
+  // 1) Before calling fetchNodes(), we clear transaction cache
+  if (isLoggedInOrganization(user.selectedOrganization)) {
+    const serverUrl = user.selectedOrganization.serverUrl;
+    for (const node of nodes.value) {
+      // We clear cache with strict==false to keep young data
+      if (node.transactionId) {
+        transactionCache.forget(node.transactionId, serverUrl, false);
+      }
+    }
+  }
+  // 2) Now fetch group
+  await fetchNodes(options);
 }
 
 /* Watchers */


### PR DESCRIPTION
**Description**:

This PR is a follow-up of #2626.

Changes below add some logic for clearing transaction cache when notifications are received.
When a `TRANSACTION_NOTIFICATION` arrives, `EntityCache.forget()` is called to remove existing data from BackendTransactionCache. However this removal is conditional : data are removed only if they are 1s or more old.
This behavior enables to avoid clearing the cache when notification is received immediately after a full refresh.

**Related issue(s)**:

Contributions to #2521

**Notes for reviewer**:

```
M   front-end/src/renderer/caches/base/EntityCache.ts
    # Added 'strict' parameter to EntityCache.forget()
    # When strict == true, forget() behavior is unchanged : entry is removed from cache.
    # When strict == false, forget() removes data if it is older than 1s
    # Default value is strict = true.

M   front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
M   front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
M   front-end/src/renderer/pages/Transactions/components/History.vue
M   front-end/src/renderer/pages/Transactions/components/TransactionNodeTable.vue
    # In useWebsocketSubscription(), those view now invoke a specialized fetch():
    # fetchXXXOnNotif() calls regular fetchXXX() but after calling BackendTransactionCache.forget().
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
