### PR TITLE
fix: Investigate flaky backend cache query test in CI

### DIFF
--- a/back-end/apps/notifications/jest.config.ts
+++ b/back-end/apps/notifications/jest.config.ts
@@ -13,6 +13,9 @@ const config: Config = {
     '^@app/common(|/.*)$': '<rootDir>/../../libs/common/src/$1',
     '^@entities(|/.*)$': '<rootDir>/../../libs/common/src/database/entities/$1',
   },
+  // Diagnostic (issue #2576): surface leaked timers/sockets/ioredis clients
+  // that would otherwise be attributed to whichever suite is active at teardown.
+  detectOpenHandles: true,
 };
 
 export default config;

--- a/back-end/apps/notifications/jest.config.ts
+++ b/back-end/apps/notifications/jest.config.ts
@@ -16,6 +16,10 @@ const config: Config = {
   // Diagnostic (issue #2576): surface leaked timers/sockets/ioredis clients
   // that would otherwise be attributed to whichever suite is active at teardown.
   detectOpenHandles: true,
+  // Install per-worker unhandled-error + ioredis-constructor logging so the
+  // worker that leaks a real Redis client identifies itself, regardless of
+  // which spec happens to be active when the retry budget expires.
+  setupFiles: ['<rootDir>/../../test-utils/jest.setup.diag.ts'],
 };
 
 export default config;

--- a/back-end/apps/notifications/jest.config.ts
+++ b/back-end/apps/notifications/jest.config.ts
@@ -13,12 +13,7 @@ const config: Config = {
     '^@app/common(|/.*)$': '<rootDir>/../../libs/common/src/$1',
     '^@entities(|/.*)$': '<rootDir>/../../libs/common/src/database/entities/$1',
   },
-  // Diagnostic (issue #2576): surface leaked timers/sockets/ioredis clients
-  // that would otherwise be attributed to whichever suite is active at teardown.
   detectOpenHandles: true,
-  // Install per-worker unhandled-error + ioredis-constructor logging so the
-  // worker that leaks a real Redis client identifies itself, regardless of
-  // which spec happens to be active when the retry budget expires.
   setupFiles: ['<rootDir>/../../test-utils/jest.setup.diag.ts'],
 };
 

--- a/back-end/apps/notifications/jest.config.ts
+++ b/back-end/apps/notifications/jest.config.ts
@@ -4,7 +4,11 @@ import baseConfig from '../../jest.config';
 const includeLibs = process.env.INCLUDE_LIBS !== '0';
 // Diagnostics (issue #2576) are CI-only by default: GitHub Actions sets CI=true
 // automatically. Local dev gets the fast path; opt back in with JEST_DIAG=1.
-const enableDiag = Boolean(process.env.CI || process.env.JEST_DIAG);
+// The `!== '0'` matches the INCLUDE_LIBS convention above so explicit opt-out
+// (CI=false / JEST_DIAG=0) actually disables.
+const enableDiag =
+  process.env.CI === 'true' ||
+  (process.env.JEST_DIAG !== undefined && process.env.JEST_DIAG !== '0');
 
 const config: Config = {
   ...baseConfig,

--- a/back-end/apps/notifications/jest.config.ts
+++ b/back-end/apps/notifications/jest.config.ts
@@ -1,14 +1,8 @@
 import type { Config } from 'jest';
 import baseConfig from '../../jest.config';
+import { enableDiag } from '../../test-utils/diag-enabled';
 
 const includeLibs = process.env.INCLUDE_LIBS !== '0';
-// Diagnostics (issue #2576) are CI-only by default: GitHub Actions sets CI=true
-// automatically. Local dev gets the fast path; opt back in with JEST_DIAG=1.
-// The `!== '0'` matches the INCLUDE_LIBS convention above so explicit opt-out
-// (CI=false / JEST_DIAG=0) actually disables.
-const enableDiag =
-  process.env.CI === 'true' ||
-  (process.env.JEST_DIAG !== undefined && process.env.JEST_DIAG !== '0');
 
 const config: Config = {
   ...baseConfig,

--- a/back-end/apps/notifications/jest.config.ts
+++ b/back-end/apps/notifications/jest.config.ts
@@ -2,6 +2,9 @@ import type { Config } from 'jest';
 import baseConfig from '../../jest.config';
 
 const includeLibs = process.env.INCLUDE_LIBS !== '0';
+// Diagnostics (issue #2576) are CI-only by default: GitHub Actions sets CI=true
+// automatically. Local dev gets the fast path; opt back in with JEST_DIAG=1.
+const enableDiag = Boolean(process.env.CI || process.env.JEST_DIAG);
 
 const config: Config = {
   ...baseConfig,
@@ -13,8 +16,8 @@ const config: Config = {
     '^@app/common(|/.*)$': '<rootDir>/../../libs/common/src/$1',
     '^@entities(|/.*)$': '<rootDir>/../../libs/common/src/database/entities/$1',
   },
-  detectOpenHandles: true,
-  setupFiles: ['<rootDir>/../../test-utils/jest.setup.diag.ts'],
+  detectOpenHandles: enableDiag,
+  setupFiles: enableDiag ? ['<rootDir>/../../test-utils/jest.setup.diag.ts'] : [],
 };
 
 export default config;

--- a/back-end/apps/notifications/src/email/email.service.spec.ts
+++ b/back-end/apps/notifications/src/email/email.service.spec.ts
@@ -14,6 +14,30 @@ import { EmailService } from './email.service';
 import { Notification, NotificationType } from '@entities';
 
 jest.mock('nodemailer');
+// Issue #2576: `EmailService` → `new DebouncedNotificationBatcher()` eagerly
+// constructs two real ioredis clients and calls `.subscribe(...)` in its
+// constructor. On CI there's no Redis on localhost, so each `it` in this
+// spec was leaking a pair of retrying ioredis clients that eventually hit
+// `maxRetriesPerRequest` and fired `MaxRetriesPerRequestError` — which Jest
+// then mis-attributed to whichever spec happened to be active (commonly
+// `cache.queries.spec.ts`). Mocking `ioredis` here follows the pattern used
+// in `blacklist.service.spec.ts`, `scheduler.service.spec.ts`, and
+// `redis-io.adapter.spec.ts`.
+jest.mock('ioredis', () => {
+  class MockRedis {
+    subscribe = jest.fn();
+    on = jest.fn();
+    disconnect = jest.fn();
+    set = jest.fn();
+    get = jest.fn();
+    del = jest.fn();
+    rpush = jest.fn();
+    lrange = jest.fn().mockResolvedValue([]);
+    pexpire = jest.fn();
+    keys = jest.fn().mockResolvedValue([]);
+  }
+  return { Redis: MockRedis };
+});
 jest.mock('@app/common', () => ({
   generateEmailContent: jest.fn(),
   generateUserRegisteredMessage: jest.fn(),

--- a/back-end/apps/notifications/src/email/email.service.spec.ts
+++ b/back-end/apps/notifications/src/email/email.service.spec.ts
@@ -14,15 +14,6 @@ import { EmailService } from './email.service';
 import { Notification, NotificationType } from '@entities';
 
 jest.mock('nodemailer');
-// Issue #2576: `EmailService` → `new DebouncedNotificationBatcher()` eagerly
-// constructs two real ioredis clients and calls `.subscribe(...)` in its
-// constructor. On CI there's no Redis on localhost, so each `it` in this
-// spec was leaking a pair of retrying ioredis clients that eventually hit
-// `maxRetriesPerRequest` and fired `MaxRetriesPerRequestError` — which Jest
-// then mis-attributed to whichever spec happened to be active (commonly
-// `cache.queries.spec.ts`). Mocking `ioredis` here follows the pattern used
-// in `blacklist.service.spec.ts`, `scheduler.service.spec.ts`, and
-// `redis-io.adapter.spec.ts`.
 jest.mock('ioredis', () => {
   class MockRedis {
     subscribe = jest.fn();

--- a/back-end/apps/notifications/src/websocket/websocket.gateway.spec.ts
+++ b/back-end/apps/notifications/src/websocket/websocket.gateway.spec.ts
@@ -16,11 +16,6 @@ import { roomKeys } from './helpers';
 
 jest.mock('./middlewares/auth-websocket.middleware');
 jest.mock('./middlewares/frontend-version-websocket.middleware');
-// Issue #2576: `WebsocketGateway` → `new DebouncedNotificationBatcher()`
-// eagerly constructs two real ioredis clients and calls `.subscribe(...)`.
-// Same fix as `email.service.spec.ts`: replace the ioredis module with a
-// class whose methods are all jest.fn() so the NestJS TestingModule can
-// instantiate the gateway without opening real sockets.
 jest.mock('ioredis', () => {
   class MockRedis {
     subscribe = jest.fn();

--- a/back-end/apps/notifications/src/websocket/websocket.gateway.spec.ts
+++ b/back-end/apps/notifications/src/websocket/websocket.gateway.spec.ts
@@ -16,6 +16,26 @@ import { roomKeys } from './helpers';
 
 jest.mock('./middlewares/auth-websocket.middleware');
 jest.mock('./middlewares/frontend-version-websocket.middleware');
+// Issue #2576: `WebsocketGateway` → `new DebouncedNotificationBatcher()`
+// eagerly constructs two real ioredis clients and calls `.subscribe(...)`.
+// Same fix as `email.service.spec.ts`: replace the ioredis module with a
+// class whose methods are all jest.fn() so the NestJS TestingModule can
+// instantiate the gateway without opening real sockets.
+jest.mock('ioredis', () => {
+  class MockRedis {
+    subscribe = jest.fn();
+    on = jest.fn();
+    disconnect = jest.fn();
+    set = jest.fn();
+    get = jest.fn();
+    del = jest.fn();
+    rpush = jest.fn();
+    lrange = jest.fn().mockResolvedValue([]);
+    pexpire = jest.fn();
+    keys = jest.fn().mockResolvedValue([]);
+  }
+  return { Redis: MockRedis };
+});
 
 describe('WebsocketGateway', () => {
   let gateway: WebsocketGateway;

--- a/back-end/libs/common/src/sql/queries/cache.queries.spec.ts
+++ b/back-end/libs/common/src/sql/queries/cache.queries.spec.ts
@@ -4,11 +4,6 @@ import { createTestPostgresDataSource } from '../../../../../test-utils/postgres
 import { getUpsertRefreshTokenForCacheQuery, SqlBuilderService } from '@app/common';
 import { randomUUID } from 'node:crypto';
 
-// Diagnostic logging (issue #2576). Prefixed so CI logs are greppable.
-// Process-level unhandledRejection / uncaughtException / ioredis-constructor
-// listeners are installed globally via `setupFiles` in the Notifications
-// Jest config (test-utils/jest.setup.diag.ts). This spec only adds hook
-// timing logs below.
 const DIAG_TAG = '[cache.queries.spec]';
 function diag(message: string, extra?: Record<string, unknown>) {
   const payload = {

--- a/back-end/libs/common/src/sql/queries/cache.queries.spec.ts
+++ b/back-end/libs/common/src/sql/queries/cache.queries.spec.ts
@@ -5,6 +5,10 @@ import { getUpsertRefreshTokenForCacheQuery, SqlBuilderService } from '@app/comm
 import { randomUUID } from 'node:crypto';
 
 // Diagnostic logging (issue #2576). Prefixed so CI logs are greppable.
+// Process-level unhandledRejection / uncaughtException / ioredis-constructor
+// listeners are installed globally via `setupFiles` in the Notifications
+// Jest config (test-utils/jest.setup.diag.ts). This spec only adds hook
+// timing logs below.
 const DIAG_TAG = '[cache.queries.spec]';
 function diag(message: string, extra?: Record<string, unknown>) {
   const payload = {
@@ -15,27 +19,6 @@ function diag(message: string, extra?: Record<string, unknown>) {
   };
   // eslint-disable-next-line no-console
   console.log(`${DIAG_TAG} ${message}`, payload);
-}
-
-// Capture background rejections so they aren't silently attributed to whichever
-// suite happens to be active. We attach once per worker process.
-const g = globalThis as unknown as { __cacheQueriesDiagInstalled?: boolean };
-if (!g.__cacheQueriesDiagInstalled) {
-  g.__cacheQueriesDiagInstalled = true;
-  process.on('unhandledRejection', (reason) => {
-    diag('process:unhandledRejection', {
-      message: (reason as Error)?.message ?? String(reason),
-      name: (reason as Error)?.name,
-      stack: (reason as Error)?.stack,
-    });
-  });
-  process.on('uncaughtException', (err) => {
-    diag('process:uncaughtException', {
-      message: err?.message,
-      name: err?.name,
-      stack: err?.stack,
-    });
-  });
 }
 
 describe('getUpsertRefreshTokenForCacheQuery - Integration', () => {

--- a/back-end/libs/common/src/sql/queries/cache.queries.spec.ts
+++ b/back-end/libs/common/src/sql/queries/cache.queries.spec.ts
@@ -4,25 +4,104 @@ import { createTestPostgresDataSource } from '../../../../../test-utils/postgres
 import { getUpsertRefreshTokenForCacheQuery, SqlBuilderService } from '@app/common';
 import { randomUUID } from 'node:crypto';
 
+// Diagnostic logging (issue #2576). Prefixed so CI logs are greppable.
+const DIAG_TAG = '[cache.queries.spec]';
+function diag(message: string, extra?: Record<string, unknown>) {
+  const payload = {
+    ts: new Date().toISOString(),
+    pid: process.pid,
+    testName: expect.getState?.().currentTestName ?? null,
+    ...extra,
+  };
+  // eslint-disable-next-line no-console
+  console.log(`${DIAG_TAG} ${message}`, payload);
+}
+
+// Capture background rejections so they aren't silently attributed to whichever
+// suite happens to be active. We attach once per worker process.
+const g = globalThis as unknown as { __cacheQueriesDiagInstalled?: boolean };
+if (!g.__cacheQueriesDiagInstalled) {
+  g.__cacheQueriesDiagInstalled = true;
+  process.on('unhandledRejection', (reason) => {
+    diag('process:unhandledRejection', {
+      message: (reason as Error)?.message ?? String(reason),
+      name: (reason as Error)?.name,
+      stack: (reason as Error)?.stack,
+    });
+  });
+  process.on('uncaughtException', (err) => {
+    diag('process:uncaughtException', {
+      message: err?.message,
+      name: err?.name,
+      stack: err?.stack,
+    });
+  });
+}
+
 describe('getUpsertRefreshTokenForCacheQuery - Integration', () => {
   let dataSource: DataSource;
   let cleanup: () => Promise<void>;
   let sqlBuilder: SqlBuilderService;
 
   beforeAll(async () => {
-    const testDb = await createTestPostgresDataSource();
-    dataSource = testDb.dataSource;
-    cleanup = testDb.cleanup;
-    sqlBuilder = new SqlBuilderService(dataSource.manager);
-  }, 60000);
+    const start = Date.now();
+    diag('beforeAll:start');
+    try {
+      const testDb = await createTestPostgresDataSource();
+      dataSource = testDb.dataSource;
+      cleanup = testDb.cleanup;
+      sqlBuilder = new SqlBuilderService(dataSource.manager);
+      diag('beforeAll:done', { elapsedMs: Date.now() - start });
+    } catch (err) {
+      diag('beforeAll:error', {
+        elapsedMs: Date.now() - start,
+        message: (err as Error)?.message,
+        name: (err as Error)?.name,
+        stack: (err as Error)?.stack,
+      });
+      throw err;
+    }
+  }, 90000);
 
   afterAll(async () => {
-    await cleanup();
+    const start = Date.now();
+    diag('afterAll:start');
+    try {
+      if (cleanup) {
+        await cleanup();
+      } else {
+        diag('afterAll:skip (cleanup undefined — beforeAll likely failed)');
+      }
+      diag('afterAll:done', { elapsedMs: Date.now() - start });
+    } catch (err) {
+      diag('afterAll:error', {
+        elapsedMs: Date.now() - start,
+        message: (err as Error)?.message,
+        stack: (err as Error)?.stack,
+      });
+      throw err;
+    }
+  });
+
+  beforeEach(() => {
+    diag('beforeEach');
   });
 
   afterEach(async () => {
-    await dataSource.getRepository(CachedNode).createQueryBuilder().delete().execute();
-    await dataSource.getRepository(CachedAccount).createQueryBuilder().delete().execute();
+    const start = Date.now();
+    diag('afterEach:start');
+    try {
+      await dataSource.getRepository(CachedNode).createQueryBuilder().delete().execute();
+      await dataSource.getRepository(CachedAccount).createQueryBuilder().delete().execute();
+      diag('afterEach:done', { elapsedMs: Date.now() - start });
+    } catch (err) {
+      diag('afterEach:error', {
+        elapsedMs: Date.now() - start,
+        message: (err as Error)?.message,
+        stack: (err as Error)?.stack,
+      });
+      throw err;
+    }
   });
 
   describe('INSERT path - new records', () => {

--- a/back-end/libs/common/src/sql/queries/cache.queries.spec.ts
+++ b/back-end/libs/common/src/sql/queries/cache.queries.spec.ts
@@ -1,11 +1,13 @@
 import { DataSource } from 'typeorm';
 import { CachedAccount, CachedNode } from '@entities';
 import { createTestPostgresDataSource } from '../../../../../test-utils/postgres-test-db';
+import { enableDiag } from '../../../../../test-utils/diag-enabled';
 import { getUpsertRefreshTokenForCacheQuery, SqlBuilderService } from '@app/common';
 import { randomUUID } from 'node:crypto';
 
 const DIAG_TAG = '[cache.queries.spec]';
 function diag(message: string, extra?: Record<string, unknown>) {
+  if (!enableDiag) return;
   const payload = {
     ts: new Date().toISOString(),
     pid: process.pid,

--- a/back-end/test-utils/diag-enabled.ts
+++ b/back-end/test-utils/diag-enabled.ts
@@ -1,0 +1,14 @@
+/**
+ * Single source of truth for whether diagnostic logging from issue #2576
+ * (the `[jest-diag]`, `[pg-test-db]`, and `[cache.queries.spec]` streams)
+ * should fire.
+ *
+ * Defaults to off so local-dev runs of `createTestPostgresDataSource` and
+ * the integration specs that use it stay quiet. CI runners (GitHub Actions
+ * sets `CI=true`) keep the full instrumentation. Set `JEST_DIAG=1` to opt
+ * in locally; `JEST_DIAG=0` explicitly disables (matches the `INCLUDE_LIBS`
+ * convention in `apps/notifications/jest.config.ts`).
+ */
+export const enableDiag: boolean =
+  process.env.CI === 'true' ||
+  (process.env.JEST_DIAG !== undefined && process.env.JEST_DIAG !== '0');

--- a/back-end/test-utils/jest.setup.diag.ts
+++ b/back-end/test-utils/jest.setup.diag.ts
@@ -87,13 +87,26 @@ function getTestContext(): { testPath: string | null; currentTestName: string | 
 interface DiagState {
   loadedSpecs: Array<{ at: string; testPath: string | null }>;
   ioredisRequireCount: number;
+  connectLoggedCount: number;
+  connectSuppressedCount: number;
 }
 const STATE_KEY = Symbol.for('jestDiag.state');
 const proc = process as unknown as Record<symbol, DiagState | undefined>;
 if (!proc[STATE_KEY]) {
-  proc[STATE_KEY] = { loadedSpecs: [], ioredisRequireCount: 0 };
+  proc[STATE_KEY] = {
+    loadedSpecs: [],
+    ioredisRequireCount: 0,
+    connectLoggedCount: 0,
+    connectSuppressedCount: 0,
+  };
 }
 const state = proc[STATE_KEY]!;
+
+// Cap how many connect logs we emit per worker. Once we've seen a handful
+// we know the culprit; anything beyond that is just noise (the CI log was
+// running into thousands of repeat lines). The suppressed count is reported
+// in `process:exit`.
+const CONNECT_LOG_LIMIT = 5;
 
 // Tag listeners/patches so re-runs of this file are no-ops on the target.
 const LISTENER_TAG = Symbol.for('jestDiag.listener');
@@ -175,6 +188,8 @@ addListenerOnce('exit', (...args) => {
       })),
       totalSpecsLoaded: state.loadedSpecs.length,
       totalIoredisRequires: state.ioredisRequireCount,
+      ioredisConnectLogged: state.connectLoggedCount,
+      ioredisConnectSuppressed: state.connectSuppressedCount,
     });
   } catch (e) {
     diag('process:exit:error', { message: (e as Error)?.message });
@@ -238,10 +253,17 @@ try {
       ) {
         hadConnect = true;
         function patchedConnect(this: unknown, ...args: unknown[]): unknown {
-          diag('ioredis:Redis.connect', {
-            ...getTestContext(),
-            stack: new Error('ioredis Redis.connect').stack,
-          });
+          if (state.connectLoggedCount < CONNECT_LOG_LIMIT) {
+            state.connectLoggedCount += 1;
+            diag('ioredis:Redis.connect', {
+              ...getTestContext(),
+              stack: new Error('ioredis Redis.connect').stack,
+              logged: state.connectLoggedCount,
+              limit: CONNECT_LOG_LIMIT,
+            });
+          } else {
+            state.connectSuppressedCount += 1;
+          }
           return origConnect.apply(this, args);
         }
         (patchedConnect as unknown as { __jestDiagPatched: boolean }).__jestDiagPatched = true;

--- a/back-end/test-utils/jest.setup.diag.ts
+++ b/back-end/test-utils/jest.setup.diag.ts
@@ -1,31 +1,18 @@
 /**
- * Diagnostic setup for issue #2576.
+ * Diagnostic setup for the Notifications Jest config (issue #2576).
  *
- * Registered via `setupFiles` on the Notifications Jest config. Runs once
- * per test file, in every worker process.
+ * Registered via `setupFiles`; runs once per test file, in every worker.
+ * Emits tagged `[jest-diag]` lines to stderr for:
+ *   - test-file lifecycle (`spec:start`)
+ *   - process-level errors (`unhandledRejection`, `uncaughtException`, `warning`)
+ *   - ioredis activity (`ioredis:require`, `ioredis:Redis.connect`,
+ *     `ioredis:Redis.sendCommand:first`) — dragnets every real Redis client
+ *     so a future leak identifies its own caller.
  *
- * The previous iteration used:
- *   - `globalThis.__jestDiagInstalled` as an install guard, which doesn't
- *     persist across test files because Jest resets globals between files.
- *     Result: listeners stacked, the same error logged ~25× per fire.
- *   - `console.log` for output. Jest wraps console to complain with
- *     "Cannot log after tests are done" when a handler fires asynchronously.
- *   - Wrapped only the `Redis` constructor exported from `ioredis`. The
- *     compiled ioredis module ships `Redis` as a getter-only property, so
- *     the assignment threw TypeError and no wrapping actually happened.
- *
- * This iteration fixes all three:
- *   - Every patch and listener install is idempotent per-target. Re-running
- *     the setup per test file is a no-op once any install has happened.
- *   - Output goes to `process.stderr.write`, bypassing Jest's console wrap.
- *   - Patches `Redis.prototype.connect` + `Redis.prototype.sendCommand`,
- *     which every ioredis instance shares regardless of which file
- *     constructed it. Wraps `Module.prototype.require` to log every
- *     `require('ioredis')` call with caller stack.
- *   - Tracks cumulative spec-load order on `process` (keyed by a global
- *     Symbol.for so it survives Jest's module isolation) and dumps the tail
- *     on every unhandledRejection — the culprit spec will be obvious from
- *     timing.
+ * All installs are idempotent per target (listeners keyed by Symbol, patches
+ * by a flag on the function itself), so re-evaluation per test file is a no-op.
+ * Connect logs are capped at CONNECT_LOG_LIMIT per worker; the suppressed
+ * count is reported on `process:exit`.
  */
 
 import type Module from 'module';
@@ -102,10 +89,8 @@ if (!proc[STATE_KEY]) {
 }
 const state = proc[STATE_KEY]!;
 
-// Cap how many connect logs we emit per worker. Once we've seen a handful
-// we know the culprit; anything beyond that is just noise (the CI log was
-// running into thousands of repeat lines). The suppressed count is reported
-// in `process:exit`.
+// First N connect calls per worker get a full log; the rest are counted
+// silently and reported on `process:exit`.
 const CONNECT_LOG_LIMIT = 5;
 
 // Tag listeners/patches so re-runs of this file are no-ops on the target.
@@ -197,10 +182,6 @@ addListenerOnce('exit', (...args) => {
 });
 
 // ---- Intercept every `require('ioredis')` ---------------------------------
-//
-// This runs BEFORE any transitive package loads ioredis, because setupFiles
-// runs before user code. Every require of 'ioredis' (direct or via a
-// dependency) logs its caller's stack so we can see who pulls it in.
 
 try {
   const proto = (NodeModule as unknown as { prototype: { require: (id: string) => unknown } })
@@ -226,15 +207,10 @@ try {
 }
 
 // ---- Patch ioredis prototype methods ---------------------------------------
-//
-// Every ioredis Redis instance — no matter which file imported the class,
-// no matter if some test did `jest.requireActual('ioredis')` — shares the
-// same `Redis.prototype` object. Patching prototype methods is a dragnet a
-// constructor-wrap couldn't be.
-//
-// We do NOT attempt to replace `ioredis.Redis` or `ioredis.default`: the
-// compiled ioredis module ships those as getter-only properties, so
-// assignment throws a TypeError.
+// All Redis instances share `Redis.prototype`, so patching methods there
+// catches every client regardless of import path. We do NOT attempt to
+// replace `ioredis.Redis` / `ioredis.default` because the compiled module
+// ships them as getter-only properties.
 
 let hadConnect = false;
 let hadSendCommand = false;

--- a/back-end/test-utils/jest.setup.diag.ts
+++ b/back-end/test-utils/jest.setup.diag.ts
@@ -1,0 +1,167 @@
+/**
+ * Diagnostic setup for issue #2576.
+ *
+ * Registered via `setupFiles` on the Notifications Jest config so that every
+ * worker process gets these listeners, regardless of which specs it happens
+ * to run. The previous iteration installed listeners from inside
+ * cache.queries.spec.ts, which meant only the worker that loaded that file
+ * got them — and the ioredis-level error can fire in the *other* worker.
+ *
+ * This file exists purely to capture enough context to identify the spec
+ * that creates an unmocked ioredis client. No behavior changes.
+ */
+
+const DIAG_TAG = '[jest-diag]';
+
+function diag(kind: string, extra: Record<string, unknown> = {}) {
+  const payload = {
+    ts: new Date().toISOString(),
+    pid: process.pid,
+    workerId: process.env.JEST_WORKER_ID ?? null,
+    ...extra,
+  };
+  // eslint-disable-next-line no-console
+  console.log(`${DIAG_TAG} ${kind}`, payload);
+}
+
+function getTestContext(): { testPath: string | null; currentTestName: string | null } {
+  try {
+    const state = (globalThis as unknown as { expect?: { getState?: () => Record<string, unknown> } })
+      .expect?.getState?.();
+    return {
+      testPath: (state?.testPath as string) ?? null,
+      currentTestName: (state?.currentTestName as string) ?? null,
+    };
+  } catch {
+    return { testPath: null, currentTestName: null };
+  }
+}
+
+const g = globalThis as unknown as { __jestDiagInstalled?: boolean };
+if (!g.__jestDiagInstalled) {
+  g.__jestDiagInstalled = true;
+
+  diag('worker:setupFiles:loaded', {
+    nodeVersion: process.version,
+  });
+
+  process.on('unhandledRejection', (reason: unknown) => {
+    diag('process:unhandledRejection', {
+      ...getTestContext(),
+      name: (reason as Error)?.name,
+      message: (reason as Error)?.message ?? String(reason),
+      stack: (reason as Error)?.stack,
+    });
+  });
+
+  process.on('uncaughtException', (err: Error) => {
+    diag('process:uncaughtException', {
+      ...getTestContext(),
+      name: err?.name,
+      message: err?.message,
+      stack: err?.stack,
+    });
+  });
+
+  process.on('warning', (warning) => {
+    diag('process:warning', {
+      ...getTestContext(),
+      name: warning.name,
+      message: warning.message,
+      stack: warning.stack,
+    });
+  });
+
+  // Last-chance snapshot: if the worker dies with an error, what was still
+  // holding it open? Open TCP sockets to :6379 are the smoking gun for a
+  // leaked ioredis client.
+  process.on('exit', (code) => {
+    try {
+      // Internal Node APIs, intentional for diagnostics only.
+      const proc = process as unknown as {
+        _getActiveHandles?: () => unknown[];
+        _getActiveRequests?: () => unknown[];
+      };
+      const handles = (proc._getActiveHandles?.() ?? []) as Array<Record<string, unknown>>;
+      const requests = (proc._getActiveRequests?.() ?? []) as Array<Record<string, unknown>>;
+      const handleSummary = handles.map((h) => ({
+        type: (h as { constructor?: { name?: string } })?.constructor?.name,
+        remoteAddress: (h as { remoteAddress?: string }).remoteAddress,
+        remotePort: (h as { remotePort?: number }).remotePort,
+        readable: (h as { readable?: boolean }).readable,
+        writable: (h as { writable?: boolean }).writable,
+      }));
+      const requestSummary = requests.map((r) => ({
+        type: (r as { constructor?: { name?: string } })?.constructor?.name,
+      }));
+      diag('process:exit', {
+        code,
+        handleCount: handles.length,
+        requestCount: requests.length,
+        handles: handleSummary,
+        requests: requestSummary,
+      });
+    } catch (e) {
+      diag('process:exit:error', { message: (e as Error)?.message });
+    }
+  });
+
+  // Monkey-patch the ioredis Redis constructor so every unmocked instantiation
+  // logs the stack of its caller. Specs that use `jest.mock('ioredis', ...)`
+  // will substitute their own mock and bypass this — which is exactly what we
+  // want: only unmocked, real clients show up here.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const ioredis = require('ioredis');
+    const OriginalRedis = ioredis.Redis ?? ioredis.default ?? ioredis;
+    const alreadyWrapped = (OriginalRedis as { __jestDiagWrapped?: boolean })?.__jestDiagWrapped;
+
+    if (OriginalRedis && !alreadyWrapped) {
+      class WrappedRedis extends OriginalRedis {
+        constructor(...args: unknown[]) {
+          const stack = new Error('ioredis Redis constructed').stack;
+          diag('ioredis:new-Redis', {
+            ...getTestContext(),
+            argCount: args.length,
+            firstArgType: typeof args[0],
+            firstArgPreview:
+              typeof args[0] === 'string'
+                ? (args[0] as string).slice(0, 120)
+                : undefined,
+            stack,
+          });
+          super(...(args as []));
+        }
+      }
+      (WrappedRedis as unknown as { __jestDiagWrapped: boolean }).__jestDiagWrapped = true;
+
+      if (ioredis.Redis === OriginalRedis) {
+        ioredis.Redis = WrappedRedis;
+      }
+      if (ioredis.default === OriginalRedis) {
+        ioredis.default = WrappedRedis;
+      }
+      // CommonJS default: `require('ioredis')` sometimes returns the class itself.
+      if (
+        typeof ioredis === 'function' &&
+        Object.prototype.hasOwnProperty.call(require.cache, require.resolve('ioredis'))
+      ) {
+        const modEntry = require.cache[require.resolve('ioredis')];
+        if (modEntry && modEntry.exports === OriginalRedis) {
+          modEntry.exports = WrappedRedis;
+        }
+      }
+
+      diag('ioredis:patched', {});
+    } else if (alreadyWrapped) {
+      diag('ioredis:patch-skipped', { reason: 'already-wrapped' });
+    } else {
+      diag('ioredis:patch-skipped', { reason: 'no-original-export' });
+    }
+  } catch (err) {
+    diag('ioredis:patch-failed', {
+      message: (err as Error)?.message,
+      stack: (err as Error)?.stack,
+    });
+  }
+}

--- a/back-end/test-utils/jest.setup.diag.ts
+++ b/back-end/test-utils/jest.setup.diag.ts
@@ -1,32 +1,73 @@
 /**
  * Diagnostic setup for issue #2576.
  *
- * Registered via `setupFiles` on the Notifications Jest config so that every
- * worker process gets these listeners, regardless of which specs it happens
- * to run. The previous iteration installed listeners from inside
- * cache.queries.spec.ts, which meant only the worker that loaded that file
- * got them — and the ioredis-level error can fire in the *other* worker.
+ * Registered via `setupFiles` on the Notifications Jest config. Runs once
+ * per test file, in every worker process.
  *
- * This file exists purely to capture enough context to identify the spec
- * that creates an unmocked ioredis client. No behavior changes.
+ * The previous iteration used:
+ *   - `globalThis.__jestDiagInstalled` as an install guard, which doesn't
+ *     persist across test files because Jest resets globals between files.
+ *     Result: listeners stacked, the same error logged ~25× per fire.
+ *   - `console.log` for output. Jest wraps console to complain with
+ *     "Cannot log after tests are done" when a handler fires asynchronously.
+ *   - Wrapped only the `Redis` constructor exported from `ioredis`. The
+ *     compiled ioredis module ships `Redis` as a getter-only property, so
+ *     the assignment threw TypeError and no wrapping actually happened.
+ *
+ * This iteration fixes all three:
+ *   - Every patch and listener install is idempotent per-target. Re-running
+ *     the setup per test file is a no-op once any install has happened.
+ *   - Output goes to `process.stderr.write`, bypassing Jest's console wrap.
+ *   - Patches `Redis.prototype.connect` + `Redis.prototype.sendCommand`,
+ *     which every ioredis instance shares regardless of which file
+ *     constructed it. Wraps `Module.prototype.require` to log every
+ *     `require('ioredis')` call with caller stack.
+ *   - Tracks cumulative spec-load order on `process` (keyed by a global
+ *     Symbol.for so it survives Jest's module isolation) and dumps the tail
+ *     on every unhandledRejection — the culprit spec will be obvious from
+ *     timing.
  */
+
+import type Module from 'module';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const NodeModule: typeof Module = require('module');
 
 const DIAG_TAG = '[jest-diag]';
 
-function diag(kind: string, extra: Record<string, unknown> = {}) {
-  const payload = {
+type Json = Record<string, unknown>;
+
+function safeStringify(obj: unknown): string {
+  try {
+    return JSON.stringify(obj, (_k, v) => {
+      if (typeof v === 'string' && v.length > 4000) return `${v.slice(0, 4000)}…<truncated>`;
+      return v;
+    });
+  } catch {
+    return String(obj);
+  }
+}
+
+function diag(kind: string, extra: Json = {}): void {
+  const payload: Json = {
+    tag: DIAG_TAG,
+    kind,
     ts: new Date().toISOString(),
     pid: process.pid,
     workerId: process.env.JEST_WORKER_ID ?? null,
     ...extra,
   };
-  // eslint-disable-next-line no-console
-  console.log(`${DIAG_TAG} ${kind}`, payload);
+  // stderr bypasses Jest's per-test console wrap, so listeners that fire
+  // after a test ended don't spam "Cannot log after tests are done".
+  try {
+    process.stderr.write(`${DIAG_TAG} ${kind} ${safeStringify(payload)}\n`);
+  } catch {
+    // best-effort only
+  }
 }
 
 function getTestContext(): { testPath: string | null; currentTestName: string | null } {
   try {
-    const state = (globalThis as unknown as { expect?: { getState?: () => Record<string, unknown> } })
+    const state = (globalThis as unknown as { expect?: { getState?: () => Json } })
       .expect?.getState?.();
     return {
       testPath: (state?.testPath as string) ?? null,
@@ -37,131 +78,217 @@ function getTestContext(): { testPath: string | null; currentTestName: string | 
   }
 }
 
-const g = globalThis as unknown as { __jestDiagInstalled?: boolean };
-if (!g.__jestDiagInstalled) {
-  g.__jestDiagInstalled = true;
+// ---- Shared state ----------------------------------------------------------
+//
+// Symbol.for() returns the same symbol in every VM context in the worker,
+// so even when Jest isolates the module registry per test file, we share
+// this one slot on the (real) process object.
 
-  diag('worker:setupFiles:loaded', {
-    nodeVersion: process.version,
+interface DiagState {
+  loadedSpecs: Array<{ at: string; testPath: string | null }>;
+  ioredisRequireCount: number;
+}
+const STATE_KEY = Symbol.for('jestDiag.state');
+const proc = process as unknown as Record<symbol, DiagState | undefined>;
+if (!proc[STATE_KEY]) {
+  proc[STATE_KEY] = { loadedSpecs: [], ioredisRequireCount: 0 };
+}
+const state = proc[STATE_KEY]!;
+
+// Tag listeners/patches so re-runs of this file are no-ops on the target.
+const LISTENER_TAG = Symbol.for('jestDiag.listener');
+type Tagged<T> = T & { [LISTENER_TAG]?: true };
+
+function addListenerOnce(event: string, fn: (...args: unknown[]) => void): void {
+  const already = process.listeners(event as NodeJS.Signals).some(
+    (l) => (l as Tagged<typeof l>)[LISTENER_TAG] === true,
+  );
+  if (already) return;
+  const tagged = fn as Tagged<typeof fn>;
+  tagged[LISTENER_TAG] = true;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process as any).on(event, tagged);
+}
+
+// ---- Per-file log: which test file is this setupFile invocation for? -------
+
+{
+  const ctx = getTestContext();
+  state.loadedSpecs.push({ at: new Date().toISOString(), testPath: ctx.testPath });
+  diag('spec:start', ctx);
+}
+
+// ---- Process-level error listeners (attached at most once per worker) -----
+
+addListenerOnce('unhandledRejection', (...args) => {
+  const reason = args[0];
+  diag('process:unhandledRejection', {
+    ...getTestContext(),
+    name: (reason as Error)?.name,
+    message: (reason as Error)?.message ?? String(reason),
+    stack: (reason as Error)?.stack,
+    recentSpecs: state.loadedSpecs.slice(-15),
   });
+});
 
-  process.on('unhandledRejection', (reason: unknown) => {
-    diag('process:unhandledRejection', {
-      ...getTestContext(),
-      name: (reason as Error)?.name,
-      message: (reason as Error)?.message ?? String(reason),
-      stack: (reason as Error)?.stack,
-    });
+addListenerOnce('uncaughtException', (...args) => {
+  const err = args[0] as Error;
+  diag('process:uncaughtException', {
+    ...getTestContext(),
+    name: err?.name,
+    message: err?.message,
+    stack: err?.stack,
+    recentSpecs: state.loadedSpecs.slice(-15),
   });
+});
 
-  process.on('uncaughtException', (err: Error) => {
-    diag('process:uncaughtException', {
-      ...getTestContext(),
-      name: err?.name,
-      message: err?.message,
-      stack: err?.stack,
-    });
+addListenerOnce('warning', (...args) => {
+  const warning = args[0] as Error;
+  diag('process:warning', {
+    ...getTestContext(),
+    name: warning?.name,
+    message: warning?.message,
+    stack: warning?.stack,
   });
+});
 
-  process.on('warning', (warning) => {
-    diag('process:warning', {
-      ...getTestContext(),
-      name: warning.name,
-      message: warning.message,
-      stack: warning.stack,
-    });
-  });
-
-  // Last-chance snapshot: if the worker dies with an error, what was still
-  // holding it open? Open TCP sockets to :6379 are the smoking gun for a
-  // leaked ioredis client.
-  process.on('exit', (code) => {
-    try {
-      // Internal Node APIs, intentional for diagnostics only.
-      const proc = process as unknown as {
-        _getActiveHandles?: () => unknown[];
-        _getActiveRequests?: () => unknown[];
-      };
-      const handles = (proc._getActiveHandles?.() ?? []) as Array<Record<string, unknown>>;
-      const requests = (proc._getActiveRequests?.() ?? []) as Array<Record<string, unknown>>;
-      const handleSummary = handles.map((h) => ({
+addListenerOnce('exit', (...args) => {
+  const code = args[0];
+  try {
+    const p = process as unknown as {
+      _getActiveHandles?: () => unknown[];
+      _getActiveRequests?: () => unknown[];
+    };
+    const handles = (p._getActiveHandles?.() ?? []) as Array<Record<string, unknown>>;
+    const requests = (p._getActiveRequests?.() ?? []) as Array<Record<string, unknown>>;
+    diag('process:exit', {
+      code,
+      handleCount: handles.length,
+      requestCount: requests.length,
+      handles: handles.map((h) => ({
         type: (h as { constructor?: { name?: string } })?.constructor?.name,
         remoteAddress: (h as { remoteAddress?: string }).remoteAddress,
         remotePort: (h as { remotePort?: number }).remotePort,
-        readable: (h as { readable?: boolean }).readable,
-        writable: (h as { writable?: boolean }).writable,
-      }));
-      const requestSummary = requests.map((r) => ({
+      })),
+      requests: requests.map((r) => ({
         type: (r as { constructor?: { name?: string } })?.constructor?.name,
-      }));
-      diag('process:exit', {
-        code,
-        handleCount: handles.length,
-        requestCount: requests.length,
-        handles: handleSummary,
-        requests: requestSummary,
-      });
-    } catch (e) {
-      diag('process:exit:error', { message: (e as Error)?.message });
+      })),
+      totalSpecsLoaded: state.loadedSpecs.length,
+      totalIoredisRequires: state.ioredisRequireCount,
+    });
+  } catch (e) {
+    diag('process:exit:error', { message: (e as Error)?.message });
+  }
+});
+
+// ---- Intercept every `require('ioredis')` ---------------------------------
+//
+// This runs BEFORE any transitive package loads ioredis, because setupFiles
+// runs before user code. Every require of 'ioredis' (direct or via a
+// dependency) logs its caller's stack so we can see who pulls it in.
+
+try {
+  const proto = (NodeModule as unknown as { prototype: { require: (id: string) => unknown } })
+    .prototype;
+  const originalRequire = proto.require;
+  if (!(originalRequire as unknown as { __jestDiagWrapped?: boolean }).__jestDiagWrapped) {
+    function patchedRequire(this: unknown, id: string): unknown {
+      if (id === 'ioredis') {
+        state.ioredisRequireCount += 1;
+        diag('ioredis:require', {
+          ...getTestContext(),
+          count: state.ioredisRequireCount,
+          stack: new Error('ioredis require').stack,
+        });
+      }
+      return originalRequire.call(this, id);
     }
-  });
+    (patchedRequire as unknown as { __jestDiagWrapped: boolean }).__jestDiagWrapped = true;
+    proto.require = patchedRequire as typeof proto.require;
+  }
+} catch (err) {
+  diag('require-patch:failed', { message: (err as Error)?.message });
+}
 
-  // Monkey-patch the ioredis Redis constructor so every unmocked instantiation
-  // logs the stack of its caller. Specs that use `jest.mock('ioredis', ...)`
-  // will substitute their own mock and bypass this — which is exactly what we
-  // want: only unmocked, real clients show up here.
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const ioredis = require('ioredis');
-    const OriginalRedis = ioredis.Redis ?? ioredis.default ?? ioredis;
-    const alreadyWrapped = (OriginalRedis as { __jestDiagWrapped?: boolean })?.__jestDiagWrapped;
+// ---- Patch ioredis prototype methods ---------------------------------------
+//
+// Every ioredis Redis instance — no matter which file imported the class,
+// no matter if some test did `jest.requireActual('ioredis')` — shares the
+// same `Redis.prototype` object. Patching prototype methods is a dragnet a
+// constructor-wrap couldn't be.
+//
+// We do NOT attempt to replace `ioredis.Redis` or `ioredis.default`: the
+// compiled ioredis module ships those as getter-only properties, so
+// assignment throws a TypeError.
 
-    if (OriginalRedis && !alreadyWrapped) {
-      class WrappedRedis extends OriginalRedis {
-        constructor(...args: unknown[]) {
-          const stack = new Error('ioredis Redis constructed').stack;
-          diag('ioredis:new-Redis', {
-            ...getTestContext(),
-            argCount: args.length,
-            firstArgType: typeof args[0],
-            firstArgPreview:
-              typeof args[0] === 'string'
-                ? (args[0] as string).slice(0, 120)
-                : undefined,
-            stack,
-          });
-          super(...(args as []));
-        }
-      }
-      (WrappedRedis as unknown as { __jestDiagWrapped: boolean }).__jestDiagWrapped = true;
+let hadConnect = false;
+let hadSendCommand = false;
 
-      if (ioredis.Redis === OriginalRedis) {
-        ioredis.Redis = WrappedRedis;
-      }
-      if (ioredis.default === OriginalRedis) {
-        ioredis.default = WrappedRedis;
-      }
-      // CommonJS default: `require('ioredis')` sometimes returns the class itself.
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const ioredis = require('ioredis');
+  const OriginalRedis = ioredis.Redis ?? ioredis.default ?? ioredis;
+
+  if (OriginalRedis && OriginalRedis.prototype) {
+    try {
+      const origConnect = OriginalRedis.prototype.connect;
       if (
-        typeof ioredis === 'function' &&
-        Object.prototype.hasOwnProperty.call(require.cache, require.resolve('ioredis'))
+        typeof origConnect === 'function' &&
+        !(origConnect as { __jestDiagPatched?: boolean }).__jestDiagPatched
       ) {
-        const modEntry = require.cache[require.resolve('ioredis')];
-        if (modEntry && modEntry.exports === OriginalRedis) {
-          modEntry.exports = WrappedRedis;
+        hadConnect = true;
+        function patchedConnect(this: unknown, ...args: unknown[]): unknown {
+          diag('ioredis:Redis.connect', {
+            ...getTestContext(),
+            stack: new Error('ioredis Redis.connect').stack,
+          });
+          return origConnect.apply(this, args);
         }
+        (patchedConnect as unknown as { __jestDiagPatched: boolean }).__jestDiagPatched = true;
+        OriginalRedis.prototype.connect = patchedConnect;
       }
-
-      diag('ioredis:patched', {});
-    } else if (alreadyWrapped) {
-      diag('ioredis:patch-skipped', { reason: 'already-wrapped' });
-    } else {
-      diag('ioredis:patch-skipped', { reason: 'no-original-export' });
+    } catch (err) {
+      diag('ioredis:patch-connect-failed', { message: (err as Error)?.message });
     }
-  } catch (err) {
-    diag('ioredis:patch-failed', {
-      message: (err as Error)?.message,
-      stack: (err as Error)?.stack,
+
+    try {
+      const origSend = OriginalRedis.prototype.sendCommand;
+      if (
+        typeof origSend === 'function' &&
+        !(origSend as { __jestDiagPatched?: boolean }).__jestDiagPatched
+      ) {
+        hadSendCommand = true;
+        let firstLogged = false;
+        function patchedSend(this: unknown, ...args: unknown[]): unknown {
+          if (!firstLogged) {
+            firstLogged = true;
+            const cmd = args[0] as { name?: string; args?: unknown[] } | undefined;
+            diag('ioredis:Redis.sendCommand:first', {
+              ...getTestContext(),
+              commandName: cmd?.name,
+              stack: new Error('ioredis sendCommand').stack,
+            });
+          }
+          return origSend.apply(this, args);
+        }
+        (patchedSend as unknown as { __jestDiagPatched: boolean }).__jestDiagPatched = true;
+        OriginalRedis.prototype.sendCommand = patchedSend;
+      }
+    } catch (err) {
+      diag('ioredis:patch-sendCommand-failed', { message: (err as Error)?.message });
+    }
+  }
+
+  if (hadConnect || hadSendCommand) {
+    diag('ioredis:patched', {
+      hasPrototype: !!OriginalRedis?.prototype,
+      connectPatched: hadConnect,
+      sendCommandPatched: hadSendCommand,
     });
   }
+} catch (err) {
+  diag('ioredis:patch-failed', {
+    message: (err as Error)?.message,
+    stack: (err as Error)?.stack,
+  });
 }

--- a/back-end/test-utils/jest.setup.diag.ts
+++ b/back-end/test-utils/jest.setup.diag.ts
@@ -11,8 +11,10 @@
  *
  * Scope: currently wired only into the Notifications jest config, where the
  * leak addressed by this PR lived. To extend the dragnet to other apps
- * (api, chain, typeorm, root), mirror the same `setupFiles` line into their
- * respective configs gated on the same `enableDiag` flag.
+ * (api, chain, typeorm), mirror the same `setupFiles` line into their leaf
+ * jest configs gated on the same `enableDiag` flag — `back-end/jest.config.ts`
+ * is a shared base imported by each leaf config and not a runnable target,
+ * so wiring there would also work but applies to every consumer at once.
  *
  * All installs are idempotent per target (listeners keyed by Symbol, patches
  * by a flag on the function itself), so re-evaluation per test file is a no-op.

--- a/back-end/test-utils/jest.setup.diag.ts
+++ b/back-end/test-utils/jest.setup.diag.ts
@@ -11,8 +11,8 @@
  *
  * All installs are idempotent per target (listeners keyed by Symbol, patches
  * by a flag on the function itself), so re-evaluation per test file is a no-op.
- * Connect logs are capped at CONNECT_LOG_LIMIT per worker; the suppressed
- * count is reported on `process:exit`.
+ * Connect and require logs are capped at CONNECT_LOG_LIMIT / REQUIRE_LOG_LIMIT
+ * per worker; suppressed counts are reported on `process:exit`.
  */
 
 import type Module from 'module';

--- a/back-end/test-utils/jest.setup.diag.ts
+++ b/back-end/test-utils/jest.setup.diag.ts
@@ -9,6 +9,11 @@
  *     `ioredis:Redis.sendCommand:first`) — dragnets every real Redis client
  *     so a future leak identifies its own caller.
  *
+ * Scope: currently wired only into the Notifications jest config, where the
+ * leak addressed by this PR lived. To extend the dragnet to other apps
+ * (api, chain, typeorm, root), mirror the same `setupFiles` line into their
+ * respective configs gated on the same `enableDiag` flag.
+ *
  * All installs are idempotent per target (listeners keyed by Symbol, patches
  * by a flag on the function itself), so re-evaluation per test file is a no-op.
  * Connect and require logs are capped at CONNECT_LOG_LIMIT / REQUIRE_LOG_LIMIT

--- a/back-end/test-utils/jest.setup.diag.ts
+++ b/back-end/test-utils/jest.setup.diag.ts
@@ -74,6 +74,7 @@ function getTestContext(): { testPath: string | null; currentTestName: string | 
 interface DiagState {
   loadedSpecs: Array<{ at: string; testPath: string | null }>;
   ioredisRequireCount: number;
+  ioredisRequireLoggedCount: number;
   connectLoggedCount: number;
   connectSuppressedCount: number;
 }
@@ -83,6 +84,7 @@ if (!proc[STATE_KEY]) {
   proc[STATE_KEY] = {
     loadedSpecs: [],
     ioredisRequireCount: 0,
+    ioredisRequireLoggedCount: 0,
     connectLoggedCount: 0,
     connectSuppressedCount: 0,
   };
@@ -92,6 +94,7 @@ const state = proc[STATE_KEY]!;
 // First N connect calls per worker get a full log; the rest are counted
 // silently and reported on `process:exit`.
 const CONNECT_LOG_LIMIT = 5;
+const REQUIRE_LOG_LIMIT = 5;
 
 // Tag listeners/patches so re-runs of this file are no-ops on the target.
 const LISTENER_TAG = Symbol.for('jestDiag.listener');
@@ -173,6 +176,9 @@ addListenerOnce('exit', (...args) => {
       })),
       totalSpecsLoaded: state.loadedSpecs.length,
       totalIoredisRequires: state.ioredisRequireCount,
+      ioredisRequireLogged: state.ioredisRequireLoggedCount,
+      ioredisRequireSuppressed:
+        state.ioredisRequireCount - state.ioredisRequireLoggedCount,
       ioredisConnectLogged: state.connectLoggedCount,
       ioredisConnectSuppressed: state.connectSuppressedCount,
     });
@@ -191,11 +197,16 @@ try {
     function patchedRequire(this: unknown, id: string): unknown {
       if (id === 'ioredis') {
         state.ioredisRequireCount += 1;
-        diag('ioredis:require', {
-          ...getTestContext(),
-          count: state.ioredisRequireCount,
-          stack: new Error('ioredis require').stack,
-        });
+        if (state.ioredisRequireLoggedCount < REQUIRE_LOG_LIMIT) {
+          state.ioredisRequireLoggedCount += 1;
+          diag('ioredis:require', {
+            ...getTestContext(),
+            count: state.ioredisRequireCount,
+            logged: state.ioredisRequireLoggedCount,
+            limit: REQUIRE_LOG_LIMIT,
+            stack: new Error('ioredis require').stack,
+          });
+        }
       }
       return originalRequire.call(this, id);
     }

--- a/back-end/test-utils/postgres-test-db.ts
+++ b/back-end/test-utils/postgres-test-db.ts
@@ -4,35 +4,116 @@ import { AppDataSource } from '../typeorm/data-source';
 
 const POSTGRES_TEST_IMAGE = 'postgres:16.13-alpine3.22';
 
+// Diagnostic logging (issue #2576) — tag every line so CI logs are searchable.
+const DIAG_TAG = '[pg-test-db]';
+function diag(message: string, extra?: Record<string, unknown>) {
+  const payload = {
+    ts: new Date().toISOString(),
+    pid: process.pid,
+    ...extra,
+  };
+  // eslint-disable-next-line no-console
+  console.log(`${DIAG_TAG} ${message}`, payload);
+}
+
 export function createTestPostgresContainer() {
   return new PostgreSqlContainer(POSTGRES_TEST_IMAGE);
 }
 
 export async function createTestPostgresDataSource() {
-  const container = await createTestPostgresContainer()
-    .withDatabase('testdb')
-    .withUsername('testuser')
-    .withPassword('testpass')
-    .start();
+  const overallStart = Date.now();
+  diag('createTestPostgresDataSource:start');
 
-  Object.assign(AppDataSource.options, {
-    host: container.getHost(),
-    port: container.getMappedPort(5432),
-    username: container.getUsername(),
-    password: container.getPassword(),
-    database: container.getDatabase(),
-  });
+  let container: Awaited<ReturnType<ReturnType<typeof createTestPostgresContainer>['start']>> | undefined;
+  try {
+    const containerStart = Date.now();
+    diag('container.start:begin', { image: POSTGRES_TEST_IMAGE });
+    container = await createTestPostgresContainer()
+      .withDatabase('testdb')
+      .withUsername('testuser')
+      .withPassword('testpass')
+      .start();
+    diag('container.start:done', {
+      elapsedMs: Date.now() - containerStart,
+      containerId: container.getId(),
+      containerName: container.getName(),
+      host: container.getHost(),
+      mappedPort: container.getMappedPort(5432),
+    });
 
-  const dataSource = new DataSource(AppDataSource.options);
-  await dataSource.initialize();
-  await dataSource.runMigrations();
+    Object.assign(AppDataSource.options, {
+      host: container.getHost(),
+      port: container.getMappedPort(5432),
+      username: container.getUsername(),
+      password: container.getPassword(),
+      database: container.getDatabase(),
+    });
 
-  return {
-    dataSource,
-    container,
-    async cleanup() {
-      await dataSource.destroy();
-      await container.stop();
-    },
-  };
+    const initStart = Date.now();
+    diag('dataSource.initialize:begin');
+    const dataSource = new DataSource(AppDataSource.options);
+    await dataSource.initialize();
+    diag('dataSource.initialize:done', { elapsedMs: Date.now() - initStart });
+
+    const migrateStart = Date.now();
+    diag('dataSource.runMigrations:begin');
+    const migrations = await dataSource.runMigrations();
+    diag('dataSource.runMigrations:done', {
+      elapsedMs: Date.now() - migrateStart,
+      appliedCount: migrations.length,
+      applied: migrations.map((m) => m.name),
+    });
+
+    diag('createTestPostgresDataSource:ready', { totalElapsedMs: Date.now() - overallStart });
+
+    return {
+      dataSource,
+      container,
+      async cleanup() {
+        const cleanupStart = Date.now();
+        diag('cleanup:begin', { containerId: container!.getId() });
+        try {
+          await dataSource.destroy();
+          diag('cleanup:dataSource.destroy:done', { elapsedMs: Date.now() - cleanupStart });
+        } catch (err) {
+          diag('cleanup:dataSource.destroy:error', {
+            message: (err as Error)?.message,
+            stack: (err as Error)?.stack,
+          });
+          throw err;
+        }
+        const stopStart = Date.now();
+        try {
+          await container!.stop();
+          diag('cleanup:container.stop:done', { elapsedMs: Date.now() - stopStart });
+        } catch (err) {
+          diag('cleanup:container.stop:error', {
+            message: (err as Error)?.message,
+            stack: (err as Error)?.stack,
+          });
+          throw err;
+        }
+      },
+    };
+  } catch (err) {
+    diag('createTestPostgresDataSource:error', {
+      elapsedMs: Date.now() - overallStart,
+      containerStarted: Boolean(container),
+      containerId: container?.getId(),
+      message: (err as Error)?.message,
+      name: (err as Error)?.name,
+      stack: (err as Error)?.stack,
+    });
+    // Best-effort teardown so a failed boot doesn't leak a container.
+    if (container) {
+      try {
+        await container.stop();
+      } catch (stopErr) {
+        diag('createTestPostgresDataSource:error:stop-failed', {
+          message: (stopErr as Error)?.message,
+        });
+      }
+    }
+    throw err;
+  }
 }

--- a/back-end/test-utils/postgres-test-db.ts
+++ b/back-end/test-utils/postgres-test-db.ts
@@ -4,7 +4,6 @@ import { AppDataSource } from '../typeorm/data-source';
 
 const POSTGRES_TEST_IMAGE = 'postgres:16.13-alpine3.22';
 
-// Diagnostic logging (issue #2576) — tag every line so CI logs are searchable.
 const DIAG_TAG = '[pg-test-db]';
 function diag(message: string, extra?: Record<string, unknown>) {
   const payload = {

--- a/back-end/test-utils/postgres-test-db.ts
+++ b/back-end/test-utils/postgres-test-db.ts
@@ -105,9 +105,16 @@ export async function createTestPostgresDataSource() {
           });
         }
 
-        // Surface the proximate failure (destroy) first if both occurred.
-        if (destroyErr || stopErr) {
-          throw destroyErr ?? stopErr;
+        // Surface the proximate failure (destroy) first if both occurred,
+        // attaching the secondary one as `cause` so it isn't silently dropped.
+        if (destroyErr) {
+          if (stopErr) {
+            (destroyErr as Error & { cause?: unknown }).cause = stopErr;
+          }
+          throw destroyErr;
+        }
+        if (stopErr) {
+          throw stopErr;
         }
       },
     };
@@ -121,10 +128,14 @@ export async function createTestPostgresDataSource() {
       stack: (err as Error)?.stack,
     });
     // Best-effort teardown so a failed boot doesn't leak handles or a
-    // container. Destroy the partially-initialized DataSource first to close
-    // the JS-level pool — otherwise `detectOpenHandles` reports lingering PG
-    // sockets even after the container is killed.
-    if (dataSource?.isInitialized) {
+    // container. Destroy the (possibly partially-initialized) DataSource
+    // first to close the JS-level pool — otherwise `detectOpenHandles`
+    // reports lingering PG sockets even after the container is killed.
+    // We deliberately do NOT gate on `dataSource.isInitialized`: a failure
+    // partway through `initialize()` can leave the flag false while pg
+    // sockets are already open, and `destroy()` on an uninit'd DataSource
+    // either no-ops or throws (caught below).
+    if (dataSource) {
       try {
         await dataSource.destroy();
       } catch (destroyErr) {

--- a/back-end/test-utils/postgres-test-db.ts
+++ b/back-end/test-utils/postgres-test-db.ts
@@ -24,6 +24,9 @@ export async function createTestPostgresDataSource() {
   diag('createTestPostgresDataSource:start');
 
   let container: Awaited<ReturnType<ReturnType<typeof createTestPostgresContainer>['start']>> | undefined;
+  // Hoisted out of the `try` so the outer catch can reach it for best-effort
+  // teardown if a later step (e.g. runMigrations) throws after initialize().
+  let dataSource: DataSource | undefined;
   try {
     const containerStart = Date.now();
     diag('container.start:begin', { image: POSTGRES_TEST_IMAGE });
@@ -50,7 +53,7 @@ export async function createTestPostgresDataSource() {
 
     const initStart = Date.now();
     diag('dataSource.initialize:begin');
-    const dataSource = new DataSource(AppDataSource.options);
+    dataSource = new DataSource(AppDataSource.options);
     await dataSource.initialize();
     diag('dataSource.initialize:done', { elapsedMs: Date.now() - initStart });
 
@@ -117,7 +120,19 @@ export async function createTestPostgresDataSource() {
       name: (err as Error)?.name,
       stack: (err as Error)?.stack,
     });
-    // Best-effort teardown so a failed boot doesn't leak a container.
+    // Best-effort teardown so a failed boot doesn't leak handles or a
+    // container. Destroy the partially-initialized DataSource first to close
+    // the JS-level pool — otherwise `detectOpenHandles` reports lingering PG
+    // sockets even after the container is killed.
+    if (dataSource?.isInitialized) {
+      try {
+        await dataSource.destroy();
+      } catch (destroyErr) {
+        diag('createTestPostgresDataSource:error:destroy-failed', {
+          message: (destroyErr as Error)?.message,
+        });
+      }
+    }
     if (container) {
       try {
         await container.stop();

--- a/back-end/test-utils/postgres-test-db.ts
+++ b/back-end/test-utils/postgres-test-db.ts
@@ -71,26 +71,40 @@ export async function createTestPostgresDataSource() {
       async cleanup() {
         const cleanupStart = Date.now();
         diag('cleanup:begin', { containerId: container!.getId() });
+
+        // Capture errors from each step instead of rethrowing the first one,
+        // so a failed `dataSource.destroy()` never blocks `container.stop()`
+        // from running. A leaked testcontainer holds a port and a Docker
+        // resource indefinitely; that's worse than a noisy error log.
+        let destroyErr: Error | undefined;
+        let stopErr: Error | undefined;
+
         try {
           await dataSource.destroy();
           diag('cleanup:dataSource.destroy:done', { elapsedMs: Date.now() - cleanupStart });
         } catch (err) {
+          destroyErr = err as Error;
           diag('cleanup:dataSource.destroy:error', {
-            message: (err as Error)?.message,
-            stack: (err as Error)?.stack,
+            message: destroyErr?.message,
+            stack: destroyErr?.stack,
           });
-          throw err;
         }
+
         const stopStart = Date.now();
         try {
           await container!.stop();
           diag('cleanup:container.stop:done', { elapsedMs: Date.now() - stopStart });
         } catch (err) {
+          stopErr = err as Error;
           diag('cleanup:container.stop:error', {
-            message: (err as Error)?.message,
-            stack: (err as Error)?.stack,
+            message: stopErr?.message,
+            stack: stopErr?.stack,
           });
-          throw err;
+        }
+
+        // Surface the proximate failure (destroy) first if both occurred.
+        if (destroyErr || stopErr) {
+          throw destroyErr ?? stopErr;
         }
       },
     };

--- a/back-end/test-utils/postgres-test-db.ts
+++ b/back-end/test-utils/postgres-test-db.ts
@@ -1,11 +1,13 @@
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
 import { DataSource } from 'typeorm';
 import { AppDataSource } from '../typeorm/data-source';
+import { enableDiag } from './diag-enabled';
 
 const POSTGRES_TEST_IMAGE = 'postgres:16.13-alpine3.22';
 
 const DIAG_TAG = '[pg-test-db]';
 function diag(message: string, extra?: Record<string, unknown>) {
+  if (!enableDiag) return;
   const payload = {
     ts: new Date().toISOString(),
     pid: process.pid,

--- a/back-end/test-utils/postgres-test-db.ts
+++ b/back-end/test-utils/postgres-test-db.ts
@@ -109,7 +109,10 @@ export async function createTestPostgresDataSource() {
         // don't mutate the upstream Error instances (TypeORM/pg often expose
         // the same Error reference elsewhere with their own `cause` chain).
         if (destroyErr && stopErr) {
-          throw new AggregateError([destroyErr, stopErr], 'cleanup failed');
+          throw new AggregateError(
+            [destroyErr, stopErr],
+            'cleanup failed: dataSource.destroy and container.stop both threw',
+          );
         }
         if (destroyErr) {
           throw destroyErr;

--- a/back-end/test-utils/postgres-test-db.ts
+++ b/back-end/test-utils/postgres-test-db.ts
@@ -105,12 +105,13 @@ export async function createTestPostgresDataSource() {
           });
         }
 
-        // Surface the proximate failure (destroy) first if both occurred,
-        // attaching the secondary one as `cause` so it isn't silently dropped.
+        // Aggregate when both occurred so neither error is dropped and we
+        // don't mutate the upstream Error instances (TypeORM/pg often expose
+        // the same Error reference elsewhere with their own `cause` chain).
+        if (destroyErr && stopErr) {
+          throw new AggregateError([destroyErr, stopErr], 'cleanup failed');
+        }
         if (destroyErr) {
-          if (stopErr) {
-            (destroyErr as Error & { cause?: unknown }).cause = stopErr;
-          }
           throw destroyErr;
         }
         if (stopErr) {


### PR DESCRIPTION
Fixes: [#2576](https://github.com/hashgraph/hedera-transaction-tool/issues/2576)

**Description**:

`../../libs/common/src/sql/queries/cache.queries.spec.ts` is failing intermittently in CI, and it appears at least once on every PR. The failure output is minimal and does not provide enough context to diagnose the issue. We should start by enabling additional logging in the `beforeEach`, `afterEach`, `beforeAll`, and `afterAll` hooks to get more information about the test setup and teardown.

**Requirements**:

- Investigate the flaky failure in cache.queries.spec.ts.
- Add logging around beforeEach, afterEach, beforeAll, and afterAll to capture more context when the test fails.
- Improve test output so the root cause can be identified more easily in CI.
- Keep the test behavior unchanged aside from added diagnostics.

**Summary**:

The spec named in the issue (`cache.queries.spec.ts`) was not the cause. Two other specs in the same Notifications worker, `email.service.spec.ts` and `websocket.gateway.spec.ts`, were missing `jest.mock('ioredis')` (a pattern already adopted by `blacklist.service.spec.ts`, `scheduler.service.spec.ts`, and `redis-io.adapter.spec.ts`). As a result, every time their NestJS TestingModule instantiated EmailService / WebsocketGateway, the DebouncedNotificationBatcher constructor opened two real `ioredis` clients and issued `subscribe('__keyevent@0__:expired').` With no Redis on the CI runner, those clients burned through the default retry budget `(maxRetriesPerRequest: 20 × min(n*50, 2000)ms ≈ 10.5 seconds)` before throwing `MaxRetriesPerRequestError`. The error was attributed to whichever spec Jest considered "active" at that moment — usually `cache.queries.spec.ts`, because its Postgres testcontainer boot kept it on the clock for the full retry window.

**Root-cause fix**:

- `apps/notifications/src/email/email.service.spec.ts` — jest.mock('ioredis', ...) with a MockRedis class.
- `apps/notifications/src/websocket/websocket.gateway.spec.ts` — same pattern.
Follows the existing convention in `blacklist.service.spec.ts`, `scheduler.service.spec.ts`, and r`edis-io.adapter.spec.ts.`

**Diagnostics** (per issue requirements)

- `libs/common/src/sql/queries/cache.queries.spec.ts` — tagged [cache.queries.spec] logs in beforeAll / afterAll / beforeEach / afterEach, including PID, test name, and elapsed ms. beforeAll timeout raised 60s → 90s. try/catch around async hook bodies so real errors get proper stacks.
- `test-utils/postgres-test-db.ts `— tagged [pg-test-db] logs per stage of createTestPostgresDataSource (container start, initialize, runMigrations, cleanup) with elapsed ms, container id, host/port.
- `test-utils/jest.setup.diag.ts `(new) — wired into `apps/notifications/jest.config.ts` via setupFiles. Per-worker listeners (unhandledRejection, uncaughtException, warning, exit) and patches on Module.prototype.require (for require('ioredis') call-sites) and Redis.prototype.connect / sendCommand (to catch any future real Redis instantiation, regardless of import path).
- `apps/notifications/jest.config.ts` — detectOpenHandles: true, setupFiles wired to the diag module.