### PR TITLE
fix: update electron-builder configuration for universal builds 

### DIFF
--- a/front-end/electron-builder.yml
+++ b/front-end/electron-builder.yml
@@ -9,10 +9,19 @@ directories:
   buildResources: build
   output: 'release'
 files:
-  - 'dist'
-  - 'dist-electron'
+  - 'dist/**'
+  - 'dist-electron/**'
+  - 'package.json'
+  - '!**/test/**'
+  - '!**/tests/**'
+  - '!**/*.evts'
 asarUnpack:
-  - prisma/**
+  - '**/*.node'
+extraResources:
+  - from: src/generated/prisma
+    to: src/generated/prisma
+  - prisma/schema.prisma
+  - prisma/migrations/**
 win:
   executableName: ${productName}
 nsis:
@@ -32,8 +41,8 @@ mac:
         - x64
         - arm64
         - universal
-  x64ArchFiles: '*'
-  mergeASARs: true
+  x64ArchFiles: "{**/*.node,node_modules/.prisma/**}"
+  mergeASARs: false
 linux:
   target:
     - snap
@@ -51,7 +60,3 @@ publish:
   # This ensures electron-builder knows where to publish releases
   owner: hashgraph
   repo: hedera-transaction-tool
-extraResources:
-  - node_modules/prisma/**/*
-  - node_modules/@prisma/adapter-better-sqlite3/**/*
-  - prisma/**

--- a/front-end/electron-builder.yml
+++ b/front-end/electron-builder.yml
@@ -15,6 +15,10 @@ files:
   - '!**/test/**'
   - '!**/tests/**'
   - '!**/*.evts'
+  - '!**/*.map'
+  - '!**/*.d.ts'
+  - '!**/node_modules/**/{README,CHANGELOG,CONTRIBUTING,LICENSE}*'
+  - '!**/node_modules/**/.{eslintrc,prettierrc,editorconfig,npmignore}'
 asarUnpack:
   - '**/*.node'
 extraResources:
@@ -41,7 +45,6 @@ mac:
         - x64
         - arm64
         - universal
-  x64ArchFiles: "{**/*.node,node_modules/.prisma/**}"
   mergeASARs: false
 linux:
   target:


### PR DESCRIPTION
**Description**:
This pull request updates the Electron build configuration to allow for universal builds to work again. ASAR and module merging was broken due to limitations in the builder. In addition, unnecessary code, like tests, is removed from the build.

**Related issue(s)**:

Fixes #2725 

**Checklist**

- [x] Tested (unit, integration, etc.)
