### PR TITLE
fix: require freezeWith of transaction in transaction.service.ts if unfrozen

### DIFF
--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -663,7 +663,10 @@ describe('TransactionsService', () => {
     });
 
     it('should throw on transaction create if expired', async () => {
-      const sdkTransaction = new AccountCreateTransaction();
+      const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      const sdkTransaction = new AccountCreateTransaction().setTransactionId(
+        new TransactionId(AccountId.fromString('0.0.1'), Timestamp.fromDate(oneDayAgo)),
+      );
 
       const dto: CreateTransactionDto = {
         name: 'Transaction 1',

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -924,9 +924,6 @@ export class TransactionsService {
       throw new BadRequestException(ErrorCodes.TNVN);
     }
 
-    // Freeze transaction with shared client
-    sdkTransaction.freezeWith(client);
-
     const transactionHash = await sdkTransaction.getTransactionHash();
     const transactionType = getTransactionTypeEnumValue(sdkTransaction);
 

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -908,6 +908,11 @@ export class TransactionsService {
     // Parse SDK transaction
     const sdkTransaction = SDKTransaction.fromBytes(dto.transactionBytes);
 
+    // Check the transaction is frozen, cannot require it to be frozen, breaks backwards compatibility
+    if (!sdkTransaction.isFrozen()) {
+      sdkTransaction.freezeWith(client);
+    }
+
     // Check if expired
     if (isExpired(sdkTransaction)) {
       throw new BadRequestException(ErrorCodes.TE);


### PR DESCRIPTION
**Description**:
The JS SDK does a bit of extra work in transaction.freezeWith that was not expected if the transaction contains signatures. The SDK team is looking into it. For our part, the transaction does not need an extra freezeWith call before saving the transaction if the transaction is already frozen. It appears that we cannot assume that the transactions from the frontend are frozen, so a check has been added.

**Related issue(s)**:

Fixes #2670
