### PR TITLE
fix: hide file hash row when hash is empty

### DIFF
--- a/front-end/src/renderer/components/Transaction/Details/FreezeDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/FreezeDetails.vue
@@ -59,7 +59,7 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
     </div>
 
     <!-- File Hash -->
-    <div v-if="transaction.fileHash" class="col-12 py-3">
+    <div v-if="transaction.fileHash && transaction.fileHash.length > 0" class="col-12 py-3">
       <h4 :class="detailItemLabelClass">File Hash</h4>
       <p :class="detailItemValueClass">
         {{ fileHashHex.startsWith('0x') ? fileHashHex : `0x${fileHashHex}` }}

--- a/front-end/src/tests/renderer/components/Transaction/Details/FreezeDetails.spec.ts
+++ b/front-end/src/tests/renderer/components/Transaction/Details/FreezeDetails.spec.ts
@@ -1,0 +1,118 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import {
+  AccountId,
+  FileId,
+  FreezeTransaction,
+  FreezeType,
+  Timestamp,
+  Transaction,
+  TransactionId,
+} from '@hiero-ledger/sdk';
+
+import FreezeDetails from '@renderer/components/Transaction/Details/FreezeDetails.vue';
+
+/**
+ * Regression tests for issue #2586:
+ *   FreezeAbort transaction incorrectly displays `file hash` as `0x`.
+ *
+ * Reproduction context: in production the details view receives a transaction
+ * that was reconstructed from bytes (`Transaction.fromBytes`). After that
+ * round-trip, the SDK's `FreezeTransaction.fileHash` getter returns an empty
+ * `Buffer` (a `Uint8Array` subclass) — the protobuf default for `bytes` —
+ * rather than null. An empty `Uint8Array` is truthy in JS, so the previous
+ * `v-if="transaction.fileHash"` guard rendered the row anyway and `uint8ToHex`
+ * produced `""`, which the template prefixed with `0x`.
+ *
+ * The fix changed the guard to `transaction.fileHash.length > 0`, which is
+ * what these tests exercise.
+ */
+describe('FreezeDetails.vue', () => {
+  /**
+   * Build a frozen FreezeTransaction and round-trip it through bytes, so the
+   * resulting object matches what the details view actually receives.
+   */
+  const roundTrip = (configure: (tx: FreezeTransaction) => FreezeTransaction) => {
+    const base = new FreezeTransaction()
+      .setNodeAccountIds([new AccountId(3)])
+      .setTransactionId(
+        TransactionId.withValidStart(new AccountId(2), Timestamp.fromDate(new Date())),
+      );
+    const frozen = configure(base).freeze();
+    const parsed = Transaction.fromBytes(frozen.toBytes());
+    if (!(parsed instanceof FreezeTransaction)) {
+      throw new Error('round-trip did not produce a FreezeTransaction');
+    }
+    return parsed;
+  };
+
+  const mountWith = (transaction: Transaction) =>
+    mount(FreezeDetails, {
+      props: { transaction },
+      global: {
+        // Stub `DateTimeString` so we don't need to wire up its dependencies.
+        stubs: { DateTimeString: true },
+      },
+    });
+
+  const findFileHashRow = (wrapper: ReturnType<typeof mountWith>) =>
+    wrapper
+      .findAll('h4')
+      .find(h => h.text() === 'File Hash')
+      ?.element.parentElement ?? null;
+
+  it('does NOT render the File Hash row for a FreezeAbort transaction', () => {
+    const tx = roundTrip(t => t.setFreezeType(FreezeType.FreezeAbort));
+
+    // Pre-conditions: this is the exact bug shape — fileHash is a Uint8Array
+    // (Buffer) of length 0, NOT null/undefined.
+    expect(tx.fileHash).toBeInstanceOf(Uint8Array);
+    expect(tx.fileHash?.length).toBe(0);
+
+    const wrapper = mountWith(tx);
+
+    expect(findFileHashRow(wrapper)).toBeNull();
+    expect(wrapper.text()).not.toContain('File Hash');
+    // The bug symptom: a stray "0x" with nothing after it.
+    expect(wrapper.text()).not.toMatch(/0x(?!\w)/);
+  });
+
+  it('does NOT render the File Hash row for FreezeOnly (no hash set)', () => {
+    const tx = roundTrip(t =>
+      t
+        .setFreezeType(FreezeType.FreezeOnly)
+        .setStartTimestamp(Timestamp.fromDate(new Date('2026-01-01T00:00:00Z'))),
+    );
+
+    expect(tx.fileHash?.length ?? 0).toBe(0);
+
+    const wrapper = mountWith(tx);
+
+    expect(findFileHashRow(wrapper)).toBeNull();
+    expect(wrapper.text()).not.toContain('File Hash');
+  });
+
+  it('renders the File Hash row for PrepareUpgrade when a hash is set', () => {
+    // Arbitrary 4-byte hash -> hex "deadbeef".
+    const hashBytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+
+    const tx = roundTrip(t =>
+      t
+        .setFreezeType(FreezeType.PrepareUpgrade)
+        .setFileId(FileId.fromString('0.0.150'))
+        .setFileHash(hashBytes),
+    );
+
+    expect(tx.fileHash?.length).toBe(hashBytes.length);
+
+    const wrapper = mountWith(tx);
+
+    const row = findFileHashRow(wrapper);
+    expect(row).not.toBeNull();
+    expect(row?.textContent).toContain('File Hash');
+    // The template prefixes the hex with `0x` if not already present.
+    expect(row?.textContent).toContain('0xdeadbeef');
+  });
+});


### PR DESCRIPTION
Fixes: [#2586](https://github.com/hashgraph/hedera-transaction-tool/issues/2586)

**Description**:
When viewing FreezeAbort transaction details, the UI currently shows a file hash field with the value 0x. This field should not be displayed, as FreezeAbort transactions do not include or use a file hash.

**Cause**
In `front-end/src/renderer/components/Transaction/Details/FreezeDetails.vue`, the template guards the File Hash row with:

> <div v-if="transaction.fileHash" class="col-12 py-3">

The Hedera SDK's `FreezeTransaction.fileHash` getter returns a Uint8Array — never null or undefined. For freeze types that don't set a hash (including FreezeAbort), it returns an empty Uint8Array(0), because that's the protobuf default for a bytes field.

In JavaScript, an empty Uint8Array is truthy (it's an object, not null), so:

- `v-if="transaction.fileHash" `passes → the row renders.
- onBeforeMount runs uint8ToHex(transaction.fileHash), which iterates zero bytes and returns `""`.
- The template renders `0x${fileHashHex}` → `0x${""}` → `0x`.
The transaction creation logic in `createTransactions.ts` correctly skips setFileHash for FreezeAbort, so the bug is purely on the display side.

**Fix**
Change the guard to also check the array's length, so an empty Uint8Array is treated as "no hash set":

> <div v-if="transaction.fileHash && transaction.fileHash.length > 0" class="col-12 py-3">

This hides the File Hash row for FreezeAbort (and any other freeze type that doesn't populate a hash), while still rendering it correctly for PrepareUpgrade and FreezeUpgrade where a real hash is present.