### PR TITLE
fix: make sure account balance is refreshed after transaction execution

### DIFF
--- a/front-end/src/renderer/composables/useAccountId.ts
+++ b/front-end/src/renderer/composables/useAccountId.ts
@@ -82,7 +82,8 @@ export default function useAccountId() {
       accountInfoController.value = new AbortController();
       const accountInfoRes = await accountByIdCache.lookup(
         baseId,
-        networkStore.mirrorNodeBaseURL
+        networkStore.mirrorNodeBaseURL,
+        true /* To get the latest balance */
       );
 
       allowancesController.value = new AbortController();


### PR DESCRIPTION
**Description**:

Change below force AccountByIdCache to load fresh data to make sure that `Account Creation` form displays the latest payer balance available.

**Related issue(s)**:

Fixes #2782

**Notes for reviewer**:

See #2782 for test scenario.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
