### PR TITLE
fix: unread badge doesn't support 3+ digits

### DIFF
--- a/front-end/src/renderer/components/ui/AppTabs.vue
+++ b/front-end/src/renderer/components/ui/AppTabs.vue
@@ -36,7 +36,7 @@ defineEmits(['update:active-index']);
           <span
             v-if="item.notifications"
             data-testid="span-notification-number"
-            class="notification d-inline-block rounded-circle bg-danger text-white"
+            class="badge tab-badge bg-danger text-white"
             >{{ item.notifications.toFixed(0) }}</span
           >
         </AppButton>
@@ -47,3 +47,13 @@ defineEmits(['update:active-index']);
     </div>
   </div>
 </template>
+<style scoped>
+.tab-badge {
+  border-radius: 16px;
+  font-size: 0.8rem;
+  padding: 0.3em 0.5em;
+  min-width: 1.6em;
+  height: 1.6em;
+  font-weight: 500;
+}
+</style>


### PR DESCRIPTION
**Description**:

Revamp the tab's unread badge such that it is able to display 3 (or more digits).

**Related issue(s)**:

Fixes #2753

**Before**:
<img width="165" height="75" alt="Screenshot 2026-05-06 at 12 20 47" src="https://github.com/user-attachments/assets/b106d2ed-f19d-4de4-8c47-e1f02f8f7407" />
<img width="165" height="75" alt="Screenshot 2026-05-06 at 12 21 02" src="https://github.com/user-attachments/assets/f7e7cbe8-3865-4997-939e-43e407851db1" />
<img width="165" height="75" alt="Screenshot 2026-05-06 at 12 21 31" src="https://github.com/user-attachments/assets/77b9bcae-fea1-4b77-8ebb-35d4af820ca9" />

**After**:
<img width="162" height="77" alt="Screenshot 2026-05-07 at 10 43 40" src="https://github.com/user-attachments/assets/2cbba933-8c8e-4852-8bcf-3d4cf0f73e1c" />
<img width="171" height="77" alt="Screenshot 2026-05-07 at 10 44 01" src="https://github.com/user-attachments/assets/24310340-317d-438f-815a-893c79868230" />
<img width="174" height="77" alt="Screenshot 2026-05-07 at 10 44 18" src="https://github.com/user-attachments/assets/31da48e5-0902-4af3-98da-798c116e07ca" />
