### PR TITLE
fix: require keys for DAB transactions updated

### DIFF
--- a/back-end/libs/common/src/schemas/HederaSchema.ts
+++ b/back-end/libs/common/src/schemas/HederaSchema.ts
@@ -585,6 +585,8 @@ export interface NetworkNode {
   stake_rewarded: number | null; // The sum (balance + staked) for all accounts staked to the node that are not declining rewards at the beginning of the staking period
   staking_period: TimestampRange | null;
   reward_rate_start: number | null;
+  decline_reward: boolean | null;
+  grpc_web_proxy_endpoint: ServiceEndPoint | null;
 }
 
 export interface ServiceEndPoint {

--- a/back-end/libs/common/src/transaction-signature/transaction-signature.service.spec.ts
+++ b/back-end/libs/common/src/transaction-signature/transaction-signature.service.spec.ts
@@ -1,0 +1,706 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  AccountId,
+  EvmAddress,
+  FileId,
+  Hbar,
+  Key,
+  NodeDeleteTransaction,
+  NodeUpdateTransaction,
+  ServiceEndpoint,
+  Transaction as SDKTransaction,
+} from '@hiero-ledger/sdk';
+
+import { TransactionSignatureService } from './transaction-signature.service';
+import { AccountCacheService } from '@app/common/transaction-signature/account-cache.service';
+import { NodeCacheService } from '@app/common/transaction-signature/node-cache.service';
+import TransactionFactory from '@app/common/transaction-signature/model/transaction-factory';
+import { COUNCIL_ACCOUNTS } from '@app/common/constants';
+import { Transaction } from '@entities';
+import { AccountInfoParsed, NodeInfoParsed } from '@app/common/types';
+import { TimestampRange } from '@app/common/schemas';
+
+// ---------------------------------------------------------------------------
+// Helpers / shared mocks
+// ---------------------------------------------------------------------------
+
+const mockKey = (label: string) => ({ __key: label });
+
+const makeAccountInfo = (
+  keyLabel: string,
+  receiverSignatureRequired = false,
+): AccountInfoParsed => ({
+  accountId: { toString: () => '0.0.100' } as unknown as AccountId,
+  alias: null,
+  balance: { toTinybars: () => 0 } as unknown as Hbar,
+  declineReward: false,
+  deleted: false,
+  ethereumNonce: 0,
+  evmAddress: {} as unknown as EvmAddress,
+  createdTimestamp: null,
+  expiryTimestamp: null,
+  key: mockKey(keyLabel) as unknown as Key,
+  maxAutomaticTokenAssociations: null,
+  memo: null,
+  pendingRewards: { toTinybars: () => 0 } as unknown as Hbar,
+  receiverSignatureRequired,
+  stakedAccountId: null,
+  stakedNodeId: null,
+  autoRenewPeriod: null,
+});
+
+const makeNodeInfo = (
+  adminKeyLabel: string | null,
+  nodeAccountId: AccountId | null = {
+    toString: () => '0.0.50',
+    equals: (other: any) => other?.toString?.() === '0.0.50',
+  } as unknown as AccountId,
+): NodeInfoParsed => ({
+  admin_key: adminKeyLabel ? (mockKey(adminKeyLabel) as unknown as Key) : null,
+  description: null,
+  file_id: null as unknown as FileId,
+  memo: null,
+  node_id: null,
+  node_account_id: nodeAccountId,
+  node_cert_hash: null,
+  public_key: null,
+  service_endpoints: [],
+  timestamp: null as unknown as TimestampRange,
+  max_stake: null as unknown as Hbar,
+  min_stake: null as unknown as Hbar,
+  stake: null as unknown as Hbar,
+  stake_not_rewarded: null as unknown as Hbar,
+  stake_rewarded: null as unknown as Hbar,
+  staking_period: null as unknown as TimestampRange,
+  reward_rate_start: null as unknown as Hbar,
+  decline_reward: null,
+  grpc_web_proxy_endpoint: null as unknown as ServiceEndpoint,
+});
+
+const makeTransaction = (overrides: Partial<Transaction> = {}): Transaction =>
+  ({
+    transactionBytes: Buffer.from('fake-bytes'),
+    ...overrides,
+  } as unknown as Transaction);
+
+function buildTransactionModel(overrides: any = {}) {
+  return {
+    getFeePayerAccountId: jest.fn().mockReturnValue({ toString: () => '0.0.100' }),
+    getSigningAccounts: jest.fn().mockReturnValue(new Set<string>()),
+    getReceiverAccounts: jest.fn().mockReturnValue(new Set<string>()),
+    getNewKeys: jest.fn().mockReturnValue([]),
+    getNodeId: jest.fn().mockReturnValue(null),
+    ...overrides,
+  };
+}
+
+const makeTransactionModel = (
+  overrides: Partial<ReturnType<typeof buildTransactionModel>> = {},
+) => buildTransactionModel(overrides);
+
+// ---------------------------------------------------------------------------
+// Module bootstrap helper
+// ---------------------------------------------------------------------------
+
+async function createService() {
+  const accountCacheMock = {
+    getAccountInfoForTransaction: jest.fn(),
+  } as jest.Mocked<Pick<AccountCacheService, 'getAccountInfoForTransaction'>>;
+
+  const nodeCacheMock = {
+    getNodeInfoForTransaction: jest.fn(),
+  } as jest.Mocked<Pick<NodeCacheService, 'getNodeInfoForTransaction'>>;
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      TransactionSignatureService,
+      { provide: AccountCacheService, useValue: accountCacheMock },
+      { provide: NodeCacheService, useValue: nodeCacheMock },
+    ],
+  }).compile();
+
+  return {
+    service: module.get<TransactionSignatureService>(TransactionSignatureService),
+    accountCacheMock,
+    nodeCacheMock,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SDK mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('@hiero-ledger/sdk', () => {
+  const actual = jest.requireActual('@hiero-ledger/sdk');
+  class MockKeyList {
+    private items: any[] = [];
+    private threshold: number | undefined;
+
+    push(...args: any[]) {
+      this.items.push(...args);
+    }
+    setThreshold(t: number) {
+      this.threshold = t;
+    }
+    getThreshold() {
+      return this.threshold;
+    }
+    getItems() {
+      return this.items;
+    }
+    toArray() {
+      return this.items;
+    }
+  }
+
+  return {
+    ...actual,
+    KeyList: MockKeyList,
+    Transaction: { fromBytes: jest.fn() },
+    AccountId: {
+      fromString: jest.fn((s: string) => ({
+        toString: () => s,
+        equals: (other: any) => other?.toString?.() === s,
+      })),
+    },
+    NodeDeleteTransaction: class NodeDeleteTransaction {},
+    NodeUpdateTransaction: class NodeUpdateTransaction {
+      accountId: any = null;
+      adminKey: any = null;
+      description: any = null;
+      certificateHash: any = null;
+      gossipCaCertificate: any = null;
+      serviceEndpoints: any = null;
+      gossipEndpoints: any = null;
+      grpcWebProxyEndpoint: any = null;
+      declineReward: any = null;
+    },
+  };
+});
+
+jest.mock('@app/common/transaction-signature/model/transaction-factory');
+
+// ---------------------------------------------------------------------------
+// Convenience type alias so casts stay concise
+// ---------------------------------------------------------------------------
+
+type AsMockKeyList = { getItems: () => any[] };
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TransactionSignatureService', () => {
+  let service: TransactionSignatureService;
+  let accountCacheMock: jest.Mocked<AccountCacheService>;
+  let nodeCacheMock: jest.Mocked<NodeCacheService>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const setup = await createService();
+    service = setup.service;
+    accountCacheMock = setup.accountCacheMock as jest.Mocked<AccountCacheService>;
+    nodeCacheMock = setup.nodeCacheMock as jest.Mocked<NodeCacheService>;
+  });
+
+  // -------------------------------------------------------------------------
+  // computeSignatureKey — high-level integration
+  // -------------------------------------------------------------------------
+
+  describe('computeSignatureKey', () => {
+    it('returns a KeyList with only the fee payer key when no other accounts or node', async () => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({});
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(makeTransactionModel());
+      accountCacheMock.getAccountInfoForTransaction.mockResolvedValue(
+        makeAccountInfo('fee-payer-key'),
+      );
+
+      const result = await service.computeSignatureKey(makeTransaction());
+      const items = (result as unknown as AsMockKeyList).getItems();
+
+      expect(items).toHaveLength(1);
+      expect(items).toContainEqual(mockKey('fee-payer-key'));
+    });
+
+    it('includes signing account keys', async () => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({});
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({
+          getSigningAccounts: jest.fn().mockReturnValue(new Set(['0.0.200', '0.0.201'])),
+        }),
+      );
+      accountCacheMock.getAccountInfoForTransaction
+        .mockResolvedValueOnce(makeAccountInfo('fee-payer-key'))
+        .mockResolvedValueOnce(makeAccountInfo('signer-200-key'))
+        .mockResolvedValueOnce(makeAccountInfo('signer-201-key'));
+
+      const result = await service.computeSignatureKey(makeTransaction());
+      const items = (result as unknown as AsMockKeyList).getItems();
+
+      expect(items).toHaveLength(3);
+      expect(items).toContainEqual(mockKey('signer-200-key'));
+      expect(items).toContainEqual(mockKey('signer-201-key'));
+    });
+
+    it('includes receiver key when receiverSignatureRequired is true', async () => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({});
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({
+          getReceiverAccounts: jest.fn().mockReturnValue(new Set(['0.0.300'])),
+        }),
+      );
+      accountCacheMock.getAccountInfoForTransaction
+        .mockResolvedValueOnce(makeAccountInfo('fee-payer-key'))
+        .mockResolvedValueOnce(makeAccountInfo('receiver-key', true));
+
+      const result = await service.computeSignatureKey(makeTransaction());
+
+      expect((result as unknown as AsMockKeyList).getItems()).toContainEqual(
+        mockKey('receiver-key'),
+      );
+    });
+
+    it('excludes receiver key when receiverSignatureRequired is false and showAll is false', async () => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({});
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({
+          getReceiverAccounts: jest.fn().mockReturnValue(new Set(['0.0.300'])),
+        }),
+      );
+      accountCacheMock.getAccountInfoForTransaction
+        .mockResolvedValueOnce(makeAccountInfo('fee-payer-key'))
+        .mockResolvedValueOnce(makeAccountInfo('receiver-key', false));
+
+      const result = await service.computeSignatureKey(makeTransaction(), false);
+
+      expect((result as unknown as AsMockKeyList).getItems()).not.toContainEqual(
+        mockKey('receiver-key'),
+      );
+    });
+
+    it('includes receiver key when showAll is true even if receiverSignatureRequired is false', async () => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({});
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({
+          getReceiverAccounts: jest.fn().mockReturnValue(new Set(['0.0.300'])),
+        }),
+      );
+      accountCacheMock.getAccountInfoForTransaction
+        .mockResolvedValueOnce(makeAccountInfo('fee-payer-key'))
+        .mockResolvedValueOnce(makeAccountInfo('receiver-key', false));
+
+      const result = await service.computeSignatureKey(makeTransaction(), true);
+
+      expect((result as unknown as AsMockKeyList).getItems()).toContainEqual(
+        mockKey('receiver-key'),
+      );
+    });
+
+    it('includes newKeys from the transaction model', async () => {
+      const newKey1 = mockKey('new-key-1');
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({});
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({ getNewKeys: jest.fn().mockReturnValue([newKey1]) }),
+      );
+      accountCacheMock.getAccountInfoForTransaction.mockResolvedValue(
+        makeAccountInfo('fee-payer-key'),
+      );
+
+      const result = await service.computeSignatureKey(makeTransaction());
+
+      expect((result as unknown as AsMockKeyList).getItems()).toContainEqual(newKey1);
+    });
+
+    it('does NOT call addNodeKeys when nodeId is null', async () => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({});
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({ getNodeId: jest.fn().mockReturnValue(null) }),
+      );
+      accountCacheMock.getAccountInfoForTransaction.mockResolvedValue(
+        makeAccountInfo('fee-payer-key'),
+      );
+
+      await service.computeSignatureKey(makeTransaction());
+
+      expect(nodeCacheMock.getNodeInfoForTransaction).not.toHaveBeenCalled();
+    });
+
+    it('calls addNodeKeys when nodeId is provided', async () => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({});
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({ getNodeId: jest.fn().mockReturnValue(5) }),
+      );
+      accountCacheMock.getAccountInfoForTransaction.mockResolvedValue(
+        makeAccountInfo('fee-payer-key'),
+      );
+      nodeCacheMock.getNodeInfoForTransaction.mockResolvedValue(null);
+
+      await service.computeSignatureKey(makeTransaction());
+
+      expect(nodeCacheMock.getNodeInfoForTransaction).toHaveBeenCalledWith(expect.anything(), 5);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // addFeePayerKey — error handling
+  // -------------------------------------------------------------------------
+
+  describe('fee payer error handling', () => {
+    it('gracefully handles an error from accountCacheService for the fee payer', async () => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({});
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(makeTransactionModel());
+      accountCacheMock.getAccountInfoForTransaction.mockRejectedValue(new Error('cache miss'));
+
+      const result = await service.computeSignatureKey(makeTransaction());
+
+      expect(result).toBeDefined();
+    });
+
+    it('handles null accountInfo for fee payer without crashing', async () => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({});
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(makeTransactionModel());
+      accountCacheMock.getAccountInfoForTransaction.mockResolvedValue(
+        null as unknown as AccountInfoParsed,
+      );
+
+      const result = await service.computeSignatureKey(makeTransaction());
+
+      expect(result).toBeDefined();
+      expect((result as unknown as AsMockKeyList).getItems()).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // addSigningAccountKeys — error handling
+  // -------------------------------------------------------------------------
+
+  describe('signing account error handling', () => {
+    it('continues processing remaining signing accounts after one fails', async () => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({});
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({
+          getSigningAccounts: jest.fn().mockReturnValue(new Set(['0.0.200', '0.0.201'])),
+        }),
+      );
+      accountCacheMock.getAccountInfoForTransaction
+        .mockResolvedValueOnce(makeAccountInfo('fee-payer-key'))
+        .mockRejectedValueOnce(new Error('error for 200'))
+        .mockResolvedValueOnce(makeAccountInfo('signer-201-key'));
+
+      const result = await service.computeSignatureKey(makeTransaction());
+      const items = (result as unknown as AsMockKeyList).getItems();
+
+      expect(items).toContainEqual(mockKey('signer-201-key'));
+      expect(items).not.toContainEqual(mockKey('signer-200-key'));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // addNodeKeys — NodeDeleteTransaction
+  // -------------------------------------------------------------------------
+
+  describe('addNodeKeys — NodeDeleteTransaction', () => {
+    const makeNodeDeleteTx = (payerAccountId: string) => {
+      const tx = new NodeDeleteTransaction();
+      (tx as any).transactionId = {
+        accountId: { toString: () => payerAccountId },
+      };
+      return tx;
+    };
+
+    beforeEach(() => {
+      nodeCacheMock.getNodeInfoForTransaction.mockResolvedValue(makeNodeInfo('admin-key'));
+    });
+
+    it('adds admin key when fee payer is NOT a council account', async () => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue(makeNodeDeleteTx('0.0.999'));
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({ getNodeId: jest.fn().mockReturnValue(1) }),
+      );
+      accountCacheMock.getAccountInfoForTransaction.mockResolvedValue(
+        makeAccountInfo('fee-payer-key'),
+      );
+
+      const result = await service.computeSignatureKey(makeTransaction());
+
+      expect((result as unknown as AsMockKeyList).getItems()).toContainEqual(mockKey('admin-key'));
+    });
+
+    it('does NOT add admin key when fee payer IS a council account', async () => {
+      const councilAccountId = Object.keys(COUNCIL_ACCOUNTS)[0];
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue(makeNodeDeleteTx(councilAccountId));
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({ getNodeId: jest.fn().mockReturnValue(1) }),
+      );
+      accountCacheMock.getAccountInfoForTransaction.mockResolvedValue(
+        makeAccountInfo('fee-payer-key'),
+      );
+
+      const result = await service.computeSignatureKey(makeTransaction());
+
+      expect((result as unknown as AsMockKeyList).getItems()).not.toContainEqual(
+        mockKey('admin-key'),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // addNodeKeys — non-update, non-delete transactions
+  // -------------------------------------------------------------------------
+
+  describe('addNodeKeys — generic node transaction (not update or delete)', () => {
+    it('adds only the admin key', async () => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({}); // plain object — no instanceof match
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({ getNodeId: jest.fn().mockReturnValue(3) }),
+      );
+      nodeCacheMock.getNodeInfoForTransaction.mockResolvedValue(makeNodeInfo('admin-key'));
+      accountCacheMock.getAccountInfoForTransaction.mockResolvedValue(
+        makeAccountInfo('fee-payer-key'),
+      );
+
+      const result = await service.computeSignatureKey(makeTransaction());
+
+      expect((result as unknown as AsMockKeyList).getItems()).toContainEqual(mockKey('admin-key'));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // addNodeKeys — NodeUpdateTransaction cases (HIP-1299)
+  // -------------------------------------------------------------------------
+
+  describe('addNodeKeys — NodeUpdateTransaction', () => {
+    const currentNodeAccountId = {
+      toString: () => '0.0.50',
+      equals: (other: any) => other?.toString?.() === '0.0.50',
+    } as unknown as AccountId;
+
+    const newAccountId = {
+      toString: () => '0.0.999',
+      equals: (other: any) => other?.toString?.() === '0.0.999',
+    };
+
+    function makeNodeUpdateTx(
+      overrides: Partial<NodeUpdateTransaction> = {},
+    ): NodeUpdateTransaction {
+      const tx = new NodeUpdateTransaction();
+      Object.assign(tx, overrides);
+      return tx;
+    }
+
+    beforeEach(() => {
+      nodeCacheMock.getNodeInfoForTransaction.mockResolvedValue(
+        makeNodeInfo('admin-key', currentNodeAccountId),
+      );
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({ getNodeId: jest.fn().mockReturnValue(2) }),
+      );
+      accountCacheMock.getAccountInfoForTransaction.mockResolvedValue(
+        makeAccountInfo('fee-payer-key'),
+      );
+    });
+
+    it('Case 1 — accountId NOT changing: adds only admin key, no threshold list', async () => {
+      const tx = makeNodeUpdateTx({
+        accountId: { ...currentNodeAccountId, equals: () => true } as any,
+      });
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue(tx);
+
+      const result = await service.computeSignatureKey(makeTransaction());
+      const items = (result as unknown as AsMockKeyList).getItems();
+
+      expect(items).toContainEqual(mockKey('admin-key'));
+      const hasThreshold = items.some(
+        (k: any) => typeof k.getItems === 'function' && k.getThreshold() === 1,
+      );
+      expect(hasThreshold).toBe(false);
+    });
+
+    it('Case 1 — accountId is null: adds only admin key', async () => {
+      const tx = makeNodeUpdateTx({ accountId: null as any });
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue(tx);
+
+      const result = await service.computeSignatureKey(makeTransaction());
+
+      expect((result as unknown as AsMockKeyList).getItems()).toContainEqual(mockKey('admin-key'));
+    });
+
+    it('Case 2 — accountId changing + other fields changing: adds admin key and new account key, no threshold', async () => {
+      const tx = makeNodeUpdateTx({
+        accountId: newAccountId as any,
+        adminKey: mockKey('tx-admin-key') as any,
+      });
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue(tx);
+
+      accountCacheMock.getAccountInfoForTransaction
+        .mockResolvedValueOnce(makeAccountInfo('fee-payer-key'))
+        .mockResolvedValueOnce(makeAccountInfo('new-account-key'));
+
+      const result = await service.computeSignatureKey(makeTransaction());
+      const items = (result as unknown as AsMockKeyList).getItems();
+
+      expect(items).toContainEqual(mockKey('admin-key'));
+      expect(items).toContainEqual(mockKey('new-account-key'));
+      const hasThreshold = items.some(
+        (k: any) => typeof k.getItems === 'function' && k.getThreshold() === 1,
+      );
+      expect(hasThreshold).toBe(false);
+    });
+
+    it('Case 3 — only accountId is changing: adds 1-of-2 threshold (current key OR admin key) + new account key', async () => {
+      const tx = makeNodeUpdateTx({ accountId: newAccountId as any });
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue(tx);
+
+      accountCacheMock.getAccountInfoForTransaction
+        .mockResolvedValueOnce(makeAccountInfo('fee-payer-key'))
+        .mockResolvedValueOnce(makeAccountInfo('current-account-key'))
+        .mockResolvedValueOnce(makeAccountInfo('new-account-key'));
+
+      const result = await service.computeSignatureKey(makeTransaction());
+      const items = (result as unknown as AsMockKeyList).getItems();
+
+      const thresholdEntry = items.find(
+        (k: any) => typeof k.getItems === 'function' && k.getThreshold() === 1,
+      );
+
+      expect(thresholdEntry).toBeDefined();
+      expect(thresholdEntry!.getItems()).toContainEqual(mockKey('current-account-key'));
+      expect(thresholdEntry!.getItems()).toContainEqual(mockKey('admin-key'));
+      expect(items).toContainEqual(mockKey('new-account-key'));
+    });
+
+    it('Case 3 — accountId swap to 0.0.0 (removal): no new account key added', async () => {
+      const zeroAccountId = {
+        toString: () => '0.0.0',
+        equals: (other: any) => other?.toString?.() === '0.0.0',
+      };
+      (AccountId.fromString as jest.Mock).mockReturnValue(zeroAccountId);
+
+      const tx = makeNodeUpdateTx({ accountId: zeroAccountId as any });
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue(tx);
+
+      accountCacheMock.getAccountInfoForTransaction
+        .mockResolvedValueOnce(makeAccountInfo('fee-payer-key'))
+        .mockResolvedValueOnce(makeAccountInfo('current-account-key'));
+
+      const result = await service.computeSignatureKey(makeTransaction());
+
+      expect((result as unknown as AsMockKeyList).getItems()).not.toContainEqual(
+        mockKey('new-account-key'),
+      );
+    });
+
+    it('Case 3 — node_account_id is null: falls back to admin key only', async () => {
+      const tx = makeNodeUpdateTx({ accountId: newAccountId as any });
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue(tx);
+
+      nodeCacheMock.getNodeInfoForTransaction.mockResolvedValue(makeNodeInfo('admin-key', null));
+
+      accountCacheMock.getAccountInfoForTransaction
+        .mockResolvedValueOnce(makeAccountInfo('fee-payer-key'))
+        .mockResolvedValueOnce(makeAccountInfo('new-account-key'));
+
+      const result = await service.computeSignatureKey(makeTransaction());
+
+      expect((result as unknown as AsMockKeyList).getItems()).toContainEqual(mockKey('admin-key'));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // addNodeKeys — guard clauses
+  // -------------------------------------------------------------------------
+
+  describe('addNodeKeys — guard clauses', () => {
+    beforeEach(() => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({});
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({ getNodeId: jest.fn().mockReturnValue(7) }),
+      );
+      accountCacheMock.getAccountInfoForTransaction.mockResolvedValue(
+        makeAccountInfo('fee-payer-key'),
+      );
+    });
+
+    it('returns gracefully when nodeInfo is null', async () => {
+      nodeCacheMock.getNodeInfoForTransaction.mockResolvedValue(null);
+
+      const result = await service.computeSignatureKey(makeTransaction());
+      const items = (result as unknown as AsMockKeyList).getItems();
+
+      expect(result).toBeDefined();
+      expect(items).toHaveLength(1); // only fee payer
+    });
+
+    it('returns gracefully when admin_key is null', async () => {
+      nodeCacheMock.getNodeInfoForTransaction.mockResolvedValue(makeNodeInfo(null));
+
+      const result = await service.computeSignatureKey(makeTransaction());
+
+      expect((result as unknown as AsMockKeyList).getItems()).toHaveLength(1); // only fee payer
+    });
+
+    it('handles exception thrown by nodeCacheService gracefully', async () => {
+      nodeCacheMock.getNodeInfoForTransaction.mockRejectedValue(new Error('node cache failure'));
+
+      const result = await service.computeSignatureKey(makeTransaction());
+
+      expect(result).toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // shouldIncludeAccountKey — via NodeUpdateTransaction cases
+  // -------------------------------------------------------------------------
+
+  describe('shouldIncludeAccountKey — via NodeUpdateTransaction cases', () => {
+    const fields: Array<[string, Partial<NodeUpdateTransaction>]> = [
+      ['adminKey', { adminKey: mockKey('some-key') as any }],
+      ['description', { description: 'updated' as any }],
+      ['certificateHash', { certificateHash: 'hash' as any }],
+      ['gossipCaCertificate', { gossipCaCertificate: 'cert' as any }],
+      ['serviceEndpoints', { serviceEndpoints: [{}] as any }],
+      ['gossipEndpoints', { gossipEndpoints: [{}] as any }],
+      ['grpcWebProxyEndpoint', { grpcWebProxyEndpoint: {} as any }],
+      ['declineReward', { declineReward: true as any }],
+    ];
+
+    const newAccountId = {
+      toString: () => '0.0.999',
+      equals: (other: any) => other?.toString?.() === '0.0.999',
+    };
+
+    const customAccountId = {
+      toString: () => '0.0.50',
+      equals: (other: any) => other?.toString?.() === '0.0.50',
+    } as unknown as AccountId;
+
+    test.each(fields)(
+      'when %s is set alongside accountId change → Case 2 (no threshold list)',
+      async (fieldName, fieldOverride) => {
+        (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+          makeTransactionModel({ getNodeId: jest.fn().mockReturnValue(2) }),
+        );
+        nodeCacheMock.getNodeInfoForTransaction.mockResolvedValue(
+          makeNodeInfo('admin-key', customAccountId),
+        );
+
+        const tx = new NodeUpdateTransaction();
+        Object.assign(tx, { accountId: newAccountId, ...fieldOverride });
+        (SDKTransaction.fromBytes as jest.Mock).mockReturnValue(tx);
+
+        accountCacheMock.getAccountInfoForTransaction
+          .mockResolvedValueOnce(makeAccountInfo('fee-payer-key'))
+          .mockResolvedValueOnce(makeAccountInfo('new-account-key'));
+
+        const result = await service.computeSignatureKey(makeTransaction());
+        const items = (result as unknown as AsMockKeyList).getItems();
+
+        const hasThreshold = items.some(
+          (k: any) => typeof k.getItems === 'function' && k.getThreshold() === 1,
+        );
+        expect(hasThreshold).toBe(false);
+        expect(items).toContainEqual(mockKey('admin-key'));
+      },
+    );
+  });
+});

--- a/back-end/libs/common/src/transaction-signature/transaction-signature.service.ts
+++ b/back-end/libs/common/src/transaction-signature/transaction-signature.service.ts
@@ -1,10 +1,18 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Key, KeyList, Transaction as SDKTransaction } from '@hiero-ledger/sdk';
+import {
+  AccountId,
+  Key,
+  KeyList,
+  NodeDeleteTransaction,
+  NodeUpdateTransaction,
+  Transaction as SDKTransaction,
+} from '@hiero-ledger/sdk';
 import { Transaction } from '@entities';
 import TransactionFactory from '@app/common/transaction-signature/model/transaction-factory';
 import { TransactionBaseModel } from '@app/common/transaction-signature/model/transaction-base.model';
 import { AccountCacheService } from '@app/common/transaction-signature/account-cache.service';
 import { NodeCacheService } from '@app/common/transaction-signature/node-cache.service';
+import { COUNCIL_ACCOUNTS } from '@app/common/constants';
 
 export interface SignatureRequirements {
   feePayerAccount: string;
@@ -139,7 +147,29 @@ export class TransactionSignatureService {
   }
 
   /**
-   * Get node admin key and optionally node account key
+   * Resolves and adds the required signing keys for a node transaction to the provided KeyList.
+   *
+   * For NodeDeleteTransactions, the node admin key is only required if the fee payer is not a council account
+   *
+   * For NodeUpdateTransactions, HIP-1299 defines three cases based on what is changing:
+   *
+   *   Case 1 — accountId is NOT changing (or only other fields are changing):
+   *     Required: admin key only
+   *     The current account key is not needed.
+   *
+   *   Case 2 — accountId IS changing AND other fields are also changing:
+   *     Required: (current account key OR admin key) + new account key (if swap)
+   *     Admin key alone satisfies the "current owner" requirement, so the
+   *     current account key does not need to be explicitly included.
+   *
+   *   Case 3 — accountId IS changing AND it is the ONLY change:
+   *     Required: (current account key OR admin key) + new account key (if swap)
+   *     Since no other fields provide admin key context, the current account key
+   *     must be explicitly included alongside the admin key as a 1-of-2 threshold.
+   *
+   * Additionally, if the accountId is being swapped to a new (non-zero) account,
+   * that new account's key must always co-sign regardless of which case applies.
+   * Setting accountId to 0.0.0 is a removal — no new account key is required.
    */
   private async addNodeKeys(
     signatureKey: KeyList,
@@ -154,30 +184,95 @@ export class TransactionSignatureService {
         return;
       }
 
-      // Add node admin key
-      if (nodeInfo.admin_key) {
-        signatureKey.push(nodeInfo.admin_key);
+      if (!nodeInfo.admin_key) {
+        this.logger.warn(`No node admin key found for node ${nodeId}`);
+        return;
       }
 
-      //TODO documentation on this requirement is still in the works.
-      //Current documentation states that when the node account id is unset, it can be signed by
-      //the account key OR the node admin key. Which means I would need to put these in an keyList with
-      //a threshold before added them to the signature keys.
-      //In the case of account id being changed, both the old key and the new key are required
-      // to sign the transaction. So they can be added like this.
-      //NOTE: this is different than node adminKey
-      const nodeAccount = nodeInfo.node_account_id.toString();
-      if (nodeAccount) {
-        const accountInfo = await this.accountCacheService.getAccountInfoForTransaction(
-          transaction,
-          nodeAccount,
-        );
-        if (accountInfo?.key) {
-          signatureKey.push(accountInfo.key);
+      if (transaction instanceof NodeDeleteTransaction) {
+        // if fee payer is council_accounts,
+        // it will already be added to the required list
+        // and the admin key is not required (as the fee payer will already approve it)
+        // otherwise, admin key is required
+        const payerId = transaction.transactionId?.accountId;
+        const isCouncilAccount = payerId && payerId.toString() in COUNCIL_ACCOUNTS;
+
+        if (!isCouncilAccount) {
+          signatureKey.push(nodeInfo.admin_key);
+        }
+        return;
+      } else if (!(transaction instanceof NodeUpdateTransaction)) {
+        // Non-update transactions only require the admin key
+        signatureKey.push(nodeInfo.admin_key);
+        return;
+      }
+
+      const nodeUpdateTx = transaction as NodeUpdateTransaction;
+
+      const isAccountIdChanging =
+        nodeUpdateTx.accountId !== null &&
+        !nodeUpdateTx.accountId.equals(nodeInfo.node_account_id);
+
+      if (!isAccountIdChanging) {
+        // Case 1: account ID is not changing — admin key alone is sufficient
+        signatureKey.push(nodeInfo.admin_key);
+      } else {
+        // Cases 2 & 3: account ID is changing — determine if the current account
+        // key must be explicitly included to satisfy the "current owner" requirement
+        const shouldIncludeCurrentAccountKey = this.shouldIncludeAccountKey(nodeUpdateTx);
+
+        if (shouldIncludeCurrentAccountKey) {
+          // Case 3: account ID is the only change — build a 1-of-2 threshold so that
+          // either the current account key OR the admin key can satisfy current owner
+          const currentOwnerThreshold = new KeyList();
+          currentOwnerThreshold.setThreshold(1);
+
+          const currentAccountInfo = await this.accountCacheService.getAccountInfoForTransaction(
+            transaction,
+            nodeInfo.node_account_id.toString(),
+          );
+          if (currentAccountInfo?.key) {
+            currentOwnerThreshold.push(currentAccountInfo.key);
+          }
+          currentOwnerThreshold.push(nodeInfo.admin_key);
+
+          signatureKey.push(currentOwnerThreshold);
+        } else {
+          // Case 2: account ID is changing alongside other fields — admin key alone
+          // satisfies the current owner requirement
+          signatureKey.push(nodeInfo.admin_key);
+        }
+
+        // If this is a swap (not a removal), the new account must also co-sign.
+        // Setting accountId to 0.0.0 is a removal — there is no new account to sign.
+        const newAccountId = nodeUpdateTx.accountId;
+        const isSwap = !newAccountId.equals(AccountId.fromString('0.0.0'));
+        if (isSwap) {
+          const newAccountInfo = await this.accountCacheService.getAccountInfoForTransaction(
+            transaction,
+            newAccountId.toString(),
+          );
+          if (newAccountInfo?.key) {
+            signatureKey.push(newAccountInfo.key);
+          }
         }
       }
     } catch (error) {
       this.logger.error(`Failed to get node keys for node ${nodeId}: ${error.message}`);
     }
+  }
+
+  private shouldIncludeAccountKey(tx: NodeUpdateTransaction): boolean {
+    const hasOtherChanges =
+      tx.adminKey !== null ||
+      tx.description !== null ||
+      tx.certificateHash !== null ||
+      tx.gossipCaCertificate !== null ||
+      (tx.serviceEndpoints !== null && tx.serviceEndpoints.length > 0) ||
+      (tx.gossipEndpoints !== null && tx.gossipEndpoints.length > 0) ||
+      tx.grpcWebProxyEndpoint !== null ||
+      tx.declineReward !== null;
+
+    return !hasOtherChanges;
   }
 }

--- a/back-end/libs/common/src/transaction-signature/transaction-signature.service.ts
+++ b/back-end/libs/common/src/transaction-signature/transaction-signature.service.ts
@@ -158,7 +158,7 @@ export class TransactionSignatureService {
    *     The current account key is not needed.
    *
    *   Case 2 — accountId IS changing AND other fields are also changing:
-   *     Required: (current account key OR admin key) + new account key (if swap)
+   *     Required: admin key + new account key (if swap)
    *     Admin key alone satisfies the "current owner" requirement, so the
    *     current account key does not need to be explicitly included.
    *

--- a/back-end/libs/common/src/transaction-signature/transaction-signature.service.ts
+++ b/back-end/libs/common/src/transaction-signature/transaction-signature.service.ts
@@ -189,28 +189,31 @@ export class TransactionSignatureService {
         return;
       }
 
-      if (transaction instanceof NodeDeleteTransaction) {
+      const sdkTransaction = SDKTransaction.fromBytes(transaction.transactionBytes);
+
+      if (sdkTransaction instanceof NodeDeleteTransaction) {
         // if fee payer is council_accounts,
         // it will already be added to the required list
         // and the admin key is not required (as the fee payer will already approve it)
         // otherwise, admin key is required
-        const payerId = transaction.transactionId?.accountId;
+        const payerId = sdkTransaction.transactionId?.accountId;
         const isCouncilAccount = payerId && payerId.toString() in COUNCIL_ACCOUNTS;
 
         if (!isCouncilAccount) {
           signatureKey.push(nodeInfo.admin_key);
         }
         return;
-      } else if (!(transaction instanceof NodeUpdateTransaction)) {
+      } else if (!(sdkTransaction instanceof NodeUpdateTransaction)) {
         // Non-update transactions only require the admin key
         signatureKey.push(nodeInfo.admin_key);
         return;
       }
 
-      const nodeUpdateTx = transaction as NodeUpdateTransaction;
+      const nodeUpdateTx = sdkTransaction as NodeUpdateTransaction;
 
       const isAccountIdChanging =
         nodeUpdateTx.accountId !== null &&
+        nodeInfo.node_account_id !== null &&
         !nodeUpdateTx.accountId.equals(nodeInfo.node_account_id);
 
       if (!isAccountIdChanging) {
@@ -226,6 +229,12 @@ export class TransactionSignatureService {
           // either the current account key OR the admin key can satisfy current owner
           const currentOwnerThreshold = new KeyList();
           currentOwnerThreshold.setThreshold(1);
+
+          if (nodeInfo.node_account_id === null) {
+            this.logger.warn(`No node account ID found for node ${nodeId}`);
+            signatureKey.push(nodeInfo.admin_key);
+            return;
+          }
 
           const currentAccountInfo = await this.accountCacheService.getAccountInfoForTransaction(
             transaction,

--- a/back-end/libs/common/src/types/NodeInfoParsed.ts
+++ b/back-end/libs/common/src/types/NodeInfoParsed.ts
@@ -19,4 +19,6 @@ export interface NodeInfoParsed {
   stake_rewarded: Hbar | null;
   staking_period: TimestampRange | null;
   reward_rate_start: Hbar | null;
+  decline_reward: boolean;
+  grpc_web_proxy_endpoint: ServiceEndpoint | null;
 }

--- a/back-end/libs/common/src/types/NodeInfoParsed.ts
+++ b/back-end/libs/common/src/types/NodeInfoParsed.ts
@@ -19,6 +19,6 @@ export interface NodeInfoParsed {
   stake_rewarded: Hbar | null;
   staking_period: TimestampRange | null;
   reward_rate_start: Hbar | null;
-  decline_reward: boolean;
+  decline_reward: boolean | null;
   grpc_web_proxy_endpoint: ServiceEndpoint | null;
 }

--- a/back-end/libs/common/src/utils/sdk/node.ts
+++ b/back-end/libs/common/src/utils/sdk/node.ts
@@ -147,7 +147,7 @@ export const getServiceEndpoint = (endPoint: ServiceEndPoint | undefined) => {
   const ipAddressV4 = endPoint.ip_address_v4?.trim()?.split('.') || [];
   const domainName = endPoint.domain_name?.trim();
 
-  if (ipAddressV4 || domainName) {
+  if (ipAddressV4.length > 0 || domainName) {
     const serviceEndpoint = new ServiceEndpoint();
 
     if (ipAddressV4.length === 4) {

--- a/back-end/libs/common/src/utils/sdk/node.ts
+++ b/back-end/libs/common/src/utils/sdk/node.ts
@@ -30,6 +30,8 @@ export const parseNodeInfo = (nodeInfo: NetworkNode) => {
     stake_rewarded: parseNodeProperty(nodeInfo, 'stake_rewarded'),
     staking_period: parseNodeProperty(nodeInfo, 'staking_period'),
     reward_rate_start: parseNodeProperty(nodeInfo, 'reward_rate_start'),
+    decline_reward: parseNodeProperty(nodeInfo, 'decline_reward'),
+    grpc_web_proxy_endpoint: parseNodeProperty(nodeInfo, 'grpc_web_proxy_endpoint'),
   };
 
   return nodeInfoParsed;
@@ -64,6 +66,8 @@ export function parseNodeProperty(
   nodeInfo: NetworkNode,
   property: 'description' | 'memo' | 'public_key' | 'node_cert_hash',
 ): string | null;
+export function parseNodeProperty(nodeInfo: NetworkNode, property: 'decline_reward'): boolean | null;
+export function parseNodeProperty(nodeInfo: NetworkNode, property: 'grpc_web_proxy_endpoint'): ServiceEndpoint | null;
 export function parseNodeProperty(nodeInfo: NetworkNode, property: keyof NetworkNode) {
   switch (property) {
     case 'file_id':
@@ -112,6 +116,10 @@ export function parseNodeProperty(nodeInfo: NetworkNode, property: keyof Network
       return nodeInfo.memo?.trim() || null;
     case 'description':
       return nodeInfo.description?.trim() || null;
+    case 'decline_reward':
+      return nodeInfo.decline_reward ?? null;
+    case 'grpc_web_proxy_endpoint':
+      return getServiceEndpoint(nodeInfo.grpc_web_proxy_endpoint);
     default:
       throw new Error(`Unknown account info  property: ${property}`);
   }
@@ -121,25 +129,39 @@ export const getServiceEndpoints = (data: ServiceEndPoint[] | undefined) => {
   const endpoints = new Array<ServiceEndpoint>();
 
   for (const se of data || []) {
-    const ipAddressV4 = se.ip_address_v4?.trim()?.split('.') || [];
-    const domainName = se.domain_name?.trim();
+    const serviceEndpoint = getServiceEndpoint(se);
 
-    if (ipAddressV4 || domainName) {
-      const serviceEndpoint = new ServiceEndpoint();
-
-      if (ipAddressV4.length === 4) {
-        serviceEndpoint.setIpAddressV4(Uint8Array.from(ipAddressV4.map(Number)));
-      } else if (domainName) {
-        serviceEndpoint.setDomainName(domainName);
-      }
-
-      if (se.port) {
-        serviceEndpoint.setPort(se.port);
-      }
-
+    if (serviceEndpoint) {
       endpoints.push(serviceEndpoint);
     }
   }
 
   return endpoints;
 };
+
+export const getServiceEndpoint = (endPoint: ServiceEndPoint | undefined) => {
+  if (!endPoint) {
+    return null;
+  }
+
+  const ipAddressV4 = endPoint.ip_address_v4?.trim()?.split('.') || [];
+  const domainName = endPoint.domain_name?.trim();
+
+  if (ipAddressV4 || domainName) {
+    const serviceEndpoint = new ServiceEndpoint();
+
+    if (ipAddressV4.length === 4) {
+      serviceEndpoint.setIpAddressV4(Uint8Array.from(ipAddressV4.map(Number)));
+    } else if (domainName) {
+      serviceEndpoint.setDomainName(domainName);
+    }
+
+    if (endPoint.port) {
+      serviceEndpoint.setPort(endPoint.port);
+    }
+
+    return serviceEndpoint;
+  }
+
+  return null;
+}

--- a/front-end/src/renderer/components/SignatureStatus.vue
+++ b/front-end/src/renderer/components/SignatureStatus.vue
@@ -81,6 +81,16 @@ const externalKeysRaw = computed(() => {
         />
       </div>
     </template>
+    <template v-if="Object.keys(signatureKeyObject.newNodeAccountKeys).length > 0">
+      <div class="ms-4" :class="{ 'ms-5': hasMultiplePublicKeys }">
+        <SignatureStatusEntities
+          :entities="signatureKeyObject.newNodeAccountKeys"
+          :public-keys-signed="publicKeysSigned"
+          :label="`New Node Account $entityId Key`"
+          :externalKeys="externalKeysRaw"
+        />
+      </div>
+    </template>
     <template v-if="signatureKeyObject.newKeys.length > 0">
       <div class="ms-4" :class="{ 'ms-5': hasMultiplePublicKeys }">
         <SignatureStatusEntities

--- a/front-end/src/renderer/components/SignatureStatusEntities.vue
+++ b/front-end/src/renderer/components/SignatureStatusEntities.vue
@@ -35,6 +35,12 @@ const linkedAccounts = ref<HederaAccount[]>([]);
 /* Computed */
 const labelParts = computed(() => props.label.split('$entityId'));
 
+/* Functions */
+const isNumericEntityId = (entityId: string) => !Number.isNaN(Number(entityId));
+
+const getLinkedAccountNickname = (entityId: string) =>
+  linkedAccounts.value.find(la => la.account_id === entityId)?.nickname || '';
+
 /* Hooks */
 onBeforeMount(async () => {
   if (!isUserLoggedIn(user.personal)) throw new Error('User is not logged in');
@@ -72,24 +78,15 @@ onBeforeMount(async () => {
                 </template>
                 <template v-else>
                   <span>{{ part }}</span>
-                  <span>
-                    <template
-                      v-if="
-                        (linkedAccounts.find(la => la.account_id === entityId)?.nickname || '')
-                          .length > 0
-                      "
-                    >
-                      <span>
-                        <span class="text-small">
-                          {{ linkedAccounts.find(la => la.account_id === entityId)?.nickname }}
-                          ({{ getAccountIdWithChecksum(entityId) }})
-                        </span>
-                      </span>
+                  <span class="text-small">
+                    <template v-if="isNumericEntityId(entityId)">
+                      {{ entityId }}
+                    </template>
+                    <template v-else-if="getLinkedAccountNickname(entityId).length > 0">
+                      {{ getLinkedAccountNickname(entityId) }} ({{ getAccountIdWithChecksum(entityId) }})
                     </template>
                     <template v-else>
-                      <span class="text-small overflow-hidden">
-                        {{ getAccountIdWithChecksum(entityId) || entityId }}
-                      </span>
+                      <span class="overflow-hidden">{{ getAccountIdWithChecksum(entityId) || entityId }}</span>
                     </template>
                   </span>
                 </template>

--- a/front-end/src/renderer/utils/sdk/createTransactions.ts
+++ b/front-end/src/renderer/utils/sdk/createTransactions.ts
@@ -448,7 +448,7 @@ export const getServiceEndpoint = (serviceEndpoint: ComponentServiceEndpoint | n
   const domainName = serviceEndpoint.domainName?.trim();
   const port = Number.parseInt(serviceEndpoint.port?.trim());
 
-  if (ipAddressV4 || domainName) {
+  if (ipAddressV4.length > 0 || domainName) {
     const serviceEndpoint = new ServiceEndpoint();
 
     if (ipAddressV4.length > 0) {

--- a/front-end/src/renderer/utils/transactionSignatureModels/node-delete-transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/node-delete-transaction.model.ts
@@ -1,19 +1,56 @@
-import { NodeDeleteTransaction } from '@hiero-ledger/sdk';
+import { Key, NodeDeleteTransaction } from '@hiero-ledger/sdk';
 
 import { TransactionBaseModel } from './transaction.model';
 import { COUNCIL_ACCOUNTS } from './index';
+import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache';
+import type { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache';
+import { createLogger } from '@renderer/utils';
+
+const logger = createLogger('renderer.transaction.signatureModel.nodeDelete');
 
 export default class NodeDeleteTransactionModel extends TransactionBaseModel<NodeDeleteTransaction> {
-  override getNodeId(): number | null {
+  override async getNodeKeys(
+    mirrorNodeLink: string,
+    _accountInfoCache: AccountByIdCache,
+    nodeInfoCache: NodeByIdCache,
+  ): Promise<{nodeId: number, key: Key} | null> {
     // if fee payer is council_accounts,
     // it will already be added to the required list
-    // and the admin key is not required
+    // and the admin key is not required (as the fee payer will already approve it)
     // otherwise, admin key is required
     const payerId = this.transaction.transactionId?.accountId;
     const isCouncilAccount = payerId && payerId.toString() in COUNCIL_ACCOUNTS;
-    if (!isCouncilAccount && this.transaction.nodeId) {
-      return this.transaction.nodeId.toNumber();
+
+    if (isCouncilAccount) {
+      return null;
     }
-    return null;
+
+    const nodeId = this.transaction.nodeId?.toNumber();
+
+    try {
+      if (nodeId == null || Number.isNaN(nodeId)) {
+        return null;
+      }
+
+      const nodeInfo = await nodeInfoCache.lookup(nodeId, mirrorNodeLink);
+
+      if (!nodeInfo) {
+        logger.warn(`No node info found for node ${nodeId}`);
+        return null;
+      }
+
+      if (!nodeInfo.admin_key) {
+        logger.warn( `No admin key found for node ${nodeId}`);
+        return null;
+      }
+
+      return { nodeId, key: nodeInfo.admin_key };
+    } catch (error) {
+      logger.warn('Failed to resolve node admin signing key', {
+        error,
+        nodeId,
+      });
+      throw error;
+    }
   }
 }

--- a/front-end/src/renderer/utils/transactionSignatureModels/node-delete-transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/node-delete-transaction.model.ts
@@ -4,7 +4,7 @@ import { TransactionBaseModel } from './transaction.model';
 import { COUNCIL_ACCOUNTS } from './index';
 import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache';
 import type { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache';
-import { createLogger } from '@renderer/utils';
+import { createLogger } from '@renderer/utils/logger';
 
 const logger = createLogger('renderer.transaction.signatureModel.nodeDelete');
 

--- a/front-end/src/renderer/utils/transactionSignatureModels/node-update-transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/node-update-transaction.model.ts
@@ -1,6 +1,11 @@
-import { NodeUpdateTransaction } from '@hiero-ledger/sdk';
+import { AccountId, Key, KeyList, NodeUpdateTransaction } from '@hiero-ledger/sdk';
 
 import { TransactionBaseModel } from './transaction.model';
+import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache';
+import type { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache';
+import { createLogger } from '@renderer/utils';
+
+const logger = createLogger('renderer.transaction.signatureModel.nodeUpdate');
 
 export default class NodeUpdateTransactionModel extends TransactionBaseModel<NodeUpdateTransaction> {
   override getNewKeys() {
@@ -11,10 +16,114 @@ export default class NodeUpdateTransactionModel extends TransactionBaseModel<Nod
     return [];
   }
 
-  override getNodeId(): number | null {
-    if (this.transaction.nodeId) {
-      return this.transaction.nodeId.toNumber();
+  override async getNodeKeys(
+    mirrorNodeLink: string,
+    accountInfoCache: AccountByIdCache,
+    nodeInfoCache: NodeByIdCache,
+  ): Promise<{nodeId: number, key: Key} | null> {
+    const nodeId = this.transaction.nodeId?.toNumber();
+
+    try {
+      if (nodeId == null || Number.isNaN(nodeId)) {
+        return null;
+      }
+
+      const nodeInfo = await nodeInfoCache.lookup(nodeId, mirrorNodeLink);
+
+      if (!nodeInfo) {
+        logger.warn(`No node info found for node ${nodeId}`);
+        return null;
+      }
+
+      if (!nodeInfo.admin_key) {
+        logger.warn( `No admin key found for node ${nodeId}`);
+        return null;
+      }
+
+      const isAccountIdChanging =
+        this.transaction.accountId !== null &&
+        nodeInfo.node_account_id !== null &&
+        !this.transaction.accountId.equals(nodeInfo.node_account_id);
+
+      if (!isAccountIdChanging) {
+        // Case 1: account ID is not changing — admin key alone is sufficient
+        return { nodeId, key: nodeInfo.admin_key};
+      } else {
+        // Cases 2 & 3: account ID is changing — determine if the current account
+        // key must be explicitly included to satisfy the "current owner" requirement
+        const shouldIncludeCurrentAccountKey = this.shouldIncludeAccountKey(this.transaction);
+
+        if (shouldIncludeCurrentAccountKey) {
+          // Case 3: account ID is the only change — build a 1-of-2 threshold so that
+          // either the current account key OR the admin key can satisfy current owner
+          const currentOwnerThreshold = new KeyList();
+          currentOwnerThreshold.setThreshold(1);
+
+          const currentAccountInfo = await accountInfoCache.lookup(nodeInfo.node_account_id!.toString(), mirrorNodeLink);
+
+          if (currentAccountInfo?.key) {
+            currentOwnerThreshold.push(currentAccountInfo.key);
+
+            currentOwnerThreshold.push(nodeInfo.admin_key);
+
+            return { nodeId, key: currentOwnerThreshold };
+          } else {
+            logger.warn(`No account key found for account ${nodeInfo.node_account_id!.toString()}`)
+            return { nodeId, key: nodeInfo.admin_key };
+          }
+        } else {
+          // Case 2: account ID is changing alongside other fields — admin key alone
+          // satisfies the current owner requirement
+          return { nodeId, key: nodeInfo.admin_key };
+        }
+      }
+    } catch (error) {
+      logger.warn('Failed to resolve node admin signing key', {
+        error,
+        nodeId,
+      });
+      throw error;
     }
+  }
+
+  override async getNewNodeAccountKeys(
+    mirrorNodeLink: string,
+    accountInfoCache: AccountByIdCache,
+  ): Promise<{accountId: string, key: Key} | null> {
+    const newAccountId = this.transaction.accountId;
+
+    if (!newAccountId) {
+      return null;
+    }
+
+    const isSwap = !newAccountId.equals(AccountId.fromString('0.0.0'));
+
+    if (!isSwap) {
+      return null;
+    }
+
+    const newAccountInfo = await accountInfoCache.lookup(newAccountId.toString(), mirrorNodeLink);
+    if (newAccountInfo?.key) {
+      return {
+        accountId: newAccountId.toString(),
+        key: newAccountInfo.key,
+      };
+    }
+
     return null;
+  }
+
+  private shouldIncludeAccountKey(tx: NodeUpdateTransaction): boolean {
+    const hasOtherChanges =
+      tx.adminKey !== null ||
+      tx.description !== null ||
+      tx.certificateHash !== null ||
+      tx.gossipCaCertificate !== null ||
+      (tx.serviceEndpoints !== null && tx.serviceEndpoints.length > 0) ||
+      (tx.gossipEndpoints !== null && tx.gossipEndpoints.length > 0) ||
+      tx.grpcWebProxyEndpoint !== null ||
+      tx.declineReward !== null;
+
+    return !hasOtherChanges;
   }
 }

--- a/front-end/src/renderer/utils/transactionSignatureModels/node-update-transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/node-update-transaction.model.ts
@@ -3,7 +3,7 @@ import { AccountId, Key, KeyList, NodeUpdateTransaction } from '@hiero-ledger/sd
 import { TransactionBaseModel } from './transaction.model';
 import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache';
 import type { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache';
-import { createLogger } from '@renderer/utils';
+import { createLogger } from '@renderer/utils/logger';
 
 const logger = createLogger('renderer.transaction.signatureModel.nodeUpdate');
 

--- a/front-end/src/renderer/utils/transactionSignatureModels/transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/transaction.model.ts
@@ -1,7 +1,6 @@
 import { AccountId, Key, PublicKey, Transaction as SDKTransaction } from '@hiero-ledger/sdk';
 
 import { compareKeys } from '../sdk';
-import type { INodeInfoParsed } from '@shared/interfaces';
 import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
 import type { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
 import type { ConnectedOrganization } from '@renderer/types';
@@ -18,6 +17,7 @@ export interface SignatureAudit {
   newKeys: Key[];
   payerKey: Record<string, Key>; // Fee payer accounts (including transaction payer id)
   nodeAdminKeys: Record<number, Key>;
+  newNodeAccountKeys: Record<string, Key>;
   externalKeys: Set<PublicKey>; // External keys (no matching user in backend)
 }
 
@@ -44,12 +44,20 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
     return [];
   }
 
-  getNodeId(): number | null {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getNodeKeys(
+    _mirrorNodeLink: string,
+    _accountInfoCache: AccountByIdCache,
+    _nodeInfoCache: NodeByIdCache,
+  ): Promise<{nodeId: number, key: Key} | null> {
     return null;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  getNodeAccountId(_nodeInfo: INodeInfoParsed): string | null {
+  async getNewNodeAccountKeys(
+    _mirrorNodeLink: string,
+    _accountInfoCache: AccountByIdCache,
+  ): Promise<{accountId: string, key: Key} | null> {
     return null;
   }
 
@@ -64,7 +72,8 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
     const accounts = this.getSigningAccounts();
     const receiverAccounts = this.getReceiverAccounts();
     const newKeys = this.getNewKeys() ?? [];
-    const nodeId = this.getNodeId();
+    const nodeKeys = await this.getNodeKeys(mirrorNodeLink, accountInfoCache, nodeInfoCache);
+    const newNodeKeys = await this.getNewNodeAccountKeys(mirrorNodeLink, accountInfoCache);
 
     /* Create result objects */
     const signatureKeys: Key[] = [];
@@ -72,6 +81,7 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
     const payerKey: Record<string, Key> = {};
     const receiverAccountsKeys: Record<string, Key> = {};
     const nodeAdminKeys: Record<number, Key> = {};
+    const newNodeAccountKeys: Record<string, Key> = {};
     const externalKeys = new Set<PublicKey>();
 
     const currentKeyList: Key[] = [];
@@ -136,41 +146,18 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
       }
     }
 
-    /* Check if user has a key included in the node admin key */
-    try {
-      if (!Number.isNaN(nodeId) && nodeId !== null) {
-        const nodeInfo = await nodeInfoCache.lookup(nodeId, mirrorNodeLink);
-        const adminKey = nodeInfo?.admin_key;
-        if (adminKey && !hasKey(adminKey)) {
-          signatureKeys.push(adminKey);
-          nodeAdminKeys[nodeId] = adminKey;
-          currentKeyList.push(adminKey);
-        }
+    if (nodeKeys) {
+      const { nodeId, key } = nodeKeys;
+      signatureKeys.push(key);
+      nodeAdminKeys[nodeId] = key;
+      currentKeyList.push(key);
+    }
 
-        //TODO documentation on this requirement is still in the works.
-        //Current documentation states that when the node account id is unset, it can be signed by
-        //the account key OR the node admin key. Which means I would need to put these in an keyList with
-        //a threshold before added them to the signature keys.
-        //In the case of account id being changed, both the old key and the new key are required
-        // to sign the transaction. So they can be added like this.
-        //NOTE: this is different than node adminKey
-        const nodeAccountId = nodeInfo ? this.getNodeAccountId(nodeInfo) : null;
-        if (nodeAccountId) {
-          const nodeAccountInfo = await accountInfoCache.lookup(nodeAccountId, mirrorNodeLink);
-          const key = nodeAccountInfo?.key;
-          if (key && !hasKey(key)) {
-            signatureKeys.push(key);
-            nodeAdminKeys[nodeId] = key;
-            currentKeyList.push(key);
-          }
-        }
-      }
-    } catch (error) {
-      logger.warn('Failed to resolve node admin signing key', {
-        error,
-        nodeId,
-      });
-      throw error;
+    if (newNodeKeys) {
+      const { accountId, key } = newNodeKeys;
+      signatureKeys.push(key);
+      newNodeAccountKeys[accountId] = key;
+      currentKeyList.push(key);
     }
 
     /* Add keys to the signature key list */
@@ -204,8 +191,8 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
       newKeys,
       payerKey,
       nodeAdminKeys,
+      newNodeAccountKeys,
       externalKeys,
-      // nodeAccountKeys,
     };
   }
 }


### PR DESCRIPTION
**Description**:
DAB transactions require a view specific list of keys. According to HIP-1299, the NodeUpdateTransaction requires a bit more logic than the rest. This PR fixes how the require key calculations are done, and displayed to the user.

**Related issue(s)**:

Fixes #2698

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
