### PR TITLE
fix: unauthorized errors after importing signatures from TTv1

### DIFF
--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -1297,11 +1297,18 @@ describe('TransactionsService', () => {
 
       expect(dataSource.transaction).toHaveBeenCalledTimes(1);
       expect(updateQb.update).toHaveBeenCalledWith(Transaction);
-      expect(updateQb.set).toHaveBeenCalledWith({ transactionBytes: expect.any(Function) });
-      /* Invoke the SQL fragment so the arrow function body runs and we can assert
-         the CASE expression has the correct shape. */
-      const setArg = updateQb.set.mock.calls[0][0] as { transactionBytes: () => string };
+      expect(updateQb.set).toHaveBeenCalledWith({
+        transactionBytes: expect.any(Function),
+        updatedAt: expect.any(Function),
+      });
+      /* Invoke the SQL fragments so the arrow function bodies run and we can
+         assert the CASE expression and updatedAt have the correct shape. */
+      const setArg = updateQb.set.mock.calls[0][0] as {
+        transactionBytes: () => string;
+        updatedAt: () => string;
+      };
       expect(setArg.transactionBytes()).toBe('CASE id WHEN :id0 THEN :bytes0::bytea END');
+      expect(setArg.updatedAt()).toBe('NOW()');
       expect(updateQb.where).toHaveBeenCalledWith('id IN (:...ids)', { ids: [transactionId] });
       expect(updateQb.execute).toHaveBeenCalled();
 

--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -1298,6 +1298,10 @@ describe('TransactionsService', () => {
       expect(dataSource.transaction).toHaveBeenCalledTimes(1);
       expect(updateQb.update).toHaveBeenCalledWith(Transaction);
       expect(updateQb.set).toHaveBeenCalledWith({ transactionBytes: expect.any(Function) });
+      /* Invoke the SQL fragment so the arrow function body runs and we can assert
+         the CASE expression has the correct shape. */
+      const setArg = updateQb.set.mock.calls[0][0] as { transactionBytes: () => string };
+      expect(setArg.transactionBytes()).toBe('CASE id WHEN :id0 THEN :bytes0::bytea END');
       expect(updateQb.where).toHaveBeenCalledWith('id IN (:...ids)', { ids: [transactionId] });
       expect(updateQb.execute).toHaveBeenCalled();
 

--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { mock, mockDeep } from 'jest-mock-extended';
 import { BadRequestException, ConflictException } from '@nestjs/common';
-import { Brackets, DeepPartial, EntityManager, In, Not, Repository, SelectQueryBuilder } from 'typeorm';
+import { Brackets, DataSource, DeepPartial, EntityManager, In, Not, Repository, SelectQueryBuilder } from 'typeorm';
 import {
   AccountCreateTransaction,
   AccountId,
@@ -19,11 +19,14 @@ import {
 } from '@hiero-ledger/sdk';
 
 import {
+  emitDismissedNotifications,
   emitTransactionStatusUpdate,
+  emitTransactionUpdate,
   ErrorCodes,
   ExecuteService,
   flattenKeyList,
   NatsPublisherService,
+  processTransactionStatus,
   safe,
   SchedulerService,
   SqlBuilderService,
@@ -69,6 +72,9 @@ jest.mock(`@app/common/utils`, () => {
     userKeysRequiredToSign: jest.fn(),
     getTransactionSignReminderKey: jest.fn(),
     emitTransactionStatusUpdate: jest.fn(),
+    emitTransactionUpdate: jest.fn(),
+    emitDismissedNotifications: jest.fn(),
+    processTransactionStatus: jest.fn(),
     flattenKeyList: jest.fn(),
     safe: jest.fn(),
 
@@ -89,6 +95,7 @@ describe('TransactionsService', () => {
   const executeService = mockDeep<ExecuteService>();
   const sqlBuilderService = mockDeep<SqlBuilderService>();
   const entityManager = mockDeep<EntityManager>();
+  const dataSource = mockDeep<DataSource>();
 
   const user: Partial<User> = {
     id: 1,
@@ -133,6 +140,10 @@ describe('TransactionsService', () => {
         {
           provide: EntityManager,
           useValue: entityManager,
+        },
+        {
+          provide: DataSource,
+          useValue: dataSource,
         },
         {
           provide: SchedulerService,
@@ -1176,6 +1187,68 @@ describe('TransactionsService', () => {
       ],
     } as User;
 
+    /* Helpers that mirror the real typeorm chain calls used in importSignatures. */
+    const makeFindDispatcher = (transactions: unknown[], userKeys: unknown[] = [], existingSigners: unknown[] = []) => {
+      return (entity: unknown) => {
+        if (entity === Transaction) return Promise.resolve(transactions);
+        if (entity === TransactionSigner) return Promise.resolve(existingSigners);
+        if (entity === UserKey) return Promise.resolve(userKeys);
+        return Promise.resolve([]);
+      };
+    };
+
+    type UpdateQb = {
+      update: jest.Mock;
+      set: jest.Mock;
+      where: jest.Mock;
+      setParameters: jest.Mock;
+      execute: jest.Mock;
+    };
+    type InsertQb = {
+      insert: jest.Mock;
+      into: jest.Mock;
+      values: jest.Mock;
+      execute: jest.Mock;
+    };
+
+    const makeUpdateQb = (execute: jest.Mock = jest.fn().mockResolvedValue(undefined)): UpdateQb => ({
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      setParameters: jest.fn().mockReturnThis(),
+      execute,
+    });
+
+    const makeInsertQb = (execute: jest.Mock = jest.fn().mockResolvedValue(undefined)): InsertQb => ({
+      insert: jest.fn().mockReturnThis(),
+      into: jest.fn().mockReturnThis(),
+      values: jest.fn().mockReturnThis(),
+      execute,
+    });
+
+    type TxManager = {
+      createQueryBuilder: jest.Mock;
+      query: jest.Mock;
+    };
+
+    const makeTxManager = (queryResult: unknown = [[], 0]): TxManager => ({
+      createQueryBuilder: jest.fn(),
+      query: jest.fn().mockResolvedValue(queryResult),
+    });
+
+    const stubTransaction = (manager: TxManager) => {
+      (dataSource.transaction as unknown as jest.Mock).mockImplementation(
+        async (arg1: unknown, arg2?: unknown) => {
+          const callback = typeof arg1 === 'function' ? arg1 : arg2;
+          return (callback as (m: TxManager) => unknown)(manager);
+        },
+      );
+    };
+
+    const stubTransactionReject = (err: Error) => {
+      (dataSource.transaction as unknown as jest.Mock).mockRejectedValue(err);
+    };
+
     beforeEach(async () => {
       sdkTransaction = new AccountCreateTransaction()
         .setTransactionId(TransactionId.generate('0.0.2'))
@@ -1185,7 +1258,112 @@ describe('TransactionsService', () => {
       jest.resetAllMocks();
     });
 
-    it('should import signatures successfully', async () => {
+    it('should import signatures atomically and persist new signers', async () => {
+      const transaction = {
+        id: transactionId,
+        transactionId: sdkTransaction.transactionId.toString(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      const matchingUserKey = {
+        id: 42,
+        userId: 7,
+        publicKey: privateKey.publicKey.toStringRaw(),
+      };
+      await sdkTransaction.sign(privateKey);
+
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction], [matchingUserKey]) as any);
+
+      const updateQb = makeUpdateQb();
+      const insertQb = makeInsertQb();
+      const manager = makeTxManager();
+      manager.createQueryBuilder
+        .mockReturnValueOnce(updateQb)
+        .mockReturnValueOnce(insertQb);
+      stubTransaction(manager);
+
+      jest.mocked(safe).mockReturnValue({ data: [privateKey.publicKey] });
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
+      /* Simulate threshold met: status flips to WAITING_FOR_EXECUTION. */
+      jest
+        .mocked(processTransactionStatus)
+        .mockResolvedValue(new Map([[transactionId, TransactionStatus.WAITING_FOR_EXECUTION]]));
+
+      const result = await service.importSignatures(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys
+      );
+
+      expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+      expect(updateQb.update).toHaveBeenCalledWith(Transaction);
+      expect(updateQb.set).toHaveBeenCalledWith({ transactionBytes: expect.any(Function) });
+      expect(updateQb.where).toHaveBeenCalledWith('id IN (:...ids)', { ids: [transactionId] });
+      expect(updateQb.execute).toHaveBeenCalled();
+
+      /* New signer row inserted so the key owner is recognised as a participant. */
+      expect(insertQb.into).toHaveBeenCalledWith(TransactionSigner);
+      expect(insertQb.values).toHaveBeenCalledWith([
+        { userId: 7, transactionId, userKeyId: 42 },
+      ]);
+      expect(insertQb.execute).toHaveBeenCalled();
+
+      /* Status recomputation so threshold-met transitions to WAITING_FOR_EXECUTION. */
+      expect(processTransactionStatus).toHaveBeenCalledWith(
+        transactionsRepo,
+        transactionSignatureService,
+        [expect.objectContaining({ id: transactionId })],
+      );
+
+      expect(result).toEqual([{ id: transactionId }]);
+      /* Payload shape matches SignersService.updateStatusesAndNotify — no additionalData. */
+      expect(emitTransactionStatusUpdate).toHaveBeenCalledWith(
+        notificationsPublisher,
+        [{ entityId: transactionId }],
+      );
+      expect(emitTransactionUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should skip inserting a signer row if one already exists for the key', async () => {
+      const transaction = {
+        id: transactionId,
+        transactionId: sdkTransaction.transactionId.toString(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      const existingSigner = { transactionId, userKeyId: 42 };
+      const matchingUserKey = {
+        id: 42,
+        userId: 7,
+        publicKey: privateKey.publicKey.toStringRaw(),
+      };
+      await sdkTransaction.sign(privateKey);
+
+      entityManager.find.mockImplementation(
+        makeFindDispatcher([transaction], [matchingUserKey], [existingSigner]) as any,
+      );
+
+      const updateQb = makeUpdateQb();
+      const insertQb = makeInsertQb();
+      const manager = makeTxManager();
+      manager.createQueryBuilder
+        .mockReturnValueOnce(updateQb)
+        .mockReturnValueOnce(insertQb);
+      stubTransaction(manager);
+
+      jest.mocked(safe).mockReturnValue({ data: [privateKey.publicKey] });
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
+
+      await service.importSignatures(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys,
+      );
+
+      expect(insertQb.execute).not.toHaveBeenCalled();
+    });
+
+    it('should update bytes but skip signer insert when no UserKey matches the imported public key', async () => {
       const transaction = {
         id: transactionId,
         transactionId: sdkTransaction.transactionId.toString(),
@@ -1195,48 +1373,267 @@ describe('TransactionsService', () => {
       };
       await sdkTransaction.sign(privateKey);
 
-      entityManager.find.mockResolvedValue([transaction]);
-      const executeMock = jest.fn().mockResolvedValue(undefined);
-      const qbMock = {
-        update: jest.fn().mockReturnThis(),
-        set: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        setParameters: jest.fn().mockReturnThis(),
-        execute: executeMock,
-      };
-      entityManager.createQueryBuilder.mockReturnValue(qbMock as unknown as any);
+      /* UserKey find returns empty — the signature is cryptographically valid but its
+         public key isn't owned by anyone we know about. We still update the tx bytes. */
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction], []) as any);
 
-      jest.mocked(safe).mockReturnValue({
-        data: [privateKey.publicKey],
-      });
+      const updateQb = makeUpdateQb();
+      const insertQb = makeInsertQb();
+      const manager = makeTxManager();
+      manager.createQueryBuilder
+        .mockReturnValueOnce(updateQb)
+        .mockReturnValueOnce(insertQb);
+      stubTransaction(manager);
 
-      // Any value will do here, this just shows the user has access to the transaction
+      jest.mocked(safe).mockReturnValue({ data: [privateKey.publicKey] });
       jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
-
-      entityManager.update.mockResolvedValue(undefined);
 
       const result = await service.importSignatures(
         [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
-        userWithKeys
+        userWithKeys,
       );
 
-      expect(qbMock.update).toHaveBeenCalledWith(Transaction);
-      expect(qbMock.set).toHaveBeenCalledWith({ transactionBytes: expect.any(Function) });
-      expect(qbMock.where).toHaveBeenCalledWith('id IN (:...ids)', { ids: expect.any(Array) });
-      expect(qbMock.setParameters).toHaveBeenCalledWith(expect.any(Object));
-      expect(executeMock).toHaveBeenCalled();
+      expect(updateQb.execute).toHaveBeenCalled();
+      expect(insertQb.execute).not.toHaveBeenCalled();
+      expect(manager.query).not.toHaveBeenCalled();
+      expect(result).toEqual([{ id: transactionId }]);
+    });
+
+    it('should insert signer rows for every owner when multiple UserKeys match', async () => {
+      const transaction = {
+        id: transactionId,
+        transactionId: sdkTransaction.transactionId.toString(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      const secondKey = PrivateKey.generateECDSA();
+      const userKeys = [
+        { id: 42, userId: 7, publicKey: privateKey.publicKey.toStringRaw() },
+        { id: 43, userId: 9, publicKey: secondKey.publicKey.toStringRaw() },
+      ];
+      await sdkTransaction.sign(privateKey);
+      await sdkTransaction.sign(secondKey);
+
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction], userKeys) as any);
+
+      const updateQb = makeUpdateQb();
+      const insertQb = makeInsertQb();
+      const manager = makeTxManager();
+      manager.createQueryBuilder
+        .mockReturnValueOnce(updateQb)
+        .mockReturnValueOnce(insertQb);
+      stubTransaction(manager);
+
+      jest.mocked(safe).mockReturnValue({
+        data: [privateKey.publicKey, secondKey.publicKey],
+      });
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
+
+      await service.importSignatures(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys,
+      );
+
+      expect(insertQb.values).toHaveBeenCalledWith([
+        { userId: 7, transactionId, userKeyId: 42 },
+        { userId: 9, transactionId, userKeyId: 43 },
+      ]);
+    });
+
+    it('should unwrap the [rows, rowCount] tuple from manager.query and emit dismissed notifications', async () => {
+      const transaction = {
+        id: transactionId,
+        transactionId: sdkTransaction.transactionId.toString(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      const matchingUserKey = {
+        id: 42,
+        userId: 7,
+        publicKey: privateKey.publicKey.toStringRaw(),
+      };
+      const dismissedRows = [{ id: 101, userId: 7 }];
+      await sdkTransaction.sign(privateKey);
+
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction], [matchingUserKey]) as any);
+
+      const updateQb = makeUpdateQb();
+      const insertQb = makeInsertQb();
+      /* manager.query returns the [rows, rowCount] tuple produced by the pg driver on
+         UPDATE ... RETURNING. The service must destructure the first element or it
+         will send a malformed payload to the NATS consumer. */
+      const manager = makeTxManager([dismissedRows, dismissedRows.length]);
+      manager.createQueryBuilder
+        .mockReturnValueOnce(updateQb)
+        .mockReturnValueOnce(insertQb);
+      stubTransaction(manager);
+
+      jest.mocked(safe).mockReturnValue({ data: [privateKey.publicKey] });
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
+
+      await service.importSignatures(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys,
+      );
+
+      expect(manager.query).toHaveBeenCalled();
+      expect(emitDismissedNotifications).toHaveBeenCalledWith(notificationsPublisher, dismissedRows);
+    });
+
+    it('should fail all touched ids with FST when the atomic transaction rolls back', async () => {
+      const transaction = {
+        id: transactionId,
+        transactionId: sdkTransaction.transactionId.toString(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      await sdkTransaction.sign(privateKey);
+
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction]) as any);
+      stubTransactionReject(new Error('deadlock'));
+
+      jest.mocked(safe).mockReturnValue({ data: [privateKey.publicKey] });
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
+
+      const result = await service.importSignatures(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys,
+      );
+
+      expect(result[0]).toEqual({ id: transactionId, error: ErrorCodes.FST });
+      /* Status and dismissal side-effects must NOT run when the write rolled back. */
+      expect(processTransactionStatus).not.toHaveBeenCalled();
+      expect(emitDismissedNotifications).not.toHaveBeenCalled();
+      expect(emitTransactionStatusUpdate).not.toHaveBeenCalled();
+      expect(emitTransactionUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should still return success and emit an unchanged-status event when processTransactionStatus fails after commit', async () => {
+      const transaction = {
+        id: transactionId,
+        transactionId: sdkTransaction.transactionId.toString(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      const matchingUserKey = {
+        id: 42,
+        userId: 7,
+        publicKey: privateKey.publicKey.toStringRaw(),
+      };
+      await sdkTransaction.sign(privateKey);
+
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction], [matchingUserKey]) as any);
+
+      const updateQb = makeUpdateQb();
+      const insertQb = makeInsertQb();
+      const manager = makeTxManager();
+      manager.createQueryBuilder
+        .mockReturnValueOnce(updateQb)
+        .mockReturnValueOnce(insertQb);
+      stubTransaction(manager);
+
+      jest.mocked(safe).mockReturnValue({ data: [privateKey.publicKey] });
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
+      jest.mocked(processTransactionStatus).mockRejectedValueOnce(new Error('status boom'));
+
+      const result = await service.importSignatures(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys,
+      );
 
       expect(result).toEqual([{ id: transactionId }]);
-      expect(emitTransactionStatusUpdate).toHaveBeenCalledWith(
+      /* statusMap is empty on failure -> transaction is treated as unchanged. */
+      expect(emitTransactionStatusUpdate).not.toHaveBeenCalled();
+      expect(emitTransactionUpdate).toHaveBeenCalledWith(
         notificationsPublisher,
-        [{
-          entityId: transactionId,
-          additionalData: {
-            transactionId: sdkTransaction.transactionId.toString(),
-            network: transaction.mirrorNetwork,
-          },
-        }],
+        [{ entityId: transactionId }],
       );
+    });
+
+    it('should be a no-op when every imported signature is already on the transaction', async () => {
+      await sdkTransaction.sign(privateKey);
+      /* Pre-apply the signature to the stored bytes so the import produces no change. */
+      const alreadySignedBytes = Buffer.from(sdkTransaction.toBytes());
+      const transaction = {
+        id: transactionId,
+        transactionId: sdkTransaction.transactionId.toString(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: alreadySignedBytes,
+        mirrorNetwork: 'testnet',
+      };
+
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction]) as any);
+
+      /* validateSignature short-circuits keys already present on the transaction. */
+      jest.mocked(safe).mockReturnValue({ data: [] });
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
+
+      const result = await service.importSignatures(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys,
+      );
+
+      expect(result).toEqual([{ id: transactionId }]);
+      /* No writes, no emissions, no status recomputation — matches the normal path. */
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+      expect(processTransactionStatus).not.toHaveBeenCalled();
+      expect(emitTransactionStatusUpdate).not.toHaveBeenCalled();
+      expect(emitTransactionUpdate).not.toHaveBeenCalled();
+      expect(emitDismissedNotifications).not.toHaveBeenCalled();
+    });
+
+    it('should roll back and mark all ids FST when the signer INSERT fails inside the transaction callback', async () => {
+      const transaction = {
+        id: transactionId,
+        transactionId: sdkTransaction.transactionId.toString(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      const matchingUserKey = {
+        id: 42,
+        userId: 7,
+        publicKey: privateKey.publicKey.toStringRaw(),
+      };
+      await sdkTransaction.sign(privateKey);
+
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction], [matchingUserKey]) as any);
+
+      /* UPDATE succeeds; INSERT then rejects — typeorm propagates the rejection out
+         of dataSource.transaction, which rolls back the already-executed UPDATE. */
+      const updateQb = makeUpdateQb();
+      const insertQb = makeInsertQb(jest.fn().mockRejectedValue(new Error('unique constraint')));
+      const manager = makeTxManager();
+      manager.createQueryBuilder
+        .mockReturnValueOnce(updateQb)
+        .mockReturnValueOnce(insertQb);
+      (dataSource.transaction as unknown as jest.Mock).mockImplementation(
+        async (arg1: unknown, arg2?: unknown) => {
+          const callback = typeof arg1 === 'function' ? arg1 : arg2;
+          return (callback as (m: TxManager) => unknown)(manager);
+        },
+      );
+
+      jest.mocked(safe).mockReturnValue({ data: [privateKey.publicKey] });
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
+
+      const result = await service.importSignatures(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys,
+      );
+
+      expect(updateQb.execute).toHaveBeenCalled();
+      expect(insertQb.execute).toHaveBeenCalled();
+      expect(result[0]).toEqual({ id: transactionId, error: ErrorCodes.FST });
+      /* Rolled back — no NATS emissions, no status recomputation. */
+      expect(processTransactionStatus).not.toHaveBeenCalled();
+      expect(emitDismissedNotifications).not.toHaveBeenCalled();
+      expect(emitTransactionStatusUpdate).not.toHaveBeenCalled();
+      expect(emitTransactionUpdate).not.toHaveBeenCalled();
     });
     
     it('should return error if transaction not found', async () => {
@@ -1258,7 +1655,7 @@ describe('TransactionsService', () => {
       };
       await sdkTransaction.sign(privateKey);
 
-      entityManager.find.mockResolvedValue([transaction]);
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction]) as any);
 
       const result = await service.importSignatures(
         [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
@@ -1276,7 +1673,7 @@ describe('TransactionsService', () => {
       };
       await sdkTransaction.sign(privateKey);
 
-      entityManager.find.mockResolvedValue([transaction]);
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction]) as any);
 
       // Any value will do here, this just shows the user has access to the transaction
       jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
@@ -1301,7 +1698,7 @@ describe('TransactionsService', () => {
         mirrorNetwork: 'testnet',
       };
       await sdkTransaction.sign(privateKey);
-      entityManager.find.mockResolvedValue([transaction]);
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction]) as any);
 
       // Any value will do here, this just shows the user has access to the transaction
       jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
@@ -1320,7 +1717,7 @@ describe('TransactionsService', () => {
       });
     });
 
-    it('should return error if entityManager.update throws', async () => {
+    it('should return FST error when the UPDATE inside the transaction throws', async () => {
       const transaction = {
         id: transactionId,
         status: TransactionStatus.WAITING_FOR_SIGNATURES,
@@ -1328,35 +1725,32 @@ describe('TransactionsService', () => {
         mirrorNetwork: 'testnet',
       };
       await sdkTransaction.sign(privateKey);
-      entityManager.find.mockResolvedValue([transaction]);
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction]) as any);
 
-      // Any value will do here, this just shows the user has access to the transaction
       jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
+      jest.mocked(safe).mockReturnValue({ data: [privateKey.publicKey] });
 
-      jest.mocked(safe).mockReturnValue({
-        data: [privateKey.publicKey],
-      });
-
-      // mock query builder to reject on execute
-      const executeMock = jest.fn().mockRejectedValue(new Error('Fail'));
-      const qbMock = {
-        update: jest.fn().mockReturnThis(),
-        set: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        setParameters: jest.fn().mockReturnThis(),
-        execute: executeMock,
-      };
-      entityManager.createQueryBuilder.mockReturnValue(qbMock as unknown as any);
+      const updateQb = makeUpdateQb(jest.fn().mockRejectedValue(new Error('Fail')));
+      const insertQb = makeInsertQb();
+      const manager = makeTxManager();
+      manager.createQueryBuilder
+        .mockReturnValueOnce(updateQb)
+        .mockReturnValueOnce(insertQb);
+      /* Real DataSource.transaction propagates callback rejections after rolling back. */
+      (dataSource.transaction as unknown as jest.Mock).mockImplementation(
+        async (arg1: unknown, arg2?: unknown) => {
+          const callback = typeof arg1 === 'function' ? arg1 : arg2;
+          return (callback as (m: TxManager) => unknown)(manager);
+        },
+      );
 
       const result = await service.importSignatures(
         [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
         userWithKeys
       );
-      expect(executeMock).toHaveBeenCalled();
-      expect(result[0]).toMatchObject({
-        id: transactionId,
-        error: 'An unexpected error occurred while saving the signatures: Fail',
-      });
+      expect(updateQb.execute).toHaveBeenCalled();
+      expect(result[0]).toEqual({ id: transactionId, error: ErrorCodes.FST });
+      expect(processTransactionStatus).not.toHaveBeenCalled();
     });
 
     it('should return error if user does not have verified access', async () => {
@@ -1368,7 +1762,7 @@ describe('TransactionsService', () => {
       };
       await sdkTransaction.sign(privateKey);
 
-      entityManager.find.mockResolvedValue([transaction]);
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction]) as any);
 
       // force verifyAccess to say the user has no access
       jest.spyOn(service, 'verifyAccess').mockResolvedValueOnce(false);
@@ -1393,7 +1787,7 @@ describe('TransactionsService', () => {
       };
       await sdkTransaction.sign(privateKey);
 
-      entityManager.find.mockResolvedValue([transaction]);
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction]) as any);
 
       // user has access
       jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -545,6 +545,9 @@ export class TransactionsService {
     const updates = new Map<number, UpdateRecord>();
     const newSignerRows: { userId: number; transactionId: number; userKeyId: number }[] = [];
     const notificationDismissals: { userId: number; transactionId: number }[] = [];
+    /* Dedup (userId, transactionId) pairs so a user with multiple keys signing
+       the same tx doesn't produce duplicate UNNEST rows in the receiver UPDATE. */
+    const notificationDismissalKeys = new Set<string>();
     /* Transactions with at least one persistable side-effect. Status recomputation
        and NATS emission operate on this set, not on `updates` alone. */
     const transactionsToProcess = new Map<number, Transaction>();
@@ -624,7 +627,11 @@ export class TransactionsService {
 
         for (const row of newSignersForDto) {
           newSignerRows.push(row);
-          notificationDismissals.push({ userId: row.userId, transactionId: id });
+          const dismissalKey = `${row.userId}:${id}`;
+          if (!notificationDismissalKeys.has(dismissalKey)) {
+            notificationDismissalKeys.add(dismissalKey);
+            notificationDismissals.push({ userId: row.userId, transactionId: id });
+          }
         }
 
         transactionsToProcess.set(id, transaction);

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -2,9 +2,10 @@ import {
   BadRequestException,
   ConflictException,
   Injectable,
+  Logger,
   UnauthorizedException,
 } from '@nestjs/common';
-import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
+import { InjectDataSource, InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
 
 import {
   AccountUpdateTransaction,
@@ -19,6 +20,7 @@ import {
 
 import {
   Brackets,
+  DataSource,
   EntityManager,
   FindManyOptions,
   FindOperator,
@@ -36,10 +38,12 @@ import {
   TransactionStatus,
   TransactionType,
   User,
+  UserKey,
 } from '@entities';
 
 import {
   attachKeys,
+  emitDismissedNotifications,
   emitTransactionStatusUpdate,
   emitTransactionUpdate,
   encodeUint8Array,
@@ -57,6 +61,7 @@ import {
   TransactionSignatureService,
   PaginatedResourceDto,
   Pagination,
+  processTransactionStatus,
   safe,
   SchedulerService,
   Sorting,
@@ -78,9 +83,12 @@ export enum CancelTransactionOutcome {
 
 @Injectable()
 export class TransactionsService {
+  private readonly logger = new Logger(TransactionsService.name);
+
   constructor(
     @InjectRepository(Transaction) private repo: Repository<Transaction>,
     @InjectEntityManager() private entityManager: EntityManager,
+    @InjectDataSource() private dataSource: DataSource,
     private readonly approversService: ApproversService,
     private readonly transactionSignatureService: TransactionSignatureService,
     private readonly schedulerService: SchedulerService,
@@ -519,8 +527,32 @@ export class TransactionsService {
     // Create a map for quick lookup
     const transactionMap = new Map(transactions.map(t => [t.id, t]));
 
+    /* Preload existing signer rows so we can dedupe new inserts. Soft-deleted
+       UserKey rows are intentionally excluded below (TypeORM default) — a revoked
+       key must not regain signer access retroactively when a historical TTv1
+       signature is imported. */
+    const existingSigners = await this.entityManager.find(TransactionSigner, {
+      where: { transactionId: In(ids) },
+      select: ['transactionId', 'userKeyId'],
+    });
+    const signersByTransaction = new Map<number, Set<number>>();
+    for (const s of existingSigners) {
+      let set = signersByTransaction.get(s.transactionId);
+      if (!set) {
+        set = new Set<number>();
+        signersByTransaction.set(s.transactionId, set);
+      }
+      set.add(s.userKeyId);
+    }
+
     const results = new Map<number, SignatureImportResultDto>();
     const updates = new Map<number, UpdateRecord>();
+    const newSignerRows: { userId: number; transactionId: number; userKeyId: number }[] = [];
+    const notificationDismissals: { userId: number; transactionId: number }[] = [];
+    /* Transactions that passed per-DTO validation AND have at least one persistable
+       side-effect (new bytes OR new signer row). Status recomputation and NATS
+       emission operate on this set, not on `updates` alone. */
+    const transactionsToProcess = new Map<number, Transaction>();
 
     for (const { id, signatureMap: map } of dto) {
       const transaction = transactionMap.get(id);
@@ -552,15 +584,61 @@ export class TransactionsService {
           sdkTransaction.addSignature(publicKey, map);
         }
 
-        transaction.transactionBytes = Buffer.from(sdkTransaction.toBytes());
+        const originalBytes = transaction.transactionBytes;
+        const newBytes = Buffer.from(sdkTransaction.toBytes());
+        const isSameBytes = newBytes.equals(originalBytes);
 
-        results.set(id, { id });
-        updates.set(id, {
-          id,
-          transactionBytes: transaction.transactionBytes,
-          transactionId: transaction.transactionId,
-          network: transaction.mirrorNetwork,
-        });
+        /* Resolve each signing public key to its owning UserKey so we can record
+           the signer relation. Without this the signing user can't access the
+           transaction post-import because verifyAccess relies on transaction.signers.
+           Soft-deleted UserKey rows are excluded by TypeORM default (see preload
+           comment above). */
+        const newSignersForDto: { userId: number; transactionId: number; userKeyId: number }[] = [];
+        if (publicKeys.length > 0) {
+          const pubKeyStrings = new Set<string>();
+          for (const pk of publicKeys) {
+            pubKeyStrings.add(pk.toStringRaw());
+            pubKeyStrings.add(pk.toStringDer());
+          }
+          const userKeys = await this.entityManager.find(UserKey, {
+            where: { publicKey: In([...pubKeyStrings]) },
+          });
+          let txExistingSigners = signersByTransaction.get(id);
+          if (!txExistingSigners) {
+            txExistingSigners = new Set<number>();
+            signersByTransaction.set(id, txExistingSigners);
+          }
+          for (const uk of userKeys) {
+            if (txExistingSigners.has(uk.id)) continue;
+            txExistingSigners.add(uk.id);
+            newSignersForDto.push({ userId: uk.userId, transactionId: id, userKeyId: uk.id });
+          }
+        }
+
+        /* No-op import: bytes unchanged and no new signer rows. Skip DB writes and
+           NATS emission so duplicate imports don't produce spurious status-update
+           events. Matches the parity guard in SignersService.uploadSignatureMaps. */
+        if (isSameBytes && newSignersForDto.length === 0) {
+          results.set(id, { id });
+          continue;
+        }
+
+        if (!isSameBytes) {
+          transaction.transactionBytes = newBytes;
+          updates.set(id, {
+            id,
+            transactionBytes: newBytes,
+            transactionId: transaction.transactionId,
+            network: transaction.mirrorNetwork,
+          });
+        }
+
+        for (const row of newSignersForDto) {
+          newSignerRows.push(row);
+          notificationDismissals.push({ userId: row.userId, transactionId: id });
+        }
+
+        transactionsToProcess.set(id, transaction);
       } catch (error) {
         results.set(id, {
           id,
@@ -572,54 +650,144 @@ export class TransactionsService {
       }
     }
 
-    //Added a batch mechanism, probably should limit this on the api side of things
     const BATCH_SIZE = 500;
-
     const updateArray = Array.from(updates.values());
+    let dismissedRows: Array<{ id: number; userId: number }> = [];
+    let committed = false;
 
-    if (updateArray.length > 0) {
-      for (let i = 0; i < updateArray.length; i += BATCH_SIZE) {
-        const batch = updateArray.slice(i, i + BATCH_SIZE);
+    /* Persist atomically: transactionBytes updates, new signer rows, and notification
+       dismissals all succeed or all roll back. Without this wrapper, a signer insert
+       failure after a successful byte update would recreate the original access bug. */
+    if (updateArray.length > 0 || newSignerRows.length > 0) {
+      try {
+        await this.dataSource.transaction(async manager => {
+          if (updateArray.length > 0) {
+            for (let i = 0; i < updateArray.length; i += BATCH_SIZE) {
+              const batch = updateArray.slice(i, i + BATCH_SIZE);
 
-        let caseSQL = 'CASE id ';
-        const params: any = {};
+              let caseSQL = 'CASE id ';
+              const params: Record<string, unknown> = {};
 
-        batch.forEach((update, idx) => {
-          caseSQL += `WHEN :id${idx} THEN :bytes${idx}::bytea `;
-          params[`id${idx}`] = update.id;
-          params[`bytes${idx}`] = update.transactionBytes;
+              batch.forEach((update, idx) => {
+                caseSQL += `WHEN :id${idx} THEN :bytes${idx}::bytea `;
+                params[`id${idx}`] = update.id;
+                params[`bytes${idx}`] = update.transactionBytes;
+              });
+              caseSQL += 'END';
+
+              await manager
+                .createQueryBuilder()
+                .update(Transaction)
+                .set({ transactionBytes: () => caseSQL })
+                .where('id IN (:...ids)', { ids: batch.map(u => u.id) })
+                .setParameters(params)
+                .execute();
+            }
+          }
+
+          if (newSignerRows.length > 0) {
+            await manager
+              .createQueryBuilder()
+              .insert()
+              .into(TransactionSigner)
+              .values(newSignerRows)
+              .execute();
+          }
+
+          if (notificationDismissals.length > 0) {
+            const userIds = notificationDismissals.map(n => n.userId);
+            const txIds = notificationDismissals.map(n => n.transactionId);
+            const [rows] = await manager.query(
+              `
+              WITH input(user_id, tx_id) AS (
+                SELECT * FROM UNNEST($1::int[], $2::int[])
+              )
+              UPDATE notification_receiver nr
+              SET "isRead" = true,
+                  "updatedAt" = NOW()
+              FROM notification n, input i
+              WHERE nr."notificationId" = n.id
+                AND n.type = 'TRANSACTION_INDICATOR_SIGN'
+                AND i.tx_id = n."entityId"
+                AND i.user_id = nr."userId"
+                AND nr."isRead" = false
+              RETURNING nr.id, nr."userId"
+              `,
+              [userIds, txIds],
+            );
+            if (Array.isArray(rows)) {
+              dismissedRows = rows;
+            }
+          }
         });
-        caseSQL += 'END';
+        committed = true;
 
-        try {
-          await this.entityManager
-            .createQueryBuilder()
-            .update(Transaction)
-            .set({ transactionBytes: () => caseSQL })
-            .where('id IN (:...ids)', { ids: batch.map(u => u.id) })
-            .setParameters(params)
-            .execute();
+        for (const id of transactionsToProcess.keys()) {
+          results.set(id, { id });
+        }
+      } catch (err) {
+        this.logger.error(
+          'Failed to persist imported signatures atomically',
+          err instanceof Error ? err.stack : String(err),
+        );
+        const message = ErrorCodes.FST;
+        for (const id of transactionsToProcess.keys()) {
+          results.set(id, { id, error: message });
+        }
+        transactionsToProcess.clear();
+        dismissedRows = [];
+      }
+    }
 
-          // mark each update in the batch as succeeded
-          batch.forEach(u => results.set(u.id, { id: u.id }));
-        } catch (err) {
-          const SAVE_ERROR_PREFIX = 'An unexpected error occurred while saving the signatures';
-          const message =
-            err instanceof Error && err.message
-              ? `${SAVE_ERROR_PREFIX}: ${err.message}`
-              : SAVE_ERROR_PREFIX;
+    if (dismissedRows.length > 0) {
+      emitDismissedNotifications(this.notificationsPublisher, dismissedRows);
+    }
 
-          batch.forEach(u => results.set(u.id, { id: u.id, error: message }));
+    /* Re-evaluate status only for transactions whose writes actually committed.
+       Using transactionsToProcess (cleared on rollback) prevents promoting a tx to
+       WAITING_FOR_EXECUTION when the atomic write above rolled back and the DB
+       still holds the pre-import bytes. */
+    if (committed && transactionsToProcess.size > 0) {
+      let statusMap = new Map<number, TransactionStatus>();
+      try {
+        const result = await processTransactionStatus(
+          this.repo,
+          this.transactionSignatureService,
+          Array.from(transactionsToProcess.values()),
+        );
+        if (result) statusMap = result;
+      } catch (err) {
+        this.logger.error(
+          'processTransactionStatus failed on import',
+          err instanceof Error ? err.stack : String(err),
+        );
+      }
+
+      /* Partition by status change — mirrors SignersService.updateStatusesAndNotify
+         so downstream NATS consumers see a consistent payload shape regardless of
+         which signing path produced the update. */
+      const changed: number[] = [];
+      const unchanged: number[] = [];
+      for (const id of transactionsToProcess.keys()) {
+        if (statusMap.has(id)) {
+          changed.push(id);
+        } else {
+          unchanged.push(id);
         }
       }
 
-      emitTransactionStatusUpdate(
-        this.notificationsPublisher,
-        updateArray.map(r => ({
-          entityId: r.id,
-          additionalData: { transactionId: r.transactionId, network: r.network },
-        })),
-      );
+      if (changed.length > 0) {
+        emitTransactionStatusUpdate(
+          this.notificationsPublisher,
+          changed.map(id => ({ entityId: id })),
+        );
+      }
+      if (unchanged.length > 0) {
+        emitTransactionUpdate(
+          this.notificationsPublisher,
+          unchanged.map(id => ({ entityId: id })),
+        );
+      }
     }
 
     return Array.from(results.values());

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -505,8 +505,6 @@ export class TransactionsService {
     type UpdateRecord = {
       id: number;
       transactionBytes: Buffer;
-      transactionId: string;
-      network: string;
     };
 
     const ids = dto.map(d => d.id);
@@ -621,8 +619,6 @@ export class TransactionsService {
           updates.set(id, {
             id,
             transactionBytes: newBytes,
-            transactionId: transaction.transactionId,
-            network: transaction.mirrorNetwork,
           });
         }
 

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -527,10 +527,8 @@ export class TransactionsService {
     // Create a map for quick lookup
     const transactionMap = new Map(transactions.map(t => [t.id, t]));
 
-    /* Preload existing signer rows so we can dedupe new inserts. Soft-deleted
-       UserKey rows are intentionally excluded below (TypeORM default) — a revoked
-       key must not regain signer access retroactively when a historical TTv1
-       signature is imported. */
+    /* Soft-deleted UserKey rows are intentionally excluded (TypeORM default):
+       a revoked key must not regain signer access via a historical TTv1 import. */
     const existingSigners = await this.entityManager.find(TransactionSigner, {
       where: { transactionId: In(ids) },
       select: ['transactionId', 'userKeyId'],
@@ -549,9 +547,8 @@ export class TransactionsService {
     const updates = new Map<number, UpdateRecord>();
     const newSignerRows: { userId: number; transactionId: number; userKeyId: number }[] = [];
     const notificationDismissals: { userId: number; transactionId: number }[] = [];
-    /* Transactions that passed per-DTO validation AND have at least one persistable
-       side-effect (new bytes OR new signer row). Status recomputation and NATS
-       emission operate on this set, not on `updates` alone. */
+    /* Transactions with at least one persistable side-effect. Status recomputation
+       and NATS emission operate on this set, not on `updates` alone. */
     const transactionsToProcess = new Map<number, Transaction>();
 
     for (const { id, signatureMap: map } of dto) {
@@ -588,11 +585,8 @@ export class TransactionsService {
         const newBytes = Buffer.from(sdkTransaction.toBytes());
         const isSameBytes = newBytes.equals(originalBytes);
 
-        /* Resolve each signing public key to its owning UserKey so we can record
-           the signer relation. Without this the signing user can't access the
-           transaction post-import because verifyAccess relies on transaction.signers.
-           Soft-deleted UserKey rows are excluded by TypeORM default (see preload
-           comment above). */
+        /* Record the signer relation for each imported key — without this, the
+           signing user fails verifyAccess post-import (the original bug). */
         const newSignersForDto: { userId: number; transactionId: number; userKeyId: number }[] = [];
         if (publicKeys.length > 0) {
           const pubKeyStrings = new Set<string>();
@@ -615,9 +609,8 @@ export class TransactionsService {
           }
         }
 
-        /* No-op import: bytes unchanged and no new signer rows. Skip DB writes and
-           NATS emission so duplicate imports don't produce spurious status-update
-           events. Matches the parity guard in SignersService.uploadSignatureMaps. */
+        /* No-op: skip DB writes and NATS emission so duplicate imports don't
+           produce spurious status-update events. */
         if (isSameBytes && newSignersForDto.length === 0) {
           results.set(id, { id });
           continue;
@@ -655,9 +648,8 @@ export class TransactionsService {
     let dismissedRows: Array<{ id: number; userId: number }> = [];
     let committed = false;
 
-    /* Persist atomically: transactionBytes updates, new signer rows, and notification
-       dismissals all succeed or all roll back. Without this wrapper, a signer insert
-       failure after a successful byte update would recreate the original access bug. */
+    /* Atomic write: bytes, signer rows, and dismissals must all commit together —
+       a half-applied write recreates the original access bug. */
     if (updateArray.length > 0 || newSignerRows.length > 0) {
       try {
         await this.dataSource.transaction(async manager => {
@@ -743,10 +735,8 @@ export class TransactionsService {
       emitDismissedNotifications(this.notificationsPublisher, dismissedRows);
     }
 
-    /* Re-evaluate status only for transactions whose writes actually committed.
-       Using transactionsToProcess (cleared on rollback) prevents promoting a tx to
-       WAITING_FOR_EXECUTION when the atomic write above rolled back and the DB
-       still holds the pre-import bytes. */
+    /* Re-evaluate status only after a successful commit — transactionsToProcess
+       is cleared on rollback to prevent promoting a tx whose bytes never landed. */
     if (committed && transactionsToProcess.size > 0) {
       let statusMap = new Map<number, TransactionStatus>();
       try {
@@ -763,9 +753,8 @@ export class TransactionsService {
         );
       }
 
-      /* Partition by status change — mirrors SignersService.updateStatusesAndNotify
-         so downstream NATS consumers see a consistent payload shape regardless of
-         which signing path produced the update. */
+      /* Mirror SignersService.updateStatusesAndNotify so NATS consumers see a
+         consistent payload shape regardless of which signing path produced it. */
       const changed: number[] = [];
       const unchanged: number[] = [];
       for (const id of transactionsToProcess.keys()) {

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -670,7 +670,7 @@ export class TransactionsService {
               await manager
                 .createQueryBuilder()
                 .update(Transaction)
-                .set({ transactionBytes: () => caseSQL })
+                .set({ transactionBytes: () => caseSQL, updatedAt: () => 'NOW()' })
                 .where('id IN (:...ids)', { ids: batch.map(u => u.id) })
                 .setParameters(params)
                 .execute();


### PR DESCRIPTION
Fixes: [2552](https://github.com/hashgraph/hedera-transaction-tool/issues/2522)

**Problem**
After importing User B's signature from a TTv1 zip, User B got 401 Unauthorized when opening the transaction details from Ready to sign or In progress. The History tab worked because executed transactions skip the access check.

Root cause: `importSignatures` only updated `transaction.transactionBytes` — it never inserted a `transaction_signer` row for the imported signer. `verifyAccess` grants access on five predicates (creator, observer, key-still-required, signer row, approver). Once B's signature was embedded in the bytes, B's key was no longer "required to sign", and with no signer row, all five predicates failed.

So it mutated the transaction's bytes (embedding User B's signature in the protobuf signature map) but never inserted a `transaction_signer` row for the imported signer. 

The same scenario does not break the in-app sign flow, because that flow goes through `SignersService.uploadSignatureMaps`, which does insert `transaction_signer` rows, dismiss pending sign-reminder notifications, and re-evaluate transaction status. _The TTv1 import path simply skipped all of that_.

**Solution**
Bring `importSignatures` to parity with `uploadSignatureMaps`:

- Insert `transaction_signer` rows for each imported signature — resolved from public key to `UserKey` (matched on both `toStringRaw` and `toStringDer`), deduped against existing rows.
- Atomic persistence — bytes update + signer insert + notification dismissal wrapped in a single `dataSource.transaction(...).` On rollback, all touched ids are marked `ErrorCodes.FST` and status recompute is skipped.
- Dismiss pending sign-reminder notifications for the owners of the imported keys.
- Skip no-op imports (same bytes + no new signer rows) to avoid spurious NATS events.
- Recompute transaction status post-commit so threshold-satisfied transactions advance to WAITING_FOR_EXECUTION. Emission split into changed (`emitTransactionStatusUpdate`) vs unchanged (`emitTransactionUpdate`) to match SignersService.

**Reproduction**
- As User A, create a multi-sig transaction (e.g., AccountUpdate on an account whose key is KeyList(A.pub, B.pub)) — both A and B's signatures are required.
 - As User A, sign in the UI and export the transaction (TTv1 .tx file).
- Sign the file externally with User B's private key, producing a TTv1 zip ({transaction.tx, signatures.json}).
- As User A, import the zip via the TTv1 import flow.
- Log in as User B → open the transaction details → 401 Unauthorized.