### PR TITLE
chore: disable no-unused-vars rule for variables and arguments prefixed with _

### DIFF
--- a/front-end/eslint.config.cjs
+++ b/front-end/eslint.config.cjs
@@ -29,7 +29,13 @@ module.exports = [
       'vue/require-default-prop': 'off',
       'vue/multi-word-component-names': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+        },
+      ],
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
       'newline-per-chained-call': 'off',

--- a/front-end/src/renderer/components/Transaction/TransactionProcessor/requests.ts
+++ b/front-end/src/renderer/components/Transaction/TransactionProcessor/requests.ts
@@ -80,7 +80,6 @@ export class CustomRequest extends BaseRequest {
     this.description = opts.description ?? '';
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async deriveRequestKey(_mirrorNodeBaseURL: string, _accountInfoCache: AccountByIdCache) {
     throw new Error('Not implemented');
   }

--- a/front-end/src/renderer/services/organization/transaction.ts
+++ b/front-end/src/renderer/services/organization/transaction.ts
@@ -153,8 +153,8 @@ export const importSignatures = async (
 
 /* Get if user should approve a transaction */
 export const getUserShouldApprove = async (
-  _serverUrl: string, // eslint-disable-line @typescript-eslint/no-unused-vars
-  _transactionId: number, // eslint-disable-line @typescript-eslint/no-unused-vars
+  _serverUrl: string,
+  _transactionId: number,
 ): Promise<boolean> =>
   commonRequestHandler(async () => {
     //TODO Approve is not implemented yet, and doing it this way is not correct

--- a/front-end/src/renderer/utils/transactionSignatureModels/transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/transaction.model.ts
@@ -44,7 +44,6 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
     return [];
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getNodeKeys(
     _mirrorNodeLink: string,
     _accountInfoCache: AccountByIdCache,
@@ -53,7 +52,6 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
     return null;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getNewNodeAccountKeys(
     _mirrorNodeLink: string,
     _accountInfoCache: AccountByIdCache,


### PR DESCRIPTION
**Description**:

Modify ESLint configuration such that variables and arguments prefixed with `_`  (underscore) will now be ignored by the `no-unused-vars` rule.
