### PR TITLE
feat: change workers for Local Basic tests

### DIFF
--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -73,8 +73,8 @@ jobs:
             grep: '@local-basic'
             soloRequired: false
             backendRequired: false
-            sharedEnvironment: false
-            workers: 1
+            sharedEnvironment: true
+            workers: 2
           - name: Shared E2E
             grep: '@local-transactions|@organization-basic|@organization-advanced'
             soloRequired: true


### PR DESCRIPTION
Description:                                       
                                                                                                                                                                               
  This PR tunes the @local-basic E2E job in .github/workflows/test-frontend.yaml to run faster by parallelizing workers and sharing the Electron environment across specs.     
   
  - Change workers from 1 to 2 for the @local-basic job                                                                                                                        
  - Change sharedEnvironment from false to true for the @local-basic job
                                                                                                                                                                               
  Related issue(s):
                                                                                                                                                                               
  Fixes #2728 

  Notes for reviewer:

  Checklist                                                                                                                                                                    
   
  - Documented (Code comments, README, etc.)                                                                                                                                   
  - Tested (unit, integration, etc.)