### PR TITLE
chore: grouping caches in AppCache

### DIFF
--- a/front-end/src/renderer/App.vue
+++ b/front-end/src/renderer/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onErrorCaptured, onMounted, reactive, ref } from 'vue';
+import { onErrorCaptured, onMounted, reactive, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 
 import 'bootstrap/dist/js/bootstrap.bundle.min';
@@ -18,14 +18,9 @@ import UserPasswordModal from '@renderer/components/UserPasswordModal.vue';
 import OrganizationStatusModal from '@renderer/components/Organization/OrganizationStatusModal.vue';
 import GlobalModalLoader from '@renderer/components/GlobalModalLoader.vue';
 import GlobalAppProcesses from '@renderer/components/GlobalAppProcesses';
-import { AccountByPublicKeyCache } from '@renderer/caches/mirrorNode/AccountByPublicKeyCache.ts';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import { TransactionByIdCache } from '@renderer/caches/mirrorNode/TransactionByIdCache.ts';
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
-import { PublicKeyOwnerCache } from './caches/backend/PublicKeyOwnerCache';
 import { ToastManager } from './utils/ToastManager';
 import { createLogger, getErrorMessage } from '@renderer/utils';
-import { BackendTransactionCache } from './caches/backend/BackendTransactionCache.ts';
+import { AppCache } from './caches/AppCache';
 
 /* Composables */
 const router = useRouter();
@@ -68,12 +63,6 @@ onErrorCaptured((err: unknown) => {
 provideUserModalRef(userPasswordModalRef);
 provideGlobalModalLoaderlRef(globalModalLoaderRef);
 provideDynamicLayout(dynamicLayout);
-AccountByIdCache.provide();
-AccountByPublicKeyCache.provide();
-TransactionByIdCache.provide();
-NodeByIdCache.provide();
-PublicKeyOwnerCache.provide();
-BackendTransactionCache.provide();
 ToastManager.provide();
 </script>
 <template>

--- a/front-end/src/renderer/App.vue
+++ b/front-end/src/renderer/App.vue
@@ -64,6 +64,14 @@ provideUserModalRef(userPasswordModalRef);
 provideGlobalModalLoaderlRef(globalModalLoaderRef);
 provideDynamicLayout(dynamicLayout);
 ToastManager.provide();
+
+/* AppCache */
+const appCache = AppCache.inject();
+watch([() => user.personal, () => user.selectedOrganization], () => {
+  // User identity has changed => backend transaction cache is obsolete
+  appCache.backendTransaction.clear();
+}, { immediate: true });
+
 </script>
 <template>
   <AppHeader

--- a/front-end/src/renderer/caches/AppCache.ts
+++ b/front-end/src/renderer/caches/AppCache.ts
@@ -1,0 +1,65 @@
+import { inject } from 'vue';
+import { Transaction as SDKTransaction } from '@hiero-ledger/sdk';
+import type { ConnectedOrganization } from '@renderer/types';
+import type { SignatureAudit } from '@renderer/utils/transactionSignatureModels/transaction.model';
+import { AccountByIdCache } from './mirrorNode/AccountByIdCache';
+import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
+import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
+import { TransactionByIdCache } from '@renderer/caches/mirrorNode/TransactionByIdCache.ts';
+import { BackendTransactionCache } from './backend/BackendTransactionCache.ts';
+import { AccountByPublicKeyCache } from './mirrorNode/AccountByPublicKeyCache';
+import TransactionFactory from '@renderer/utils/transactionSignatureModels/transaction-factory.ts';
+import { createLogger } from '@renderer/utils';
+
+export class AppCache {
+  private static readonly injectKey = Symbol();
+  public static instance = new AppCache();
+
+  // Mirror node
+  public readonly mirrorAccountById = new AccountByIdCache();
+  public readonly mirrorAccountByPublicKey = new AccountByPublicKeyCache();
+  public readonly mirrorNodeById = new NodeByIdCache();
+  public readonly mirrorTransactionById = new TransactionByIdCache();
+
+  // Backend
+  public readonly backendTransaction = new BackendTransactionCache();
+  public readonly backendPublicKeyOwner = new PublicKeyOwnerCache();
+
+  //
+  // Public
+  //
+
+  public static inject(): AppCache {
+    return inject<AppCache>(AppCache.injectKey, this.instance);
+  }
+
+  public async computeSignatureKey(
+    transaction: SDKTransaction,
+    organization: ConnectedOrganization | null,
+    mirrorNodeUrl: string,
+  ): Promise<SignatureAudit> {
+    const transactionModel = TransactionFactory.fromTransaction(transaction);
+
+    return await transactionModel.computeSignatureKey(
+      mirrorNodeUrl,
+      this.mirrorAccountById,
+      this.mirrorNodeById,
+      this.backendPublicKeyOwner,
+      organization,
+    );
+  }
+
+  //
+  // Protected
+  //
+
+  private static instanceCount = 0;
+
+  private constructor() {
+    AppCache.instanceCount += 1;
+    if (AppCache.instanceCount >= 2) {
+      const logger = createLogger('renderer.cache');
+      logger.error(`${AppCache.instanceCount} instances of AppCache are created`);
+    }
+  }
+}

--- a/front-end/src/renderer/caches/backend/BackendTransactionCache.ts
+++ b/front-end/src/renderer/caches/backend/BackendTransactionCache.ts
@@ -1,24 +1,12 @@
-import { inject, provide } from 'vue';
 import { TransactionId } from '@hiero-ledger/sdk';
 import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
 import { getTransactionById } from '@renderer/services/organization';
 import type { ITransactionFull } from '@shared/interfaces';
 
 export class BackendTransactionCache extends EntityCache<number | string, ITransactionFull> {
-  private static readonly injectKey = Symbol();
-
   //
   // Public
   //
-
-  public static provide(): void {
-    provide(BackendTransactionCache.injectKey, new BackendTransactionCache());
-  }
-
-  public static inject(): BackendTransactionCache {
-    const defaultFactory = () => new BackendTransactionCache();
-    return inject<BackendTransactionCache>(BackendTransactionCache.injectKey, defaultFactory, true);
-  }
 
   public forgetTransaction(transaction: ITransactionFull, serverUrl: string): void {
     this.forget(transaction.id, serverUrl);

--- a/front-end/src/renderer/caches/backend/PublicKeyOwnerCache.ts
+++ b/front-end/src/renderer/caches/backend/PublicKeyOwnerCache.ts
@@ -1,23 +1,7 @@
-import { inject, provide } from 'vue';
 import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
 import { getPublicKeyOwner } from '@renderer/services/organization';
 
 export class PublicKeyOwnerCache extends EntityCache<string, string | null> {
-  private static readonly injectKey = Symbol();
-
-  //
-  // Public
-  //
-
-  public static provide(): void {
-    provide(PublicKeyOwnerCache.injectKey, new PublicKeyOwnerCache());
-  }
-
-  public static inject(): PublicKeyOwnerCache {
-    const defaultFactory = () => new PublicKeyOwnerCache();
-    return inject<PublicKeyOwnerCache>(PublicKeyOwnerCache.injectKey, defaultFactory, true);
-  }
-
   //
   // EntityCache
   //

--- a/front-end/src/renderer/caches/base/EntityCache.ts
+++ b/front-end/src/renderer/caches/base/EntityCache.ts
@@ -39,10 +39,10 @@ export abstract class EntityCache<K extends string | number, E> {
     }
   }
 
-  // public clear(): void {
-  //   this.records.clear();
-  // }
-  //
+  public clear(): void {
+    this.records.clear();
+  }
+
   // public contains(key: K, mirrorNodeUrl: string, forceLoad = false): boolean {
   //   const recordKey = this.makeRecordKey(key, mirrorNodeUrl);
   //   const r = this.records.get(recordKey);

--- a/front-end/src/renderer/caches/mirrorNode/AccountByIdCache.ts
+++ b/front-end/src/renderer/caches/mirrorNode/AccountByIdCache.ts
@@ -1,27 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import axios from 'axios';
-import { inject, provide } from 'vue';
 import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
 import type { IAccountInfoParsed } from '@shared/interfaces';
 import { getAccountInfo } from '@renderer/services/mirrorNodeDataService.ts';
 
 export class AccountByIdCache extends EntityCache<string, IAccountInfoParsed | null> {
-  private static readonly injectKey = Symbol();
-
-  //
-  // Public
-  //
-
-  public static provide(): void {
-    provide(AccountByIdCache.injectKey, new AccountByIdCache());
-  }
-
-  public static inject(): AccountByIdCache {
-    const defaultFactory = () => new AccountByIdCache();
-    return inject<AccountByIdCache>(AccountByIdCache.injectKey, defaultFactory, true);
-  }
-
   //
   // EntityCache
   //

--- a/front-end/src/renderer/caches/mirrorNode/AccountByPublicKeyCache.ts
+++ b/front-end/src/renderer/caches/mirrorNode/AccountByPublicKeyCache.ts
@@ -1,23 +1,11 @@
-import { inject, provide } from 'vue';
 import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
 import type { AccountInfo } from '@shared/interfaces';
 import { getAccountsByPublicKey } from '@renderer/services/mirrorNodeDataService.ts';
 
 export class AccountByPublicKeyCache extends EntityCache<string, AccountInfo[]> {
-  private static readonly injectKey = Symbol();
-
   //
   // Public
   //
-
-  public static provide(): void {
-    provide(AccountByPublicKeyCache.injectKey, new AccountByPublicKeyCache());
-  }
-
-  public static inject(): AccountByPublicKeyCache {
-    const defaultFactory = () => new AccountByPublicKeyCache();
-    return inject<AccountByPublicKeyCache>(AccountByPublicKeyCache.injectKey, defaultFactory, true);
-  }
 
   public async batchLookup(
     publicKeys: string[],

--- a/front-end/src/renderer/caches/mirrorNode/NodeByIdCache.ts
+++ b/front-end/src/renderer/caches/mirrorNode/NodeByIdCache.ts
@@ -1,25 +1,9 @@
 import axios from 'axios';
-import { inject, provide } from 'vue';
 import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
 import type { INodeInfoParsed } from '@shared/interfaces';
 import { getNodeInfo } from '@renderer/services/mirrorNodeDataService.ts';
 
 export class NodeByIdCache extends EntityCache<number, INodeInfoParsed | null> {
-  private static readonly injectKey = Symbol();
-
-  //
-  // Public
-  //
-
-  public static provide(): void {
-    provide(NodeByIdCache.injectKey, new NodeByIdCache());
-  }
-
-  public static inject(): NodeByIdCache {
-    const defaultFactory = () => new NodeByIdCache();
-    return inject<NodeByIdCache>(NodeByIdCache.injectKey, defaultFactory, true);
-  }
-
   //
   // EntityCache
   //

--- a/front-end/src/renderer/caches/mirrorNode/TransactionByIdCache.ts
+++ b/front-end/src/renderer/caches/mirrorNode/TransactionByIdCache.ts
@@ -1,25 +1,9 @@
-import { inject, provide } from 'vue';
 import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
 import type { TransactionByIdResponse } from '@shared/interfaces';
 import { getTransactionInfo } from '@renderer/services/mirrorNodeDataService.ts';
 import axios from 'axios';
 
 export class TransactionByIdCache extends EntityCache<string, TransactionByIdResponse | null> {
-  private static readonly injectKey = Symbol();
-
-  //
-  // Public
-  //
-
-  public static provide(): void {
-    provide(TransactionByIdCache.injectKey, new TransactionByIdCache());
-  }
-
-  public static inject(): TransactionByIdCache {
-    const defaultFactory = () => new TransactionByIdCache();
-    return inject<TransactionByIdCache>(TransactionByIdCache.injectKey, defaultFactory, true);
-  }
-
   //
   // EntityCache
   //

--- a/front-end/src/renderer/components/ComplexKey/ComplexKeyAddPublicKeyModal.vue
+++ b/front-end/src/renderer/components/ComplexKey/ComplexKeyAddPublicKeyModal.vue
@@ -12,7 +12,7 @@ import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppListItem from '@renderer/components/ui/AppListItem.vue';
 import AppModal from '@renderer/components/ui/AppModal.vue';
 import AppInput from '@renderer/components/ui/AppInput.vue';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 import { createLogger } from '@renderer/utils/logger';
 
 const logger = createLogger('renderer.component.complexKeyAddPublicKeyModal');
@@ -42,7 +42,7 @@ const user = useUserStore();
 const contacts = useContactsStore();
 
 /* Injected */
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const publicKeyOwnerCache = AppCache.inject().backendPublicKeyOwner;
 
 /* State */
 const publicKey = ref('');

--- a/front-end/src/renderer/components/Contacts/ContactDetails.vue
+++ b/front-end/src/renderer/components/Contacts/ContactDetails.vue
@@ -28,7 +28,7 @@ import AppInput from '@renderer/components/ui/AppInput.vue';
 import ContactDetailsAssociatedAccounts from '@renderer/components/Contacts/ContactDetailsAssociatedAccounts.vue';
 import ContactDetailsLinkedAccounts from '@renderer/components/Contacts/ContactDetailsLinkedAccounts.vue';
 import RenamePublicKeyModal from '@renderer/pages/Settings/components/PublicKeysTab/components/RenamePublicKeyModal.vue';
-import { AccountByPublicKeyCache } from '@renderer/caches/mirrorNode/AccountByPublicKeyCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts';
 import { formatDatePart } from '@renderer/utils/dateTimeFormat.ts';
 import { getLatestClient } from '@renderer/utils/clientVersion.ts';
@@ -50,7 +50,7 @@ const network = useNetworkStore();
 const contacts = useContactsStore();
 
 /* Injected */
-const accountByPublicKeyCache = AccountByPublicKeyCache.inject();
+const accountByPublicKeyCache = AppCache.inject().mirrorAccountByPublicKey;
 
 /* State */
 const isNicknameInputShown = ref(false);

--- a/front-end/src/renderer/components/ExternalSigning/ExportTransactionsModal.vue
+++ b/front-end/src/renderer/components/ExternalSigning/ExportTransactionsModal.vue
@@ -27,10 +27,7 @@ import { ToastManager } from '@renderer/utils/ToastManager';
 
 import { Transaction } from '@hiero-ledger/sdk';
 import { createLogger } from '@renderer/utils/logger';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 const logger = createLogger('renderer.component.exportTransactionsModal');
 
@@ -45,10 +42,11 @@ const network = useNetworkStore();
 const toastManager = ToastManager.inject();
 
 /* Injected */
-const accountInfoCache = AccountByIdCache.inject();
-const nodeInfoCache = NodeByIdCache.inject();
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
-const transactionCache = BackendTransactionCache.inject();
+const appCache = AppCache.inject();
+const accountInfoCache = appCache.mirrorAccountById;
+const nodeInfoCache = appCache.mirrorNodeById;
+const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
+const transactionCache = appCache.backendTransaction;
 
 /* State */
 const isOnlyExternalSelected = ref(false);

--- a/front-end/src/renderer/components/ExternalSigning/SignTransactionFileModal.vue
+++ b/front-end/src/renderer/components/ExternalSigning/SignTransactionFileModal.vue
@@ -10,15 +10,13 @@ import {
 } from '@shared/utils/transactionFile.ts';
 import useUserStore from '@renderer/stores/storeUser.ts';
 import useNetworkStore from '@renderer/stores/storeNetwork';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 import { SignatureMap, Transaction } from '@hiero-ledger/sdk';
 import { assertUserLoggedIn, hexToUint8Array, uint8ToHex } from '@renderer/utils';
 import { signTransaction } from '@renderer/services/transactionService.ts';
 import TransactionBrowser from '@renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowser.vue';
 import { ToastManager } from '@renderer/utils/ToastManager';
 import AppCustomIcon from '@renderer/components/ui/AppCustomIcon.vue';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
 import { createLogger } from '@renderer/utils/logger';
 
 /* Props */
@@ -37,9 +35,10 @@ const network = useNetworkStore();
 const toastManager = ToastManager.inject();
 
 /* Injected */
-const accountInfoCache = AccountByIdCache.inject();
-const nodeInfoCache = NodeByIdCache.inject();
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const appCache = AppCache.inject();
+const accountInfoCache = appCache.mirrorAccountById;
+const nodeInfoCache = appCache.mirrorNodeById;
+const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 const logger = createLogger('renderer.externalSigning.signTransactionFile');
 
 /* State */

--- a/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowser.vue
+++ b/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowser.vue
@@ -5,10 +5,8 @@ import AppLoader from '@renderer/components/ui/AppLoader.vue';
 import type { ITransactionBrowserItem } from './ITransactionBrowserItem.ts';
 import TransactionBrowserTable from './TransactionBrowserTable.vue';
 import { TransactionBrowserEntry } from '@renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserEntry.ts';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 import useUserStore from '@renderer/stores/storeUser.ts';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
 
 /* Props */
 const props = defineProps<{
@@ -16,9 +14,10 @@ const props = defineProps<{
 }>();
 
 /* Injected */
-const accountInfoCache = AccountByIdCache.inject();
-const nodeInfoCache = NodeByIdCache.inject();
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const appCache = AppCache.inject();
+const accountInfoCache = appCache.mirrorAccountById;
+const nodeInfoCache = appCache.mirrorNodeById;
+const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 
 /* Stores */
 const network = useNetworkStore();

--- a/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserKeySection.vue
+++ b/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserKeySection.vue
@@ -10,9 +10,7 @@ import {
 } from '@renderer/utils';
 import useUserStore from '@renderer/stores/storeUser';
 import useNetwork from '@renderer/stores/storeNetwork';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 import { createLogger } from '@renderer/utils/logger';
 
 const logger = createLogger('renderer.component.transactionBrowserKeySection');
@@ -27,9 +25,10 @@ const user = useUserStore();
 const network = useNetwork();
 
 /* Injected */
-const accountByIdCache = AccountByIdCache.inject();
-const nodeByIdCache = NodeByIdCache.inject();
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const appCache = AppCache.inject();
+const accountByIdCache = appCache.mirrorAccountById;
+const nodeByIdCache = appCache.mirrorNodeById;
+const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 
 /* State */
 const signatureKeyObject: Ref<SignatureAudit | null> = ref(null);

--- a/front-end/src/renderer/components/KeyField.vue
+++ b/front-end/src/renderer/components/KeyField.vue
@@ -27,7 +27,7 @@ import ComplexKeyModal from '@renderer/components/ComplexKey/ComplexKeyModal.vue
 import ComplexKeyAddPublicKeyModal from '@renderer/components/ComplexKey/ComplexKeyAddPublicKeyModal.vue';
 import ComplexKeySelectSavedKey from '@renderer/components/ComplexKey/ComplexKeySelectSavedKey.vue';
 import ComplexKeySaveKeyModal from '@renderer/components/ComplexKey/ComplexKeySaveKeyModal.vue';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache';
+import { AppCache } from '@renderer/caches/AppCache';
 
 /* Props */
 const props = withDefaults(
@@ -57,7 +57,7 @@ const user = useUserStore();
 const toastManager = ToastManager.inject();
 
 /* Injected */
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const publicKeyOwnerCache = AppCache.inject().backendPublicKeyOwner;
 
 /* State */
 const currentTab = ref(Tabs.SIGNLE);

--- a/front-end/src/renderer/components/KeyStructureModal.vue
+++ b/front-end/src/renderer/components/KeyStructureModal.vue
@@ -5,7 +5,7 @@ import { formatPublicKey } from '@renderer/utils';
 
 import AppModal from '@renderer/components/ui/AppModal.vue';
 import KeyStructure from '@renderer/components/KeyStructure.vue';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 /* Props */
 const props = defineProps<{
@@ -17,7 +17,7 @@ const props = defineProps<{
 const emit = defineEmits(['update:show']);
 
 /* Injected */
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const publicKeyOwnerCache = AppCache.inject().backendPublicKeyOwner;
 
 /* State */
 const formattedKey = ref('');

--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
@@ -50,14 +50,12 @@ import BaseDraftLoad from '@renderer/components/Transaction/Create/BaseTransacti
 import BaseGroupHandler from '@renderer/components/Transaction/Create/BaseTransaction/BaseGroupHandler.vue';
 import BaseApproversObserverData from '@renderer/components/Transaction/Create/BaseTransaction/BaseApproversObserverData.vue';
 import { getTransactionType } from '@renderer/utils/sdk/transactions';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 import useNextTransactionV2, {
   type TransactionNodeId,
 } from '@renderer/stores/storeNextTransactionV2.ts';
 import { useRoute, useRouter } from 'vue-router';
 import { addDraft, updateDraft } from '@renderer/services/transactionDraftsService';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
 
 /* Props */
 const { createTransaction, preCreateAssert, customRequest } = defineProps<{
@@ -89,9 +87,10 @@ const payerData = useAccountId();
 const withLoader = useLoader();
 
 /* Injected */
-const accountByIdCache = AccountByIdCache.inject();
-const nodeByIdCache = NodeByIdCache.inject();
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const appCache = AppCache.inject();
+const accountByIdCache = appCache.mirrorAccountById;
+const nodeByIdCache = appCache.mirrorNodeById;
+const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 
 /* State */
 const transactionProcessor = ref<InstanceType<typeof TransactionProcessor> | null>(null);

--- a/front-end/src/renderer/components/Transaction/Create/TransferHbar/TransferHbar.vue
+++ b/front-end/src/renderer/components/Transaction/Create/TransferHbar/TransferHbar.vue
@@ -8,7 +8,7 @@ import { Hbar, Transaction } from '@hiero-ledger/sdk';
 
 import useNetworkStore from '@renderer/stores/storeNetwork';
 
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 
 import { createTransferHbarTransaction, getTransferHbarData } from '@renderer/utils/sdk';
 
@@ -21,7 +21,7 @@ const network = useNetworkStore();
 const user = useUserStore();
 
 /* Injected */
-const accountByIdCache = AccountByIdCache.inject();
+const accountByIdCache = AppCache.inject().mirrorAccountById;
 
 /* State */
 const baseTransactionRef = ref<InstanceType<typeof BaseTransaction> | null>(null);

--- a/front-end/src/renderer/components/Transaction/Create/TransferHbar/TransferHbarFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/TransferHbar/TransferHbarFormData.vue
@@ -9,7 +9,7 @@ import { Hbar, Transfer } from '@hiero-ledger/sdk';
 import useUserStore from '@renderer/stores/storeUser';
 import useNetworkStore from '@renderer/stores/storeNetwork';
 
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 import { getAll } from '@renderer/services/accountsService';
 
 import { getAccountIdWithChecksum, isUserLoggedIn, stringifyHbar } from '@renderer/utils';
@@ -42,7 +42,7 @@ const user = useUserStore();
 const network = useNetworkStore();
 
 /* Injected */
-const accountByIdCache = AccountByIdCache.inject();
+const accountByIdCache = AppCache.inject().mirrorAccountById;
 
 /* State */
 const linkedAccounts = ref<HederaAccount[]>([]);

--- a/front-end/src/renderer/components/Transaction/Details/AccountDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/AccountDetails.vue
@@ -34,8 +34,7 @@ import {
 
 import KeyStructureModal from '@renderer/components/KeyStructureModal.vue';
 import AppButton from '@renderer/components/ui/AppButton.vue';
-import { TransactionByIdCache } from '@renderer/caches/mirrorNode/TransactionByIdCache.ts';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 /* Props */
 const props = defineProps<{
@@ -48,11 +47,12 @@ const user = useUserStore();
 const network = useNetworkStore();
 
 /* Composables */
-const toastManager = ToastManager.inject()
+const toastManager = ToastManager.inject();
 
 /* Injected */
-const transactionByIdCache = TransactionByIdCache.inject();
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const appCache = AppCache.inject();
+const transactionByIdCache = appCache.mirrorTransactionById;
+const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 
 /* State */
 const isKeyStructureModalShown = ref(false);

--- a/front-end/src/renderer/components/Transaction/Details/DeleteAccountDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/DeleteAccountDetails.vue
@@ -14,7 +14,7 @@ import {
   safeAwait,
   stringifyHbar,
 } from '@renderer/utils';
-import { TransactionByIdCache } from '@renderer/caches/mirrorNode/TransactionByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 
 /* Props */
 const props = defineProps<{
@@ -26,7 +26,7 @@ const props = defineProps<{
 const network = useNetworkStore();
 
 /* Injected */
-const transactionByIdCache = TransactionByIdCache.inject();
+const transactionByIdCache = AppCache.inject().mirrorTransactionById;
 
 /* State */
 const controller = ref<AbortController | null>(null);

--- a/front-end/src/renderer/components/Transaction/Details/FileDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/FileDetails.vue
@@ -26,8 +26,7 @@ import { isUserLoggedIn, getFormattedDateFromTimestamp, safeAwait } from '@rende
 
 import KeyStructureModal from '@renderer/components/KeyStructureModal.vue';
 import AppButton from '@renderer/components/ui/AppButton.vue';
-import { TransactionByIdCache } from '@renderer/caches/mirrorNode/TransactionByIdCache.ts';
-
+import { AppCache } from '@renderer/caches/AppCache';
 
 /* Props */
 const props = defineProps<{
@@ -40,10 +39,10 @@ const user = useUserStore();
 const network = useNetworkStore();
 
 /* Composables */
-const toastManager = ToastManager.inject()
+const toastManager = ToastManager.inject();
 
 /* Injected */
-const transactionByIdCache = TransactionByIdCache.inject();
+const transactionByIdCache = AppCache.inject().mirrorTransactionById;
 
 /* State */
 const isKeyStructureModalShown = ref(false);

--- a/front-end/src/renderer/components/Transaction/Details/TransferDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/TransferDetails.vue
@@ -11,7 +11,7 @@ import useNetworkStore from '@renderer/stores/storeNetwork';
 import { getAll } from '@renderer/services/accountsService';
 
 import { getAccountIdWithChecksum, isUserLoggedIn, stringifyHbar } from '@renderer/utils';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 
 /* Props */
 const props = defineProps<{
@@ -23,7 +23,7 @@ const user = useUserStore();
 const network = useNetworkStore();
 
 /* Injected */
-const accountByIdCache = AccountByIdCache.inject()
+const accountByIdCache = AppCache.inject().mirrorAccountById;
 
 /* State */
 const linkedAccounts = ref<HederaAccount[]>([]);

--- a/front-end/src/renderer/components/Transaction/TransactionProcessor/components/ValidateRequestHandler.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionProcessor/components/ValidateRequestHandler.vue
@@ -10,7 +10,7 @@ import useNetworkStore from '@renderer/stores/storeNetwork';
 import { assertUserLoggedIn, ableToSign, validateFileUpdateTransaction } from '@renderer/utils';
 import { getTransactionType } from '@renderer/utils/sdk/transactions';
 import { getMaxTransactionSizeForTransaction } from '@renderer/utils/sdk/privilegedPayer';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 /* Constants */
 const SIZE_BUFFER_BYTES = 200;
@@ -20,7 +20,7 @@ const user = useUserStore();
 const network = useNetworkStore();
 
 /* Injected */
-const accountByIdCache = AccountByIdCache.inject()
+const accountByIdCache = AppCache.inject().mirrorAccountById;
 
 /* State */
 const nextHandler = ref<Handler | null>(null);

--- a/front-end/src/renderer/components/TransactionImportModal.vue
+++ b/front-end/src/renderer/components/TransactionImportModal.vue
@@ -15,7 +15,7 @@ import {
 } from '@shared/interfaces';
 import { makeSignatureMap } from '@renderer/utils/signatureTools.ts';
 import { importSignatures } from '@renderer/services/organization';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 import useUserStore from '@renderer/stores/storeUser.ts';
 import { assertIsLoggedInOrganization } from '@renderer/utils';
 import { ErrorCodes, ErrorMessages } from '@shared/constants';
@@ -30,7 +30,7 @@ const props = defineProps<{
 
 /* Injected */
 const toastManager = ToastManager.inject();
-const transactionCache = BackendTransactionCache.inject();
+const transactionCache = AppCache.inject().backendTransaction;
 
 /* Model */
 const show = defineModel<boolean>('show', { required: true });

--- a/front-end/src/renderer/components/ui/AppPublicKeyNickname.vue
+++ b/front-end/src/renderer/components/ui/AppPublicKeyNickname.vue
@@ -2,7 +2,7 @@
 import { computed, ref, watchEffect } from 'vue';
 import { PublicKey } from '@hiero-ledger/sdk';
 import { extractIdentifier, formatPublicKey } from '@renderer/utils';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 /* Props */
 const props = defineProps<{
@@ -12,7 +12,7 @@ const props = defineProps<{
 }>();
 
 /* Injected */
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const publicKeyOwnerCache = AppCache.inject().backendPublicKeyOwner;
 
 /* State */
 const formattedPublicKey = ref('');

--- a/front-end/src/renderer/composables/useAccountId.ts
+++ b/front-end/src/renderer/composables/useAccountId.ts
@@ -10,7 +10,7 @@ import { getAccountAllowances } from '@renderer/services/mirrorNodeDataService';
 import { flattenKeyList } from '@renderer/services/keyPairService';
 
 import { stringifyHbar } from '@renderer/utils';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 
 export default function useAccountId() {
   /* Stores */
@@ -28,7 +28,7 @@ export default function useAccountId() {
   const isValid = computed(() => Boolean(accountInfo.value));
 
   /* Injected */
-  const accountByIdCache = AccountByIdCache.inject();
+  const accountByIdCache = AppCache.inject().mirrorAccountById;
 
   const accountIdFormatted = computed(() => {
     if (!isValid.value) {

--- a/front-end/src/renderer/composables/useNodeId.ts
+++ b/front-end/src/renderer/composables/useNodeId.ts
@@ -4,7 +4,7 @@ import { computed, ref, watch } from 'vue';
 
 import useNetworkStore from '@renderer/stores/storeNetwork';
 
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 
 import useAccountId from './useAccountId';
 
@@ -16,7 +16,7 @@ export default function useNodeId() {
   const accountData = useAccountId();
 
   /* Injected */
-  const nodeByIdCache = NodeByIdCache.inject();
+  const nodeByIdCache = AppCache.inject().mirrorNodeById;
 
   /* State */
   const nodeId = ref<number | null>(null);

--- a/front-end/src/renderer/composables/useTransactionAudit.ts
+++ b/front-end/src/renderer/composables/useTransactionAudit.ts
@@ -7,13 +7,10 @@ import {
   isLoggedInOrganization,
   type SignatureAudit,
 } from '@renderer/utils';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
 import type { ITransactionFull } from '@shared/interfaces';
 import useUserStore from '@renderer/stores/storeUser.ts';
 import useNetworkStore from '@renderer/stores/storeNetwork.ts';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 
 const logger = createLogger('renderer.useTransactionAudit');
 
@@ -30,10 +27,11 @@ export default function useTransactionAudit(transactionId: Ref<number | null>): 
   const network = useNetworkStore();
 
   /* Injected */
-  const accountByIdCache = AccountByIdCache.inject();
-  const nodeByIdCache = NodeByIdCache.inject();
-  const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
-  const transactionCache = BackendTransactionCache.inject();
+  const appCache = AppCache.inject();
+  const accountByIdCache = appCache.mirrorAccountById;
+  const nodeByIdCache = appCache.mirrorNodeById;
+  const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
+  const transactionCache = appCache.backendTransaction;
 
   /* Computed */
   const transaction = computed(async () => {

--- a/front-end/src/renderer/pages/Accounts/Accounts.vue
+++ b/front-end/src/renderer/pages/Accounts/Accounts.vue
@@ -33,19 +33,19 @@ import AppModal from '@renderer/components/ui/AppModal.vue';
 import KeyStructureModal from '@renderer/components/KeyStructureModal.vue';
 import AppInput from '@renderer/components/ui/AppInput.vue';
 import AppCheckBox from '@renderer/components/ui/AppCheckBox.vue';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 /* Stores */
 const user = useUserStore();
 const network = useNetworkStore();
 
 /* Composables */
-const toastManager = ToastManager.inject()
+const toastManager = ToastManager.inject();
 const accountData = useAccountId();
 useSetDynamicLayout(LOGGED_IN_LAYOUT);
 
 /* Injected */
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const publicKeyOwnerCache = AppCache.inject().backendPublicKeyOwner;
 
 /* State */
 const accounts = ref<HederaAccount[]>([]);

--- a/front-end/src/renderer/pages/CreateTransactionGroup/ImportCSVController.vue
+++ b/front-end/src/renderer/pages/CreateTransactionGroup/ImportCSVController.vue
@@ -5,7 +5,7 @@ import { ToastManager } from '@renderer/utils/ToastManager.ts';
 import { createLogger, createTransactionId } from '@renderer/utils';
 import useTransactionGroupStore from '@renderer/stores/storeTransactionGroup.ts';
 import { Hbar, HbarUnit, KeyList, TransferTransaction } from '@hiero-ledger/sdk';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 import useNetworkStore from '@renderer/stores/storeNetwork.ts';
 import useAccountId from '@renderer/composables/useAccountId.ts';
 import type { ActionReport } from '@renderer/components/ActionController/ActionReport.ts';
@@ -26,7 +26,7 @@ const payerData = useAccountId();
 
 /* Injected */
 const toastManager = ToastManager.inject();
-const accountByIdCache = AccountByIdCache.inject();
+const accountByIdCache = AppCache.inject().mirrorAccountById;
 
 /* Stores */
 const transactionGroup = useTransactionGroupStore();

--- a/front-end/src/renderer/pages/Settings/components/PublicKeysTab/PublicKeysTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/PublicKeysTab/PublicKeysTab.vue
@@ -5,7 +5,7 @@ import { computed, onBeforeMount, ref, watch } from 'vue';
 import useUserStore from '@renderer/stores/storeUser';
 
 import { ToastManager } from '@renderer/utils/ToastManager';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppCheckBox from '@renderer/components/ui/AppCheckBox.vue';
@@ -19,7 +19,7 @@ const user = useUserStore();
 const toastManager = ToastManager.inject();
 
 /* Injected */
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const publicKeyOwnerCache = AppCache.inject().backendPublicKeyOwner;
 
 /* State */
 const isDeleteModalShown = ref(false);

--- a/front-end/src/renderer/pages/TransactionDetails/ApproveTransactionController.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/ApproveTransactionController.vue
@@ -17,7 +17,7 @@ import {
   type ActionReport,
   makeBugReport,
 } from '@renderer/components/ActionController/ActionReport';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 
 /* Props */
 const props = defineProps<{
@@ -32,7 +32,7 @@ const activate = defineModel<boolean>('activate', { required: true });
 const user = useUserStore();
 
 /* Injected */
-const transactionCache = BackendTransactionCache.inject();
+const transactionCache = AppCache.inject().backendTransaction;
 const toastManager = ToastManager.inject();
 
 /* Computed */

--- a/front-end/src/renderer/pages/TransactionDetails/ArchiveTransactionController.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/ArchiveTransactionController.vue
@@ -11,7 +11,7 @@ import {
   ActionStatus,
   makeBugReport,
 } from '@renderer/components/ActionController/ActionReport';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 /* Props */
 const props = defineProps<{
@@ -21,7 +21,7 @@ const props = defineProps<{
 const activate = defineModel<boolean>('activate', { required: true });
 
 /* Injected */
-const transactionCache = BackendTransactionCache.inject();
+const transactionCache = AppCache.inject().backendTransaction;
 const toastManager = ToastManager.inject();
 
 /* Stores */

--- a/front-end/src/renderer/pages/TransactionDetails/CancelTransactionController.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/CancelTransactionController.vue
@@ -10,7 +10,7 @@ import {
   type ActionReport,
   makeBugReport,
 } from '@renderer/components/ActionController/ActionReport';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 /* Props */
 const props = defineProps<{
@@ -20,7 +20,7 @@ const props = defineProps<{
 const activate = defineModel<boolean>('activate', { required: true });
 
 /* Injected */
-const transactionCache = BackendTransactionCache.inject();
+const transactionCache = AppCache.inject().backendTransaction;
 const toastManager = ToastManager.inject();
 
 /* Stores */

--- a/front-end/src/renderer/pages/TransactionDetails/ScheduleTransactionController.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/ScheduleTransactionController.vue
@@ -10,7 +10,7 @@ import {
   type ActionReport,
   makeBugReport,
 } from '@renderer/components/ActionController/ActionReport';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 /* Props */
 const props = defineProps<{
@@ -20,7 +20,7 @@ const props = defineProps<{
 const activate = defineModel<boolean>('activate', { required: true });
 
 /* Injected */
-const transactionCache = BackendTransactionCache.inject();
+const transactionCache = AppCache.inject().backendTransaction;
 const toastManager = ToastManager.inject();
 
 /* Stores */

--- a/front-end/src/renderer/pages/TransactionDetails/SignTransactionController.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/SignTransactionController.vue
@@ -11,15 +11,12 @@ import {
 import { ToastManager } from '@renderer/utils/ToastManager.ts';
 import { type ITransactionFull } from '@shared/interfaces';
 import ActionController from '@renderer/components/ActionController/ActionController.vue';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 import {
   type ActionReport,
   ActionStatus,
   makeBugReport,
 } from '@renderer/components/ActionController/ActionReport.ts';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
 
 /* Props */
 const props = defineProps<{
@@ -32,10 +29,11 @@ const activate = defineModel<boolean>('activate', { required: true });
 const user = useUserStore();
 
 /* Injected */
-const transactionCache = BackendTransactionCache.inject();
-const accountByIdCache = AccountByIdCache.inject();
-const nodeByIdCache = NodeByIdCache.inject();
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const appCache = AppCache.inject();
+const transactionCache = appCache.backendTransaction;
+const accountByIdCache = appCache.mirrorAccountById;
+const nodeByIdCache = appCache.mirrorNodeById;
+const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 const toastManager = ToastManager.inject();
 
 /* Computed */

--- a/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
@@ -48,15 +48,12 @@ import txTypeComponentMapping from '@renderer/components/Transaction/Details/txT
 import TransactionDetailsHeader from './components/TransactionDetailsHeader.vue';
 import TransactionDetailsStatusStepper from './components/TransactionDetailsStatusStepper.vue';
 import { getGroup } from '@renderer/services/transactionGroupsService';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
 import TransactionId from '@renderer/components/ui/TransactionId.vue';
 import ExpiringBadge from '@renderer/pages/TransactionDetails/components/ExpiringBadge.vue';
 import useNotificationsStore from '@renderer/stores/storeNotifications.ts';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
 import { ToastManager } from '@renderer/utils/ToastManager.ts';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
 
 /* Injectables */
 const toastManager = ToastManager.inject();
@@ -90,10 +87,11 @@ useSetDynamicLayout(LOGGED_IN_LAYOUT);
 const route = useRoute();
 
 /* Injected */
-const accountByIdCache = AccountByIdCache.inject();
-const nodeByIdCache = NodeByIdCache.inject();
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
-const transactionCache = BackendTransactionCache.inject();
+const appCache = AppCache.inject();
+const accountByIdCache = appCache.mirrorAccountById;
+const nodeByIdCache = appCache.mirrorNodeById;
+const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
+const transactionCache = appCache.backendTransaction;
 
 /* State */
 const orgTransaction = ref<ITransactionFull | null>(null);

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -30,11 +30,9 @@ import AppDropDown from '@renderer/components/ui/AppDropDown.vue';
 import NextTransactionCursor from '@renderer/components/NextTransactionCursor.vue';
 import SplitSignButtonDropdown from '@renderer/components/SplitSignButtonDropdown.vue';
 
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 import { getTransactionType } from '@renderer/utils/sdk/transactions.ts';
 import BreadCrumb from '@renderer/components/BreadCrumb.vue';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
 import {
   isApprovableStatus,
   isInProgressStatus,
@@ -101,9 +99,10 @@ const nextTransaction = useNextTransactionV2();
 const router = useRouter();
 
 /* Injected */
-const accountByIdCache = AccountByIdCache.inject();
-const nodeByIdCache = NodeByIdCache.inject();
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const appCache = AppCache.inject();
+const accountByIdCache = appCache.mirrorAccountById;
+const nodeByIdCache = appCache.mirrorNodeById;
+const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 const toastManager = ToastManager.inject();
 
 /* State */

--- a/front-end/src/renderer/pages/TransactionGroupDetails/ExportAllController.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/ExportAllController.vue
@@ -20,7 +20,7 @@ import { decryptPrivateKey } from '@renderer/services/keyPairService.ts';
 import { saveFileToPath, showSaveDialog } from '@renderer/services/electronUtilsService.ts';
 import JSZip from 'jszip';
 import type { ActionReport } from '@renderer/components/ActionController/ActionReport';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 /* Props */
 const props = defineProps<{
@@ -31,7 +31,7 @@ const activate = defineModel<boolean>('activate', { required: true });
 
 /* Injected */
 const toastManager = ToastManager.inject();
-const transactionCache = BackendTransactionCache.inject();
+const transactionCache = AppCache.inject().backendTransaction;
 
 /* Stores */
 const user = useUserStore();

--- a/front-end/src/renderer/pages/TransactionGroupDetails/SignAllController.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/SignAllController.vue
@@ -7,9 +7,7 @@ import {
   collectRequiredKeys,
   signItems,
 } from '@renderer/utils';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 import { ToastManager } from '@renderer/utils/ToastManager.ts';
 import { TransactionStatus } from '@shared/interfaces';
 import { getTransactionGroupById, type IGroup } from '@renderer/services/organization';
@@ -28,9 +26,10 @@ const props = defineProps<{
 const activate = defineModel<boolean>('activate', { required: true });
 
 /* Injected */
-const accountByIdCache = AccountByIdCache.inject();
-const nodeByIdCache = NodeByIdCache.inject();
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const appCache = AppCache.inject();
+const accountByIdCache = appCache.mirrorAccountById;
+const nodeByIdCache = appCache.mirrorNodeById;
+const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 const toastManager = ToastManager.inject();
 
 /* Stores */

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -36,22 +36,19 @@ import {
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppLoader from '@renderer/components/ui/AppLoader.vue';
 import EmptyTransactions from '@renderer/components/EmptyTransactions.vue';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 import useContactsStore from '@renderer/stores/storeContacts.ts';
 import AppDropDown from '@renderer/components/ui/AppDropDown.vue';
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
 import { getTransactionTypeFromBackendType } from '@renderer/utils/sdk/transactions.ts';
 import NextTransactionCursor from '@renderer/components/NextTransactionCursor.vue';
 import BreadCrumb from '@renderer/components/BreadCrumb.vue';
 import useNotificationsStore from '@renderer/stores/storeNotifications.ts';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
 import { isInProgressStatus } from '@renderer/utils/transactionStatusGuards.ts';
 import TransactionGroupRow from '@renderer/pages/TransactionGroupDetails/TransactionGroupRow.vue';
 import SignAllController from '@renderer/pages/TransactionGroupDetails/SignAllController.vue';
 import CancelAllController from '@renderer/pages/TransactionGroupDetails/CancelAllController.vue';
 import ExportAllController from '@renderer/pages/TransactionGroupDetails/ExportAllController.vue';
 import ApproveAllController from '@renderer/pages/TransactionGroupDetails/ApproveAllController.vue';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache';
 
 /* Types */
 type ActionButton = 'Reject All' | 'Approve All' | 'Sign All' | 'Cancel All' | 'Export All';
@@ -73,9 +70,6 @@ const buttonsDataTestIds: { [key: string]: string } = {
   [cancel]: 'button-cancel-group',
   [exportName]: 'button-export-group',
 };
-
-/* Injected */
-const transactionCache = BackendTransactionCache.inject();
 
 /* Stores */
 const user = useUserStore();
@@ -111,9 +105,11 @@ useSetDynamicLayout(LOGGED_IN_LAYOUT);
 const createTooltips = useCreateTooltips();
 
 /* Injected */
-const accountByIdCache = AccountByIdCache.inject();
-const nodeByIdCache = NodeByIdCache.inject();
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const appCache = AppCache.inject();
+const accountByIdCache = appCache.mirrorAccountById;
+const nodeByIdCache = appCache.mirrorNodeById;
+const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
+const transactionCache = appCache.backendTransaction;
 const toastManager = ToastManager.inject();
 
 /* State */

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupRow.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupRow.vue
@@ -13,9 +13,7 @@ import {
 } from '@renderer/utils';
 import useUserStore from '@renderer/stores/storeUser.ts';
 import useNetwork from '@renderer/stores/storeNetwork.ts';
-import { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
-import { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 import useRevealed from '@renderer/composables/useRevealed.ts';
 import SignSingleButton from '@renderer/pages/Transactions/components/SignSingleButton.vue';
 
@@ -32,9 +30,10 @@ const emit = defineEmits<{
 }>();
 
 /* Injected */
-const accountByIdCache = AccountByIdCache.inject();
-const nodeByIdCache = NodeByIdCache.inject();
-const publicKeyOwnerCache = PublicKeyOwnerCache.inject();
+const appCache = AppCache.inject();
+const accountByIdCache = appCache.mirrorAccountById;
+const nodeByIdCache = appCache.mirrorNodeById;
+const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 
 /* Stores */
 const user = useUserStore();

--- a/front-end/src/renderer/pages/Transactions/Transactions.vue
+++ b/front-end/src/renderer/pages/Transactions/Transactions.vue
@@ -52,7 +52,7 @@ import { readTransactionFile } from '@renderer/services/transactionFileService.t
 import { SignatureMap, Transaction } from '@hiero-ledger/sdk';
 import { importSignatures } from '@renderer/services/organization';
 import TransactionImportModal from '@renderer/components/TransactionImportModal.vue';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 const IMPORT_FORMATS = [
   { name: 'All Tx Tool files', extensions: ['tx2', 'zip'] },
@@ -62,7 +62,7 @@ const IMPORT_FORMATS = [
 
 /* Injected */
 const toastManager = ToastManager.inject();
-const transactionCache = BackendTransactionCache.inject();
+const transactionCache = AppCache.inject().backendTransaction;
 
 /* Stores */
 const user = useUserStore();

--- a/front-end/src/renderer/pages/Transactions/components/History.vue
+++ b/front-end/src/renderer/pages/Transactions/components/History.vue
@@ -44,6 +44,8 @@ import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
 import TransactionId from '@renderer/components/ui/TransactionId.vue';
 import { useRouter } from 'vue-router';
 import useTableQueryState from '@renderer/composables/useTableQueryState.ts';
+import { TransactionNodeCollection } from '../../../../../../shared/src/ITransactionNode.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 const HISTORY_SORT_URL_VALUES = [
   'created_at',
@@ -62,11 +64,9 @@ const LOCAL_TO_ORG_SORT: Record<string, keyof ITransaction> = {
   status_code: 'statusCode',
   executed_at: 'executedAt',
 };
-import { TransactionNodeCollection } from '../../../../../../shared/src/ITransactionNode.ts';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
 
 /* Injected */
-const transactionCache = BackendTransactionCache.inject();
+const transactionCache = AppCache.inject().backendTransaction;
 
 /* Stores */
 const user = useUserStore();

--- a/front-end/src/renderer/pages/Transactions/components/SignSingleButton.vue
+++ b/front-end/src/renderer/pages/Transactions/components/SignSingleButton.vue
@@ -2,7 +2,7 @@
 import { ref } from 'vue';
 import useUserStore from '@renderer/stores/storeUser.ts';
 import { assertIsLoggedInOrganization } from '@renderer/utils';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import SignTransactionController from '@renderer/pages/TransactionDetails/SignTransactionController.vue';
 import type { ITransactionFull } from '@shared/interfaces';
@@ -19,7 +19,7 @@ const emit = defineEmits<{
 }>();
 
 /* Injected */
-const transactionCache = BackendTransactionCache.inject();
+const transactionCache = AppCache.inject().backendTransaction;
 
 /* Stores */
 const user = useUserStore();

--- a/front-end/src/renderer/pages/Transactions/components/TransactionNodeTable.vue
+++ b/front-end/src/renderer/pages/Transactions/components/TransactionNodeTable.vue
@@ -33,7 +33,7 @@ import { parseTransactionActionPayload } from '@renderer/utils/parseTransactionA
 import { useTransactionLiveHighlight } from '@renderer/composables/useTransactionLiveHighlight';
 import { useRouter } from 'vue-router';
 import useTableQueryState from '@renderer/composables/useTableQueryState.ts';
-import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 
 const NOTIFICATION_TYPES_BY_COLLECTION: Record<TransactionNodeCollection, NotificationType[]> = {
   [TransactionNodeCollection.READY_FOR_REVIEW]: [],
@@ -63,7 +63,7 @@ const emit = defineEmits<{
 }>();
 
 /* Injected */
-const transactionCache = BackendTransactionCache.inject();
+const transactionCache = AppCache.inject().backendTransaction;
 
 /* Stores */
 const user = useUserStore();

--- a/front-end/src/renderer/stores/storeUser.ts
+++ b/front-end/src/renderer/stores/storeUser.ts
@@ -27,7 +27,7 @@ import { getVersionStatusForOrg } from './versionState';
 
 import useNetworkStore from './storeNetwork';
 import useOrganizationConnection from './storeOrganizationConnection';
-import { AccountByPublicKeyCache } from '@renderer/caches/mirrorNode/AccountByPublicKeyCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 import { reconnectOrganization } from '@renderer/services/organization';
 
 const useUserStore = defineStore('user', () => {
@@ -40,7 +40,7 @@ const useUserStore = defineStore('user', () => {
   const { reset: resetVersionCheck } = useVersionCheck();
 
   /* Injected */
-  const accountByKeyCache = AccountByPublicKeyCache.inject();
+  const accountByKeyCache = AppCache.inject().mirrorAccountByPublicKey;
 
   /* State */
   /** Keys */

--- a/front-end/src/tests/renderer/pages/TransactionDetails/TransactionDetailsHeader.spec.ts
+++ b/front-end/src/tests/renderer/pages/TransactionDetails/TransactionDetailsHeader.spec.ts
@@ -133,22 +133,8 @@ vi.mock('@renderer/utils', () => ({
   usersPublicRequiredToSign: vi.fn(),
 }));
 
-vi.mock('@renderer/caches/mirrorNode/AccountByIdCache.ts', () => ({
-  AccountByIdCache: {
-    inject: vi.fn(() => ({})),
-  },
-}));
-
-vi.mock('@renderer/caches/mirrorNode/NodeByIdCache.ts', () => ({
-  NodeByIdCache: {
-    inject: vi.fn(() => ({})),
-  },
-}));
-
-vi.mock('@renderer/caches/backend/PublicKeyOwnerCache.ts', () => ({
-  PublicKeyOwnerCache: {
-    inject: vi.fn(() => ({})),
-  },
+vi.mock('@renderer/utils/sdk/getData.ts', () => ({
+  default: {},
 }));
 
 const AppButtonStub = defineComponent({

--- a/front-end/src/tests/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.spec.ts
+++ b/front-end/src/tests/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.spec.ts
@@ -202,24 +202,6 @@ vi.mock('@hiero-ledger/sdk', async importOriginal => {
   };
 });
 
-vi.mock('@renderer/caches/mirrorNode/AccountByIdCache.ts', () => ({
-  AccountByIdCache: {
-    inject: vi.fn(() => ({})),
-  },
-}));
-
-vi.mock('@renderer/caches/mirrorNode/NodeByIdCache.ts', () => ({
-  NodeByIdCache: {
-    inject: vi.fn(() => ({})),
-  },
-}));
-
-vi.mock('@renderer/caches/backend/PublicKeyOwnerCache.ts', () => ({
-  PublicKeyOwnerCache: {
-    inject: vi.fn(() => ({})),
-  },
-}));
-
 const AppButtonStub = defineComponent({
   name: 'AppButton',
   props: {


### PR DESCRIPTION
**Description**:

Changes below:
- introduce new cache object `AppCache` which groups references to all other caches
- replace injections of individual caches by `AppCache` injection
- encapsulate `TransactionBaseModel.computeSignatureKey(`) in `AppCache.computeSignatureKey()`
- App view now makes sure to clear BackendTransactionCache when user identity changes

**Related issue(s)**:

Contributes to #2521

**Notes for reviewer**:

```
A   front-end/src/renderer/caches/AppCache.ts
    # Adds AppCache injectable which holds references on all other caches.
    # AppCache.computeSignatureKey() wraps TransactionBaseModel.computeSignatureKey()
    # and offers a simplified method signature.

M   front-end/src/renderer/App.vue
M   front-end/src/renderer/caches/base/EntityCache.ts
    # App view now clears BackendTransaction cache when user identity changes.

M   front-end/src/renderer/caches/backend/BackendTransactionCache.ts
M   front-end/src/renderer/caches/backend/PublicKeyOwnerCache.ts
M   front-end/src/renderer/caches/mirrorNode/AccountByIdCache.ts
M   front-end/src/renderer/caches/mirrorNode/AccountByPublicKeyCache.ts
M   front-end/src/renderer/caches/mirrorNode/NodeByIdCache.ts
M   front-end/src/renderer/caches/mirrorNode/TransactionByIdCache.ts
    # Cache instances are no longer injected but referenced in AppCache.

M   front-end/src/renderer/components/KeyField.vue
M   front-end/src/renderer/components/KeyStructureModal.vue
M   front-end/src/renderer/components/TransactionImportModal.vue
M   front-end/src/renderer/components/ComplexKey/ComplexKeyAddPublicKeyModal.vue
M   front-end/src/renderer/components/Contacts/ContactDetails.vue
M   front-end/src/renderer/components/ExternalSigning/ExportTransactionsModal.vue
M   front-end/src/renderer/components/ExternalSigning/SignTransactionFileModal.vue
M   front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowser.vue
M   front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserKeySection.vue
M   front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
M   front-end/src/renderer/components/Transaction/Create/TransferHbar/TransferHbar.vue
M   front-end/src/renderer/components/Transaction/Create/TransferHbar/TransferHbarFormData.vue
M   front-end/src/renderer/components/Transaction/Details/AccountDetails.vue
M   front-end/src/renderer/components/Transaction/Details/DeleteAccountDetails.vue
M   front-end/src/renderer/components/Transaction/Details/FileDetails.vue
M   front-end/src/renderer/components/Transaction/Details/TransferDetails.vue
M   front-end/src/renderer/components/Transaction/TransactionProcessor/components/ValidateRequestHandler.vue
M   front-end/src/renderer/components/ui/AppPublicKeyNickname.vue
M   front-end/src/renderer/composables/useAccountId.ts
M   front-end/src/renderer/composables/useNodeId.ts
M   front-end/src/renderer/composables/useTransactionAudit.ts
M   front-end/src/renderer/pages/Accounts/Accounts.vue
M   front-end/src/renderer/pages/CreateTransactionGroup/ImportCSVController.vue
M   front-end/src/renderer/pages/Settings/components/PublicKeysTab/PublicKeysTab.vue
M   front-end/src/renderer/pages/TransactionDetails/ApproveTransactionController.vue
M   front-end/src/renderer/pages/TransactionDetails/ArchiveTransactionController.vue
M   front-end/src/renderer/pages/TransactionDetails/CancelTransactionController.vue
M   front-end/src/renderer/pages/TransactionDetails/ScheduleTransactionController.vue
M   front-end/src/renderer/pages/TransactionDetails/SignTransactionController.vue
M   front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
M   front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
M   front-end/src/renderer/pages/TransactionGroupDetails/ExportAllController.vue
M   front-end/src/renderer/pages/TransactionGroupDetails/SignAllController.vue
M   front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
M   front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupRow.vue
M   front-end/src/renderer/pages/Transactions/Transactions.vue
M   front-end/src/renderer/pages/Transactions/components/History.vue
M   front-end/src/renderer/pages/Transactions/components/SignSingleButton.vue
M   front-end/src/renderer/pages/Transactions/components/TransactionNodeTable.vue
M   front-end/src/renderer/stores/storeUser.ts
    # Views now inject and use AppCache in place of individual caches


M   front-end/src/tests/renderer/pages/TransactionDetails/TransactionDetailsHeader.spec.ts
M   front-end/src/tests/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.spec.ts
    # Adapted unit tests to AppCache
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
