### PR TITLE
feat: increase number of workers in CI

### DIFF
--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -80,7 +80,7 @@ jobs:
             soloRequired: true
             backendRequired: true
             sharedEnvironment: true
-            workers: 4
+            workers: 6
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0


### PR DESCRIPTION
**Description**:

This PR increases frontend CI parallelism by raising the worker count in the frontend test workflow, in order to reduce test execution time.

* Increase `workers` in frontend test workflow from `4` to `6`

**Related issue(s)**:

Fixes #2715

**Notes for reviewer**:

- Change is limited to CI config: `.github/workflows/test-frontend.yaml`
- Please confirm runner capacity/concurrency is acceptable for `6` workers

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)