### PR TITLE
fix: cannot set threshold key as file key

### DIFF
--- a/front-end/src/renderer/components/ComplexKey/ComplexKey.vue
+++ b/front-end/src/renderer/components/ComplexKey/ComplexKey.vue
@@ -5,9 +5,15 @@ import { Key, KeyList } from '@hiero-ledger/sdk';
 import ComplexKeyThreshold from '@renderer/components/ComplexKey/ComplexKeyThreshold.vue';
 
 /* Props */
-const props = defineProps<{
-  modelKey: Key | null;
-}>();
+const props = withDefaults(
+  defineProps<{
+    modelKey: Key | null;
+    noThreshold?: boolean;
+  }>(),
+  {
+    noThreshold: false,
+  },
+);
 
 /* Emits */
 const emit = defineEmits(['update:modelKey']);
@@ -38,5 +44,6 @@ onMounted(() => {
     @update:key-list="handleKeyListChange"
     :on-remove-key-list="handleKeyListRemove"
     :depth="'0'"
+    :no-threshold="noThreshold"
   />
 </template>

--- a/front-end/src/renderer/components/ComplexKey/ComplexKeyModal.vue
+++ b/front-end/src/renderer/components/ComplexKey/ComplexKeyModal.vue
@@ -124,6 +124,7 @@ const modalContentContainerStyle = { padding: '0 10%', height: '80%' };
               <div v-else>
                 <KeyStructure
                   :key-list="currentKey instanceof KeyList ? currentKey : new KeyList([])"
+                  :no-threshold="noThreshold"
                 />
               </div>
             </Transition>

--- a/front-end/src/renderer/components/ComplexKey/ComplexKeyModal.vue
+++ b/front-end/src/renderer/components/ComplexKey/ComplexKeyModal.vue
@@ -12,11 +12,17 @@ import ComplexKey from '@renderer/components/ComplexKey/ComplexKey.vue';
 import KeyStructure from '@renderer/components/KeyStructure.vue';
 
 /* Props */
-const props = defineProps<{
-  modelKey: Key | null;
-  show: boolean;
-  onSaveComplexKey?: () => void;
-}>();
+const props = withDefaults(
+  defineProps<{
+    modelKey: Key | null;
+    show: boolean;
+    onSaveComplexKey?: () => void;
+    noThreshold?: boolean;
+  }>(),
+  {
+    noThreshold: false,
+  },
+);
 
 /* Emits */
 const emit = defineEmits(['update:show', 'update:modelKey']);
@@ -109,7 +115,11 @@ const modalContentContainerStyle = { padding: '0 10%', height: '80%' };
           <div v-if="show" class="mt-5 h-100 overflow-auto">
             <Transition name="fade" :mode="'out-in'">
               <div v-if="!summaryMode">
-                <ComplexKey :model-key="currentKey" @update:model-key="handleComplexKeyUpdate" />
+                <ComplexKey
+                  :model-key="currentKey"
+                  :no-threshold="noThreshold"
+                  @update:model-key="handleComplexKeyUpdate"
+                />
               </div>
               <div v-else>
                 <KeyStructure

--- a/front-end/src/renderer/components/ComplexKey/ComplexKeySelectSavedKey.vue
+++ b/front-end/src/renderer/components/ComplexKey/ComplexKeySelectSavedKey.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ComplexKey } from '@prisma/client';
 
-import { computed, onBeforeMount, ref } from 'vue';
+import { computed, onBeforeMount, ref, withDefaults } from 'vue';
 
 import useUserStore from '@renderer/stores/storeUser';
 
@@ -16,10 +16,16 @@ import AppListItem from '@renderer/components/ui/AppListItem.vue';
 import AppCustomIcon from '@renderer/components/ui/AppCustomIcon.vue';
 
 /* Props */
-const props = defineProps<{
-  show: boolean;
-  onKeyListSelect: (complexKey: ComplexKey) => void;
-}>();
+const props = withDefaults(
+  defineProps<{
+    show: boolean;
+    onKeyListSelect: (complexKey: ComplexKey) => void;
+    noThreshold?: boolean;
+  }>(),
+  {
+    noThreshold: true,
+  },
+);
 
 /* Emits */
 const emit = defineEmits(['update:show']);
@@ -70,6 +76,17 @@ const handleDone = () => {
   }
 };
 
+/* Functions */
+const filterKeyList = (kl: ComplexKey): boolean => {
+  const keyList = decodeKeyList(kl.protobufEncoded);
+  return (
+    (kl.nickname.toLocaleLowerCase().includes(search.value.toLocaleLowerCase()) ||
+      keyList.toArray().length.toString().includes(search.value) ||
+      '' == search.value) &&
+    (keyList.threshold === null || !props.noThreshold)
+  );
+};
+
 /* Hooks */
 onBeforeMount(async () => {
   if (!isUserLoggedIn(user.personal)) {
@@ -88,27 +105,12 @@ onBeforeMount(async () => {
         </div>
         <h1 class="text-title text-semi-bold text-center">Saved Complex Keys</h1>
         <div class="mt-5">
-          <AppInput
-            :model-value="complexKey?.nickname"
-            filled
-            readonly
-            type="text"
-            placeholder="Search Complex Key"
-          />
+          <AppInput v-model="search" filled placeholder="Search Complex Key" type="text" />
         </div>
         <hr class="separator my-5" />
         <div>
           <div class="overflow-auto" :style="{ height: '20vh', paddingRight: '10px' }">
-            <template
-              v-for="kl in keyLists.filter(
-                kl =>
-                  kl.nickname.toLocaleLowerCase().includes(search.toLocaleLowerCase()) ||
-                  decodeKeyList(kl.protobufEncoded).toArray().length.toString().includes(search) ||
-                  decodeKeyList(kl.protobufEncoded).threshold ||
-                  '' == search,
-              )"
-              :key="kl.id"
-            >
+            <template v-for="kl in keyLists.filter(filterKeyList)" :key="kl.id">
               <AppListItem
                 :value="kl.id"
                 @click="handleSelectKeyList(kl.id)"
@@ -123,16 +125,14 @@ onBeforeMount(async () => {
                       {{ kl.nickname }}
                     </span>
                     <p
-                      class="text-body bg-dark-blue-800 flex-centered rounded ms-3"
-                      style="width: 36px; height: 36px"
+                      v-if="decodeKeyList(kl.protobufEncoded).threshold !== null"
+                      class="text-secondary ms-3"
                     >
-                      {{
-                        decodeKeyList(kl.protobufEncoded).threshold ||
-                        decodeKeyList(kl.protobufEncoded).toArray().length
-                      }}
+                      ({{ decodeKeyList(kl.protobufEncoded).threshold }} of
+                      {{ decodeKeyList(kl.protobufEncoded).toArray().length }})
                     </p>
-                    <p class="text-secondary ms-3">
-                      of {{ decodeKeyList(kl.protobufEncoded).toArray().length }}
+                    <p v-else class="text-secondary ms-3">
+                      ({{ decodeKeyList(kl.protobufEncoded).toArray().length }})
                     </p>
                     <p class="text-secondary border-start border-secondary-subtle ps-4 ms-4">
                       {{ kl.updated_at.toDateString() }}

--- a/front-end/src/renderer/components/ComplexKey/ComplexKeySelectSavedKey.vue
+++ b/front-end/src/renderer/components/ComplexKey/ComplexKeySelectSavedKey.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ComplexKey } from '@prisma/client';
 
-import { computed, onBeforeMount, ref, withDefaults } from 'vue';
+import { computed, onBeforeMount, ref } from 'vue';
 
 import useUserStore from '@renderer/stores/storeUser';
 
@@ -23,7 +23,7 @@ const props = withDefaults(
     noThreshold?: boolean;
   }>(),
   {
-    noThreshold: true,
+    noThreshold: false,
   },
 );
 
@@ -82,7 +82,7 @@ const filterKeyList = (kl: ComplexKey): boolean => {
   return (
     (kl.nickname.toLocaleLowerCase().includes(search.value.toLocaleLowerCase()) ||
       keyList.toArray().length.toString().includes(search.value) ||
-      '' == search.value) &&
+      search.value === '') &&
     (keyList.threshold === null || !props.noThreshold)
   );
 };

--- a/front-end/src/renderer/components/ComplexKey/ComplexKeyThreshold.vue
+++ b/front-end/src/renderer/components/ComplexKey/ComplexKeyThreshold.vue
@@ -16,11 +16,18 @@ import ComplexKeyAddPublicKeyModal from '@renderer/components/ComplexKey/Complex
 import ComplexKeySelectAccountModal from '@renderer/components/ComplexKey/ComplexKeySelectAccountModal.vue';
 
 /* Props */
-const props = defineProps<{
-  keyList: KeyList;
-  onRemoveKeyList: () => void;
-  depth?: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    keyList: KeyList;
+    onRemoveKeyList: () => void;
+    depth?: string;
+    noThreshold?: boolean;
+  }>(),
+  {
+    depth: '0',
+    noThreshold: false,
+  },
+);
 
 /* Emits */
 const emit = defineEmits(['update:keyList']);
@@ -100,7 +107,7 @@ const handleKeyListUpdate = (index: number, newKeyList: KeyList) => {
   emit('update:keyList', newParentKeyList);
 };
 
-/* Funtions */
+/* Functions */
 function emitNewKeyList(keys: Key[], threshold: number | null) {
   const newKeyList = new KeyList(keys, threshold);
   emit('update:keyList', newKeyList);
@@ -124,8 +131,8 @@ function emitNewKeyList(keys: Key[], threshold: number | null) {
           @click="areChildrenShown = !areChildrenShown"
         ></span>
       </Transition>
-      <p class="text-small text-semi-bold ms-3">Threshold</p>
-      <div class="ms-3">
+      <p class="text-small text-semi-bold ms-3">{{ noThreshold ? 'Key list' : 'Threshold' }}</p>
+      <div v-if="!noThreshold" class="ms-3">
         <select
           class="form-select is-fill"
           :value="keyList.threshold || keyList.toArray().length"
@@ -170,6 +177,7 @@ function emitNewKeyList(keys: Key[], threshold: number | null) {
               <span class="text-small">Public Key</span>
             </li>
             <li
+              v-if="!noThreshold"
               class="dropdown-item cursor-pointer mt-3"
               @click="handleAddThreshold"
               :data-testid="`button-complex-key-add-element-threshold-${depth}`"
@@ -222,6 +230,7 @@ function emitNewKeyList(keys: Key[], threshold: number | null) {
               @update:key-list="newKeyList => handleKeyListUpdate(i, newKeyList)"
               :on-remove-key-list="() => handleRemoveThreshold(i)"
               :depth="`${depth || 0}-${i}`"
+              :no-threshold="noThreshold"
             />
           </div>
         </template>

--- a/front-end/src/renderer/components/KeyField.vue
+++ b/front-end/src/renderer/components/KeyField.vue
@@ -35,9 +35,11 @@ const props = withDefaults(
     modelKey: Key | null;
     isRequired?: boolean;
     label?: string;
+    noThreshold?: boolean;
   }>(),
   {
     label: 'Key',
+    noThreshold: false,
   },
 );
 
@@ -224,6 +226,7 @@ watch([() => props.modelKey, publicKeyInputRef], async ([newKey, newInputRef]) =
           :model-key="modelKey"
           @update:model-key="handleComplexKeyUpdate"
           :on-save-complex-key="selectedComplexKey ? undefined : handleSaveComplexKeyButtonClick"
+          :no-threshold="noThreshold"
         >
           <ComplexKeySaveKeyModal
             v-if="saveKeyListModalShown && modelKey instanceof KeyList && true"

--- a/front-end/src/renderer/components/KeyField.vue
+++ b/front-end/src/renderer/components/KeyField.vue
@@ -149,7 +149,7 @@ watch(currentTab, tab => {
 watch(
   () => props.modelKey,
   async newKey => {
-    if (newKey && newKey instanceof PublicKey && true) {
+    if (newKey && newKey instanceof PublicKey) {
       const formatted = await formatPublicKey(newKey.toStringRaw(), publicKeyOwnerCache);
       formattedKey.value = formatted;
       identifier.value = extractIdentifier(formatted)?.identifier;
@@ -273,6 +273,7 @@ watch([() => props.modelKey, publicKeyInputRef], async ([newKey, newInputRef]) =
           v-if="selectSavedKeyModalShown"
           v-model:show="selectSavedKeyModalShown"
           :on-key-list-select="handleSelectSavedComplexKey"
+          :no-threshold="noThreshold"
         />
       </template>
     </div>

--- a/front-end/src/renderer/components/KeyStructure.vue
+++ b/front-end/src/renderer/components/KeyStructure.vue
@@ -4,16 +4,23 @@ import { KeyList, PublicKey } from '@hiero-ledger/sdk';
 import AppPublicKeyNickname from '@renderer/components/ui/AppPublicKeyNickname.vue';
 
 /* Props */
-defineProps<{
-  keyList: KeyList;
-}>();
+withDefaults(
+  defineProps<{
+    keyList: KeyList;
+    noThreshold?: boolean;
+  }>(),
+  {
+    noThreshold: false,
+  },
+);
 
 /* Emits */
 defineEmits(['update:keyList']);
 </script>
 <template>
   <div class="text-nowrap">
-    <p>
+    <p v-if="noThreshold">Key List of {{ keyList.toArray().length }}</p>
+    <p v-else>
       Threshold ({{
         !keyList.threshold || keyList.threshold === keyList.toArray().length
           ? keyList.toArray().length

--- a/front-end/src/renderer/components/Transaction/Create/FileAppend/FileAppendFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileAppend/FileAppendFormData.vue
@@ -74,7 +74,7 @@ const columnClass = 'col-4 col-xxxl-3';
         @update:model-key="$emit('update:signatureKey', $event)"
         is-required
         label="Signature Key"
-        :noThreshold="true"
+        :no-threshold="true"
       />
     </div>
   </div>

--- a/front-end/src/renderer/components/Transaction/Create/FileAppend/FileAppendFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileAppend/FileAppendFormData.vue
@@ -74,6 +74,7 @@ const columnClass = 'col-4 col-xxxl-3';
         @update:model-key="$emit('update:signatureKey', $event)"
         is-required
         label="Signature Key"
+        :noThreshold="true"
       />
     </div>
   </div>

--- a/front-end/src/renderer/components/Transaction/Create/FileData/FileDataFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileData/FileDataFormData.vue
@@ -40,6 +40,7 @@ const { dateTimeSettingLabel } = useDateTimeSetting();
         "
         :is-required="keyRequired"
         :label="keyRequired ? 'Owner Key' : 'New Key'"
+        :noThreshold="true"
       />
     </div>
   </div>

--- a/front-end/src/renderer/components/Transaction/Create/FileData/FileDataFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileData/FileDataFormData.vue
@@ -40,7 +40,7 @@ const { dateTimeSettingLabel } = useDateTimeSetting();
         "
         :is-required="keyRequired"
         :label="keyRequired ? 'Owner Key' : 'New Key'"
-        :noThreshold="true"
+        :no-threshold="true"
       />
     </div>
   </div>

--- a/front-end/src/renderer/components/Transaction/Create/FileUpdate/FileUpdateFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileUpdate/FileUpdateFormData.vue
@@ -60,7 +60,7 @@ const columnClass = 'col-4 col-xxxl-3';
         @update:model-key="$emit('update:signatureKey', $event)"
         is-required
         label="Signature Key"
-        :noThreshold="true"
+        :no-threshold="true"
       />
     </div>
   </div>

--- a/front-end/src/renderer/components/Transaction/Create/FileUpdate/FileUpdateFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileUpdate/FileUpdateFormData.vue
@@ -60,6 +60,7 @@ const columnClass = 'col-4 col-xxxl-3';
         @update:model-key="$emit('update:signatureKey', $event)"
         is-required
         label="Signature Key"
+        :noThreshold="true"
       />
     </div>
   </div>

--- a/front-end/src/tests/renderer/components/ComplexKey/ComplexKeyThreshold.spec.ts
+++ b/front-end/src/tests/renderer/components/ComplexKey/ComplexKeyThreshold.spec.ts
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { KeyList } from '@hiero-ledger/sdk';
+
+import ComplexKeyThreshold from '@renderer/components/ComplexKey/ComplexKeyThreshold.vue';
+
+const mocks = vi.hoisted(() => ({
+  userStore: { keyPairs: [] },
+  contactsStore: {
+    getContactByPublicKey: vi.fn(() => null),
+  },
+  toastManager: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('@renderer/stores/storeUser', () => ({
+  default: vi.fn(() => mocks.userStore),
+}));
+
+vi.mock('@renderer/stores/storeContacts', () => ({
+  default: vi.fn(() => mocks.contactsStore),
+}));
+
+vi.mock('@renderer/utils/ToastManager', () => ({
+  ToastManager: {
+    inject: vi.fn(() => mocks.toastManager),
+  },
+}));
+
+vi.mock('@renderer/utils', () => ({
+  isPublicKeyInKeyList: vi.fn(() => false),
+}));
+
+vi.mock('@renderer/utils/userStoreHelpers', () => ({
+  getNickname: vi.fn(() => null),
+}));
+
+const globalStubs = {
+  AppButton: { template: '<button data-stub="app-button"><slot /></button>' },
+  AppPublicKeyInput: { template: '<div />' },
+  ComplexKeyAddPublicKeyModal: { template: '<div />' },
+  ComplexKeySelectAccountModal: { template: '<div />' },
+};
+
+describe('ComplexKeyThreshold.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mountThreshold(props: Record<string, unknown> = {}) {
+    return mount(ComplexKeyThreshold, {
+      props: {
+        keyList: new KeyList([]),
+        onRemoveKeyList: vi.fn(),
+        ...props,
+      },
+      global: { stubs: globalStubs },
+    });
+  }
+
+  describe('label rendering', () => {
+    it('shows "Threshold" label when noThreshold is false (default)', () => {
+      const wrapper = mountThreshold();
+      const label = wrapper.find('p.text-small.text-semi-bold');
+      expect(label.text()).toBe('Threshold');
+    });
+
+    it('shows "Key list" label when noThreshold is true', () => {
+      const wrapper = mountThreshold({ noThreshold: true });
+      const label = wrapper.find('p.text-small.text-semi-bold');
+      expect(label.text()).toBe('Key list');
+    });
+  });
+
+  describe('threshold select', () => {
+    it('renders the threshold select when noThreshold is false', () => {
+      const wrapper = mountThreshold();
+      expect(wrapper.find('[data-testid="select-complex-key-threshold-0"]').exists()).toBe(true);
+    });
+
+    it('hides the threshold select when noThreshold is true', () => {
+      const wrapper = mountThreshold({ noThreshold: true });
+      expect(wrapper.find('[data-testid="select-complex-key-threshold-0"]').exists()).toBe(false);
+    });
+  });
+
+  describe('"Add Threshold" dropdown item', () => {
+    it('renders the "Threshold" option in add dropdown when noThreshold is false', () => {
+      const wrapper = mountThreshold();
+      expect(
+        wrapper.find('[data-testid="button-complex-key-add-element-threshold-0"]').exists(),
+      ).toBe(true);
+    });
+
+    it('hides the "Threshold" option in add dropdown when noThreshold is true', () => {
+      const wrapper = mountThreshold({ noThreshold: true });
+      expect(
+        wrapper.find('[data-testid="button-complex-key-add-element-threshold-0"]').exists(),
+      ).toBe(false);
+    });
+  });
+
+  describe('noThreshold prop propagation to nested thresholds', () => {
+    it('passes noThreshold=true to nested ComplexKeyThreshold', async () => {
+      // Mount without stub so nested ComplexKeyThreshold is real
+      const nestedKeyList = new KeyList([new KeyList([])]);
+      const wrapper = mount(ComplexKeyThreshold, {
+        props: {
+          keyList: nestedKeyList,
+          onRemoveKeyList: vi.fn(),
+          noThreshold: true,
+        },
+      });
+
+      // Both root and nested nodes should show "Key list" label, not "Threshold"
+      const labels = wrapper.findAll('p.text-small.text-semi-bold');
+      expect(labels.length).toBeGreaterThan(0);
+      labels.forEach(label => {
+        expect(label.text()).toBe('Key list');
+      });
+    });
+  });
+});

--- a/front-end/src/tests/renderer/components/ComplexKey/KeyStructure.spec.ts
+++ b/front-end/src/tests/renderer/components/ComplexKey/KeyStructure.spec.ts
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { KeyList, PublicKey } from '@hiero-ledger/sdk';
+
+import KeyStructure from '@renderer/components/KeyStructure.vue';
+
+vi.mock('@renderer/components/ui/AppPublicKeyNickname.vue', () => ({
+  default: { template: '<span class="public-key-nickname" />' },
+}));
+
+// A valid DER-encoded ED25519 public key for test use
+const PK1 = '302a300506032b6570032100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const PK2 = '302a300506032b6570032100bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+describe('KeyStructure.vue', () => {
+  describe('noThreshold=true', () => {
+    it('shows "Key List of 0" header for an empty key list', () => {
+      const wrapper = mount(KeyStructure, {
+        props: { keyList: new KeyList([]), noThreshold: true },
+      });
+      expect(wrapper.find('p').text()).toBe('Key List of 0');
+    });
+
+    it('shows "Key List of N" header reflecting the number of keys', () => {
+      const pk = PublicKey.fromString(PK1);
+      const wrapper = mount(KeyStructure, {
+        props: { keyList: new KeyList([pk]), noThreshold: true },
+      });
+      expect(wrapper.find('p').text()).toBe('Key List of 1');
+    });
+
+    it('does not render a "Threshold" paragraph', () => {
+      const wrapper = mount(KeyStructure, {
+        props: { keyList: new KeyList([]), noThreshold: true },
+      });
+      expect(wrapper.find('p').text()).not.toContain('Threshold');
+    });
+  });
+
+  describe('noThreshold=false (default)', () => {
+    it('shows "Threshold (0 of 0)" for an empty key list', () => {
+      const wrapper = mount(KeyStructure, {
+        props: { keyList: new KeyList([]) },
+      });
+      expect(wrapper.find('p').text()).toBe('Threshold (0 of 0)');
+    });
+
+    it('shows explicit threshold when it differs from list size', () => {
+      const pk1 = PublicKey.fromString(PK1);
+      const pk2 = PublicKey.fromString(PK2);
+      const keyList = new KeyList([pk1, pk2], 1);
+      const wrapper = mount(KeyStructure, {
+        props: { keyList, noThreshold: false },
+      });
+      expect(wrapper.find('p').text()).toBe('Threshold (1 of 2)');
+    });
+
+    it('shows listSize as threshold when threshold equals list size', () => {
+      const pk1 = PublicKey.fromString(PK1);
+      const pk2 = PublicKey.fromString(PK2);
+      const keyList = new KeyList([pk1, pk2], 2);
+      const wrapper = mount(KeyStructure, {
+        props: { keyList, noThreshold: false },
+      });
+      expect(wrapper.find('p').text()).toBe('Threshold (2 of 2)');
+    });
+
+    it('does not render a "Key List" paragraph', () => {
+      const wrapper = mount(KeyStructure, {
+        props: { keyList: new KeyList([]) },
+      });
+      expect(wrapper.find('p').text()).not.toContain('Key List');
+    });
+  });
+
+  describe('public key rendering', () => {
+    it('renders one AppPublicKeyNickname per public key in the list', () => {
+      const pk1 = PublicKey.fromString(PK1);
+      const pk2 = PublicKey.fromString(PK2);
+      const wrapper = mount(KeyStructure, {
+        props: { keyList: new KeyList([pk1, pk2]), noThreshold: true },
+      });
+      expect(wrapper.findAll('.public-key-nickname')).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
**Description**:

Fixes #2740

When editing a complex key in the context of the creation of a FileCreate or FileUpdate transaction, the user may only provide a key list, without threshold. To achieve this, the UI components involved in editing a Complex Key gain a new `noThreshold` prop, which is set to true in the context of creating these File transactions.

Also fix the Search capability in the ComplexKeySelectSaveKey dialog.

**Default (current) behaviour**

<img width="821" height="390" alt="Screenshot 2026-05-05 at 09 48 15" src="https://github.com/user-attachments/assets/5792ef90-9b07-415f-8eb5-6cf52a2d9680" />
<img width="821" height="262" alt="Screenshot 2026-05-05 at 09 50 31" src="https://github.com/user-attachments/assets/8f275702-4538-4e70-ab62-acc61fdc8345" />

**Behaviour when noThreshold is set**

<img width="970" height="383" alt="Screenshot 2026-05-05 at 10 36 09" src="https://github.com/user-attachments/assets/ff8d6313-38b7-4c1f-846a-960d5812e78c" />
<img width="970" height="264" alt="Screenshot 2026-05-05 at 10 35 54" src="https://github.com/user-attachments/assets/e4bbff70-5911-4cf7-a164-d1762b3c7127" />

**Select Saved Complex Key dialog**

<img width="573" height="554" alt="Screenshot 2026-05-05 at 14 18 44" src="https://github.com/user-attachments/assets/c517d48d-d531-4470-8a07-321652ffbf32" />
