### PR TITLE
chore: group caches in AppCache - step 2

### DIFF
--- a/front-end/src/renderer/components/ExternalSigning/ExportTransactionsModal.vue
+++ b/front-end/src/renderer/components/ExternalSigning/ExportTransactionsModal.vue
@@ -9,7 +9,6 @@ import useUserStore from '@renderer/stores/storeUser.ts';
 import useNetworkStore from '@renderer/stores/storeNetwork';
 import {
   assertIsLoggedInOrganization,
-  computeSignatureKey,
   generateTransactionExportFileName,
   generateTransactionV2ExportContent,
   hexToUint8Array,
@@ -43,10 +42,6 @@ const toastManager = ToastManager.inject();
 
 /* Injected */
 const appCache = AppCache.inject();
-const accountInfoCache = appCache.mirrorAccountById;
-const nodeInfoCache = appCache.mirrorNodeById;
-const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
-const transactionCache = appCache.backendTransaction;
 
 /* State */
 const isOnlyExternalSelected = ref(false);
@@ -61,7 +56,7 @@ async function handleExport() {
   let collectionTransactions: ITransaction[] = await flattenNodeCollection(
     collectionNodes,
     user.selectedOrganization.serverUrl,
-    transactionCache,
+    appCache.backendTransaction,
   );
   logger.debug('Flattened transactions', { count: collectionTransactions.length });
 
@@ -71,13 +66,10 @@ async function handleExport() {
       for (const tx of collectionTransactions) {
         const sdkTransaction = Transaction.fromBytes(hexToUint8Array(tx.transactionBytes));
         const mirrorNodeLink = network.getMirrorNodeREST(network.network);
-        const audit = await computeSignatureKey(
+        const audit = await appCache.computeSignatureKey(
           sdkTransaction,
-          mirrorNodeLink,
-          accountInfoCache,
-          nodeInfoCache,
-          publicKeyOwnerCache,
           user.selectedOrganization,
+          mirrorNodeLink,
         );
         if (audit.externalKeys.size > 0) {
           filteredTransactions.push(tx);

--- a/front-end/src/renderer/components/ExternalSigning/SignTransactionFileModal.vue
+++ b/front-end/src/renderer/components/ExternalSigning/SignTransactionFileModal.vue
@@ -36,9 +36,6 @@ const toastManager = ToastManager.inject();
 
 /* Injected */
 const appCache = AppCache.inject();
-const accountInfoCache = appCache.mirrorAccountById;
-const nodeInfoCache = appCache.mirrorNodeById;
-const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 const logger = createLogger('renderer.externalSigning.signTransactionFile');
 
 /* State */
@@ -70,9 +67,7 @@ async function handleSignAll() {
           sdkTransaction,
           user.publicKeys,
           network.getMirrorNodeREST(transactionFile.value!.network),
-          accountInfoCache,
-          nodeInfoCache,
-          publicKeyOwnerCache,
+          appCache,
         );
 
         const sigMapBefore = SignatureMap._fromTransaction(sdkTransaction);
@@ -128,9 +123,7 @@ watch(
           transactionFile.value.items,
           user.publicKeys,
           network.getMirrorNodeREST(transactionFile.value.network),
-          accountInfoCache,
-          nodeInfoCache,
-          publicKeyOwnerCache,
+          appCache,
         );
 
         itemsToBeSigned.value = status.needSigning;

--- a/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowser.vue
+++ b/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowser.vue
@@ -15,9 +15,6 @@ const props = defineProps<{
 
 /* Injected */
 const appCache = AppCache.inject();
-const accountInfoCache = appCache.mirrorAccountById;
-const nodeInfoCache = appCache.mirrorNodeById;
-const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 
 /* Stores */
 const network = useNetworkStore();
@@ -34,9 +31,7 @@ const updateEntries = async () => {
     entries.value = await TransactionBrowserEntry.makeFromArray(
       props.items,
       mirrorNodeLink,
-      accountInfoCache,
-      nodeInfoCache,
-      publicKeyOwnerCache,
+      appCache,
       user.publicKeys,
     );
   } catch {

--- a/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserEntry.ts
+++ b/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserEntry.ts
@@ -1,13 +1,11 @@
 import { Transaction as SDKTransaction } from '@hiero-ledger/sdk';
 import type { ITransactionBrowserItem } from './ITransactionBrowserItem';
-import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import type { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
-import { computeSignatureKey, hexToUint8Array, type SignatureAudit } from '@renderer/utils';
+import type { AppCache } from '@renderer/caches/AppCache';
+import { hexToUint8Array, type SignatureAudit } from '@renderer/utils';
 import {
   filterAuditByUser,
   filterTransactionSignersByUser,
 } from '@shared/utils/transactionFile.ts';
-import type { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
 
 export class TransactionBrowserEntry {
   public readonly fullySignedByUser: boolean;
@@ -39,23 +37,14 @@ export class TransactionBrowserEntry {
   public static async make(
     item: ITransactionBrowserItem,
     mirrorNetwork: string,
-    accountInfoCache: AccountByIdCache,
-    nodeInfoCache: NodeByIdCache,
-    publicKeyOwnerCache: PublicKeyOwnerCache,
+    appCache: AppCache,
     userKeys: string[],
   ): Promise<TransactionBrowserEntry> {
     let transaction: SDKTransaction | null;
     let signatureAudit: SignatureAudit | null;
     try {
       transaction = SDKTransaction.fromBytes(hexToUint8Array(item.transactionBytes));
-      signatureAudit = await computeSignatureKey(
-        transaction,
-        mirrorNetwork,
-        accountInfoCache,
-        nodeInfoCache,
-        publicKeyOwnerCache,
-        null,
-      );
+      signatureAudit = await appCache.computeSignatureKey(transaction, null, mirrorNetwork);
     } catch {
       transaction = null;
       signatureAudit = null;
@@ -66,14 +55,12 @@ export class TransactionBrowserEntry {
   public static async makeFromArray(
     items: ITransactionBrowserItem[],
     mirrorNetwork: string,
-    accountInfoCache: AccountByIdCache,
-    nodeInfoCache: NodeByIdCache,
-    publicKeyOwnerCache: PublicKeyOwnerCache,
+    appCache: AppCache,
     userKeys: string[],
   ): Promise<TransactionBrowserEntry[]> {
     const result: TransactionBrowserEntry[] = [];
     for (const i of items) {
-      result.push(await this.make(i, mirrorNetwork, accountInfoCache, nodeInfoCache, publicKeyOwnerCache, userKeys));
+      result.push(await this.make(i, mirrorNetwork, appCache, userKeys));
     }
     return result;
   }

--- a/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserKeySection.vue
+++ b/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserKeySection.vue
@@ -3,11 +3,7 @@ import type { ITransactionBrowserItem } from '@renderer/components/ExternalSigni
 import SignatureStatus from '@renderer/components/SignatureStatus.vue';
 import { computed, ref, watch, type Ref } from 'vue';
 import { Transaction } from '@hiero-ledger/sdk';
-import {
-  computeSignatureKey,
-  hexToUint8Array,
-  type SignatureAudit,
-} from '@renderer/utils';
+import { hexToUint8Array, type SignatureAudit } from '@renderer/utils';
 import useUserStore from '@renderer/stores/storeUser';
 import useNetwork from '@renderer/stores/storeNetwork';
 import { AppCache } from '@renderer/caches/AppCache.ts';
@@ -26,9 +22,6 @@ const network = useNetwork();
 
 /* Injected */
 const appCache = AppCache.inject();
-const accountByIdCache = appCache.mirrorAccountById;
-const nodeByIdCache = appCache.mirrorNodeById;
-const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 
 /* State */
 const signatureKeyObject: Ref<SignatureAudit | null> = ref(null);
@@ -52,13 +45,10 @@ const signersPublicKeys = computed(() => {
 const updateSignatureKeyObject = async () => {
   if (transaction.value !== null) {
     try {
-      signatureKeyObject.value = await computeSignatureKey(
+      signatureKeyObject.value = await appCache.computeSignatureKey(
         transaction.value,
-        network.mirrorNodeBaseURL,
-        accountByIdCache,
-        nodeByIdCache,
-        publicKeyOwnerCache,
         user.selectedOrganization,
+        network.mirrorNodeBaseURL,
       );
     } catch (error) {
       logger.error('Failed to compute signature key', { error });

--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
@@ -32,12 +32,7 @@ import { ToastManager } from '@renderer/utils/ToastManager';
 import useAccountId from '@renderer/composables/useAccountId';
 import useLoader from '@renderer/composables/useLoader';
 
-import {
-  assertUserLoggedIn,
-  computeSignatureKey,
-  getErrorMessage,
-  isAccountId,
-} from '@renderer/utils';
+import { assertUserLoggedIn, getErrorMessage, isAccountId } from '@renderer/utils';
 import { getPropagationButtonLabel } from '@renderer/utils/transactions';
 
 import AppInput from '@renderer/components/ui/AppInput.vue';
@@ -88,9 +83,6 @@ const withLoader = useLoader();
 
 /* Injected */
 const appCache = AppCache.inject();
-const accountByIdCache = appCache.mirrorAccountById;
-const nodeByIdCache = appCache.mirrorNodeById;
-const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 
 /* State */
 const transactionProcessor = ref<InstanceType<typeof TransactionProcessor> | null>(null);
@@ -320,13 +312,10 @@ function basePreCreateAssert() {
 
 async function updateTransactionKey() {
   try {
-    const computedKeys = await computeSignatureKey(
+    const computedKeys = await appCache.computeSignatureKey(
       transaction.value,
-      network.mirrorNodeBaseURL,
-      accountByIdCache,
-      nodeByIdCache,
-      publicKeyOwnerCache,
       user.selectedOrganization,
+      network.mirrorNodeBaseURL,
     );
     transactionKey.value = new KeyList(computedKeys.signatureKeys);
   } catch {

--- a/front-end/src/renderer/composables/useTransactionAudit.ts
+++ b/front-end/src/renderer/composables/useTransactionAudit.ts
@@ -1,7 +1,6 @@
 import { computed, type ComputedRef, type Ref } from 'vue';
 import { Key, Transaction as SDKTransaction } from '@hiero-ledger/sdk';
 import {
-  computeSignatureKey,
   createLogger,
   hexToUint8Array,
   isLoggedInOrganization,
@@ -28,18 +27,15 @@ export default function useTransactionAudit(transactionId: Ref<number | null>): 
 
   /* Injected */
   const appCache = AppCache.inject();
-  const accountByIdCache = appCache.mirrorAccountById;
-  const nodeByIdCache = appCache.mirrorNodeById;
-  const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
-  const transactionCache = appCache.backendTransaction;
 
   /* Computed */
   const transaction = computed(async () => {
     let result: ITransactionFull | Error | null;
     if (transactionId.value !== null && isLoggedInOrganization(user.selectedOrganization)) {
       try {
-        result = await transactionCache.lookup(
-          transactionId.value, user.selectedOrganization.serverUrl,
+        result = await appCache.backendTransaction.lookup(
+          transactionId.value,
+          user.selectedOrganization.serverUrl,
         );
       } catch {
         result = null;
@@ -73,13 +69,10 @@ export default function useTransactionAudit(transactionId: Ref<number | null>): 
       result = null;
     } else {
       try {
-        result = await computeSignatureKey(
+        result = await appCache.computeSignatureKey(
           sdkTX,
-          network.mirrorNodeBaseURL,
-          accountByIdCache,
-          nodeByIdCache,
-          publicKeyOwnerCache,
           user.selectedOrganization,
+          network.mirrorNodeBaseURL,
         );
       } catch (error) {
         result = null;

--- a/front-end/src/renderer/pages/TransactionDetails/SignTransactionController.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/SignTransactionController.vue
@@ -30,10 +30,6 @@ const user = useUserStore();
 
 /* Injected */
 const appCache = AppCache.inject();
-const transactionCache = appCache.backendTransaction;
-const accountByIdCache = appCache.mirrorAccountById;
-const nodeByIdCache = appCache.mirrorNodeById;
-const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 const toastManager = ToastManager.inject();
 
 /* Computed */
@@ -53,7 +49,10 @@ const handleSign = async (personalPassword: string | null): Promise<ActionReport
   } finally {
     // We clear transaction cache
     if (props.transaction && user.selectedOrganization) {
-      transactionCache.forgetTransaction(props.transaction, user.selectedOrganization.serverUrl);
+      appCache.backendTransaction.forgetTransaction(
+        props.transaction,
+        user.selectedOrganization.serverUrl,
+      );
     }
     await props.callback(result === null);
   }
@@ -72,12 +71,7 @@ const performSign = async (
   const reportTitle = 'Sign Transaction';
 
   // 1) checks if user has all the required private keys
-  const signatureItems = await collectRequiredKeys(
-    [transaction],
-    accountByIdCache,
-    nodeByIdCache,
-    publicKeyOwnerCache,
-  );
+  const signatureItems = await collectRequiredKeys([transaction], appCache);
   const missingKeys = collectMissingKeys(signatureItems);
   const missingKeyCount = missingKeys.length;
   if (missingKeyCount > 0) {

--- a/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
@@ -25,9 +25,12 @@ import { parseTransactionActionPayload } from '@renderer/utils/parseTransactionA
 import { getTransactionGroupById } from '@renderer/services/organization';
 import { getTransaction } from '@renderer/services/transactionService';
 
-import { getTransactionPayerId, getTransactionType, getTransactionValidStart } from '@renderer/utils/sdk/transactions';
 import {
-  computeSignatureKey,
+  getTransactionPayerId,
+  getTransactionType,
+  getTransactionValidStart,
+} from '@renderer/utils/sdk/transactions';
+import {
   getAccountIdWithChecksum,
   getAccountNicknameFromId,
   getErrorMessage,
@@ -36,6 +39,7 @@ import {
   hexToUint8Array,
   isLoggedInOrganization,
   openTransactionInHashscan,
+  type SignatureAudit,
 } from '@renderer/utils';
 
 import AppLoader from '@renderer/components/ui/AppLoader.vue';
@@ -88,16 +92,12 @@ const route = useRoute();
 
 /* Injected */
 const appCache = AppCache.inject();
-const accountByIdCache = appCache.mirrorAccountById;
-const nodeByIdCache = appCache.mirrorNodeById;
-const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
-const transactionCache = appCache.backendTransaction;
 
 /* State */
 const orgTransaction = ref<ITransactionFull | null>(null);
 const localTransaction = ref<Transaction | null>(null);
 const sdkTransaction = ref<SDKTransaction | null>(null);
-const signatureKeyObject: Ref<Awaited<ReturnType<typeof computeSignatureKey>> | null> = ref(null);
+const signatureKeyObject: Ref<SignatureAudit | null> = ref(null);
 const feePayer = ref<string | null>(null);
 const feePayerNickname = ref<string | null>(null);
 const groupDescription = ref<string | undefined>(undefined);
@@ -160,7 +160,7 @@ async function fetchTransaction() {
   let transactionBytes: Uint8Array;
   try {
     if (isLoggedInOrganization(user.selectedOrganization) && !isNaN(Number(id))) {
-      orgTransaction.value = await transactionCache.lookup(
+      orgTransaction.value = await appCache.backendTransaction.lookup(
         Number(id),
         user.selectedOrganization?.serverUrl || '',
       );
@@ -221,13 +221,10 @@ async function fetchTransaction() {
 
   if (isLoggedInOrganization(user.selectedOrganization)) {
     try {
-      signatureKeyObject.value = await computeSignatureKey(
+      signatureKeyObject.value = await appCache.computeSignatureKey(
         sdkTransaction.value,
-        network.mirrorNodeBaseURL,
-        accountByIdCache,
-        nodeByIdCache,
-        publicKeyOwnerCache,
         user.selectedOrganization,
+        network.mirrorNodeBaseURL,
       );
     } catch (error) {
       signatureKeyObject.value = null;
@@ -243,7 +240,7 @@ async function fetchTransactionOnNotif(): Promise<void> {
   const id = Number(formattedId.value);
   if (isLoggedInOrganization(user.selectedOrganization) && !isNaN(id)) {
     // We clear cache with strict==false to keep young data
-    transactionCache.forget(id, user.selectedOrganization.serverUrl, false);
+    appCache.backendTransaction.forget(id, user.selectedOrganization.serverUrl, false);
   }
   // 2) Now fetch transaction
   await fetchTransaction();

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -100,9 +100,6 @@ const router = useRouter();
 
 /* Injected */
 const appCache = AppCache.inject();
-const accountByIdCache = appCache.mirrorAccountById;
-const nodeByIdCache = appCache.mirrorNodeById;
-const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 const toastManager = ToastManager.inject();
 
 /* State */
@@ -301,9 +298,7 @@ watch(
         SDKTransaction.fromBytes(hexToUint8Array(transaction.transactionBytes)),
         user.selectedOrganization.userKeys,
         network.mirrorNodeBaseURL,
-        accountByIdCache,
-        nodeByIdCache,
-        publicKeyOwnerCache,
+        appCache,
         user.selectedOrganization,
       ),
       approvePromise,

--- a/front-end/src/renderer/pages/TransactionGroupDetails/SignAllController.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/SignAllController.vue
@@ -27,9 +27,6 @@ const activate = defineModel<boolean>('activate', { required: true });
 
 /* Injected */
 const appCache = AppCache.inject();
-const accountByIdCache = appCache.mirrorAccountById;
-const nodeByIdCache = appCache.mirrorNodeById;
-const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 const toastManager = ToastManager.inject();
 
 /* Stores */
@@ -82,9 +79,7 @@ const performSignAll = async (
     progressText.value = 'Collecting required keys…';
     const signatureItems = await collectRequiredKeys(
       itemsToSign,
-      accountByIdCache,
-      nodeByIdCache,
-      publicKeyOwnerCache,
+      appCache,
     );
     const missingKeys = collectMissingKeys(signatureItems);
     const missingKeyCount = missingKeys.length;

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -106,10 +106,6 @@ const createTooltips = useCreateTooltips();
 
 /* Injected */
 const appCache = AppCache.inject();
-const accountByIdCache = appCache.mirrorAccountById;
-const nodeByIdCache = appCache.mirrorNodeById;
-const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
-const transactionCache = appCache.backendTransaction;
 const toastManager = ToastManager.inject();
 
 /* State */
@@ -287,9 +283,7 @@ const updateFirstSignableGroupItemAfterFetch = async () => {
     const signable = await isSignableTransaction(
       item.transaction,
       network.mirrorNodeBaseURL,
-      accountByIdCache,
-      nodeByIdCache,
-      publicKeyOwnerCache,
+      appCache,
       user.selectedOrganization,
     );
     if (signable) {
@@ -395,7 +389,7 @@ async function fetchGroupOnNotif(groupId: string | number) {
     const serverUrl = user.selectedOrganization.serverUrl;
     for (const item of group.value.groupItems) {
       // We clear cache with strict==false to keep young data
-      transactionCache.forget(item.transactionId, serverUrl, false);
+      appCache.backendTransaction.forget(item.transactionId, serverUrl, false);
     }
   }
   // 2) Now fetch group

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupRow.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupRow.vue
@@ -31,9 +31,6 @@ const emit = defineEmits<{
 
 /* Injected */
 const appCache = AppCache.inject();
-const accountByIdCache = appCache.mirrorAccountById;
-const nodeByIdCache = appCache.mirrorNodeById;
-const publicKeyOwnerCache = appCache.backendPublicKeyOwner;
 
 /* Stores */
 const user = useUserStore();
@@ -125,9 +122,7 @@ const updateSigningStatus = async (): Promise<void> => {
     canSign.value = await isSignableTransaction(
       tx,
       network.mirrorNodeBaseURL,
-      accountByIdCache,
-      nodeByIdCache,
-      publicKeyOwnerCache,
+      appCache,
       user.selectedOrganization,
     );
   } catch {

--- a/front-end/src/renderer/utils/index.ts
+++ b/front-end/src/renderer/utils/index.ts
@@ -20,8 +20,7 @@ import {
 } from './userStoreHelpers';
 import { isAccountId } from './validator';
 import { usersPublicRequiredToSign } from '@renderer/utils/transactionSignatureModels';
-import type { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
-import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
+import type { AppCache } from '@renderer/caches/AppCache';
 import type { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
 import type { SignatureItem } from '@renderer/types';
 import { createLogger } from './logger';
@@ -191,9 +190,7 @@ export function stringifyHbarWithFont(hbar: Hbar, fontClass = 'text-bold text-se
 
 export async function collectRequiredKeys(
   transactions: ITransaction[],
-  accountInfoCache: AccountByIdCache,
-  nodeInfoCache: NodeByIdCache,
-  publicKeyOwnerCache: PublicKeyOwnerCache,
+  appCache: AppCache,
 ): Promise<SignatureItem[]> {
   const user = useUserStore();
   const network = useNetworkStore();
@@ -210,9 +207,7 @@ export async function collectRequiredKeys(
           transaction,
           selectedOrganization.userKeys,
           network.mirrorNodeBaseURL,
-          accountInfoCache,
-          nodeInfoCache,
-          publicKeyOwnerCache,
+          appCache,
           selectedOrganization,
         );
 

--- a/front-end/src/renderer/utils/transactionSignatureModels/index.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/index.ts
@@ -2,13 +2,9 @@ import { type ITransaction, type IUserKey, TransactionStatus } from '@shared/int
 
 import { Transaction as SDKTransaction } from '@hiero-ledger/sdk';
 
-import TransactionFactory from './transaction-factory';
 import { flattenKeyList } from '../../services/keyPairService';
-import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import type { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
-import type { SignatureAudit } from './transaction.model';
+import type { AppCache } from '@renderer/caches/AppCache';
 import type { ConnectedOrganization, LoggedInOrganization } from '@renderer/types';
-import type { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
 import { hexToUint8Array } from '@renderer/utils';
 
 export * from './account-create-transaction.model';
@@ -26,33 +22,12 @@ export * from './transfer-transaction.model';
 
 export const COUNCIL_ACCOUNTS = ['0.0.2', '0.0.50', '0.0.55'];
 
-export const computeSignatureKey = async (
-  transaction: SDKTransaction,
-  mirrorNodeLink: string,
-  accountInfoCache: AccountByIdCache,
-  nodeInfoCache: NodeByIdCache,
-  publicKeyOwnerCache: PublicKeyOwnerCache,
-  organization: ConnectedOrganization | null,
-): Promise<SignatureAudit> => {
-  const transactionModel = TransactionFactory.fromTransaction(transaction);
-
-  return await transactionModel.computeSignatureKey(
-    mirrorNodeLink,
-    accountInfoCache,
-    nodeInfoCache,
-    publicKeyOwnerCache,
-    organization,
-  );
-};
-
 /* Returns only users PK required to sign */
 export const usersPublicRequiredToSign = async (
   transaction: SDKTransaction,
   userKeys: IUserKey[],
   mirrorNodeLink: string,
-  accountInfoCache: AccountByIdCache,
-  nodeInfoCache: NodeByIdCache,
-  publicKeyOwnerCache: PublicKeyOwnerCache,
+  appCache: AppCache,
   organization: ConnectedOrganization | null,
 ): Promise<string[]> => {
   const publicKeysRequired: Set<string> = new Set<string>();
@@ -63,13 +38,10 @@ export const usersPublicRequiredToSign = async (
   /* Transaction signers' public keys */
   const signerPublicKeys = new Set([...transaction._signerPublicKeys]);
 
-  const requiredKeys = await computeSignatureKey(
+  const requiredKeys = await appCache.computeSignatureKey(
     transaction,
-    mirrorNodeLink,
-    accountInfoCache,
-    nodeInfoCache,
-    publicKeyOwnerCache,
     organization,
+    mirrorNodeLink,
   );
 
   const requiredUnsignedKeys = new Set<string>();
@@ -94,9 +66,7 @@ export const usersPublicRequiredToSign = async (
 export const isSignableTransaction = async (
   tx: ITransaction,
   mirrorNodeLink: string,
-  accountInfoCache: AccountByIdCache,
-  nodeInfoCache: NodeByIdCache,
-  publicKeyOwnerCache: PublicKeyOwnerCache,
+  appCache: AppCache,
   organization: ConnectedOrganization & LoggedInOrganization,
 ): Promise<boolean> => {
   let result: boolean;
@@ -108,9 +78,7 @@ export const isSignableTransaction = async (
         sdkTransaction,
         organization.userKeys,
         mirrorNodeLink,
-        accountInfoCache,
-        nodeInfoCache,
-        publicKeyOwnerCache,
+        appCache,
         organization,
       );
       result = usersPublicKeys.length > 0;

--- a/front-end/src/shared/utils/transactionFile.ts
+++ b/front-end/src/shared/utils/transactionFile.ts
@@ -1,13 +1,11 @@
 import { Transaction as SDKTransaction } from '@hiero-ledger/sdk';
-import { computeSignatureKey, hexToUint8Array, type SignatureAudit } from '@renderer/utils';
+import { hexToUint8Array, type SignatureAudit } from '@renderer/utils';
 import type { ITransaction, TransactionFileItem } from '@shared/interfaces';
-import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
-import type { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
 import { flattenKeyList } from '@renderer/services/keyPairService.ts';
 import { getTransactionGroupById } from '@renderer/services/organization';
 import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache';
 import type { ITransactionNode } from '../../../../shared/src/ITransactionNode.ts';
-import type { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
 import { createLogger } from '@renderer/utils/logger';
 
 const logger = createLogger('renderer.transactionFile');
@@ -44,9 +42,7 @@ export async function filterTransactionFileItemsToBeSigned(
   transactionFileItems: TransactionFileItem[],
   userPublicKeys: string[],
   mirrorNetwork: string,
-  accountInfoCache: AccountByIdCache,
-  nodeInfoCache: NodeByIdCache,
-  publicKeyOwnerCache: PublicKeyOwnerCache,
+  appCache: AppCache,
 ): Promise<TransactionFileItemsStatus> {
   const fullySigned: TransactionFileItem[] = [];
   const needSigning: TransactionFileItem[] = [];
@@ -54,14 +50,7 @@ export async function filterTransactionFileItemsToBeSigned(
     try {
       const transactionBytes = hexToUint8Array(item.transactionBytes);
       const sdkTransaction = SDKTransaction.fromBytes(transactionBytes);
-      const audit = await computeSignatureKey(
-        sdkTransaction,
-        mirrorNetwork,
-        accountInfoCache,
-        nodeInfoCache,
-        publicKeyOwnerCache,
-        null,
-      );
+      const audit = await appCache.computeSignatureKey(sdkTransaction, null, mirrorNetwork);
       const requiredKeys = filterAuditByUser(audit, userPublicKeys);
       const signingKeys = filterTransactionSignersByUser(sdkTransaction, userPublicKeys);
 
@@ -86,20 +75,11 @@ export async function collectMissingSignerKeys(
   transaction: SDKTransaction,
   userPublicKeys: string[],
   mirrorNodeLink: string,
-  accountInfoCache: AccountByIdCache,
-  nodeInfoCache: NodeByIdCache,
-  publicKeyOwnerCache: PublicKeyOwnerCache,
+  appCache: AppCache,
 ): Promise<string[]> {
   const result: string[] = [];
 
-  const audit = await computeSignatureKey(
-    transaction,
-    mirrorNodeLink,
-    accountInfoCache,
-    nodeInfoCache,
-    publicKeyOwnerCache,
-    null,
-  );
+  const audit = await appCache.computeSignatureKey(transaction, null, mirrorNodeLink);
 
   const signatureKeys = transaction._signerPublicKeys;
 

--- a/front-end/src/tests/renderer/utils/index.spec.ts
+++ b/front-end/src/tests/renderer/utils/index.spec.ts
@@ -229,8 +229,6 @@ describe('collectRequiredKeys', () => {
     const result = await collectRequiredKeys(
       [{ id: 0, transactionBytes: '00' } as any, { id: 1, transactionBytes: '00' } as any],
       {} as any,
-      {} as any,
-      {} as any,
     );
     expect(result).toEqual([
       { transactionId: 0, transaction: { mocked: 'tx' }, publicKeys: ['pk-1'] },


### PR DESCRIPTION
**Description**:

This is a follow-up of #2717.

Changes below:
- make sure that `AppCache.computeSignatureKey()` is used everywhere
- replace individual cache params by a single `AppCache` param

**Related issue(s)**:

Contributes to #2521

**Notes for reviewer**:
```
M   front-end/src/renderer/utils/transactionSignatureModels/index.ts
    # Removed computeSignatureKey() which is now replaced by AppCache.computeSignatureKey()

M   front-end/src/renderer/components/ExternalSigning/ExportTransactionsModal.vue
M   front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserEntry.ts
M   front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserKeySection.vue
M   front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
M   front-end/src/renderer/composables/useTransactionAudit.ts
M   front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
    # Views now invoke AppCache.computeSignatureKey() in place of computeSignatureKey() function

M   front-end/src/renderer/utils/index.ts
M   front-end/src/shared/utils/transactionFile.ts
    # collectRequiredKeys(), collectMissingSignerKeys() and filterTransactionFileItemsToBeSigned()
    # now expect AppCache reference in place of individual caches

M   front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowser.vue
M   front-end/src/renderer/components/ExternalSigning/SignTransactionFileModal.vue
M   front-end/src/renderer/pages/TransactionDetails/SignTransactionController.vue
M   front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
M   front-end/src/renderer/pages/TransactionGroupDetails/SignAllController.vue
M   front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
M   front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupRow.vue
    # Views now pass AppCache in place of individual caches

M   front-end/src/tests/renderer/utils/index.spec.ts
    # Adapted to AppCache single param pattern
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
