### PR TITLE
fix: app password leave dialog flow in a stale empty state

### DIFF
--- a/front-end/src/main/modules/ipcHandlers/localUser/organizationCredentials.ts
+++ b/front-end/src/main/modules/ipcHandlers/localUser/organizationCredentials.ts
@@ -7,6 +7,7 @@ import {
   deleteOrganizationCredentials,
   tryAutoSignIn,
   getOrganizationCredentials,
+  encryptOrganizationPassword,
 } from '@main/services/localUser';
 import { createIPCChannel, renameFunc } from '@main/utils/electronInfra';
 
@@ -21,5 +22,6 @@ export default () => {
     renameFunc(deleteOrganizationCredentials, 'deleteOrganizationCredentials'),
     renameFunc(getOrganizationCredentials, 'getOrganizationCredentials'),
     renameFunc(tryAutoSignIn, 'tryAutoSignIn'),
+    renameFunc(encryptOrganizationPassword, 'encryptOrganizationPassword'),
   ]);
 };

--- a/front-end/src/main/services/localUser/organizationCredentials.ts
+++ b/front-end/src/main/services/localUser/organizationCredentials.ts
@@ -291,12 +291,8 @@ export const tryAutoSignIn = async (user_id: string, decryptPassword: string | n
   return failedLogins;
 };
 
-/* Encrypts an organization password for local storage.
- * Surfaces keychain-deny / wrong-personal-password failures up front
- * so callers can abort before any other side effects. The thrown
- * Error has a mode-specific message so the UI can show the user what
- * actually went wrong, and preserves the original error as `cause`
- * so in-process logs retain the underlying stack. */
+// Surfaces keychain / personal-password failures synchronously so callers can abort
+// before triggering irreversible side effects (e.g. the backend password rotation).
 export const encryptOrganizationPassword = async (
   password: string,
   encryptPassword?: string | null,
@@ -314,6 +310,9 @@ export const encryptOrganizationPassword = async (
   }
 
   if (!useKeychain && !encryptPassword) {
+    logger.warn('encryptOrganizationPassword called without a viable encryption method', {
+      useKeychain,
+    });
     throw new Error('No encryption method available');
   }
 

--- a/front-end/src/main/services/localUser/organizationCredentials.ts
+++ b/front-end/src/main/services/localUser/organizationCredentials.ts
@@ -291,7 +291,7 @@ export const tryAutoSignIn = async (user_id: string, decryptPassword: string | n
   return failedLogins;
 };
 
-// Surfaces keychain / personal-password failures synchronously so callers can abort
+// Surfaces keychain / personal-password failures up front so callers can abort
 // before triggering irreversible side effects (e.g. the backend password rotation).
 export const encryptOrganizationPassword = async (
   password: string,

--- a/front-end/src/main/services/localUser/organizationCredentials.ts
+++ b/front-end/src/main/services/localUser/organizationCredentials.ts
@@ -204,11 +204,12 @@ export const updateOrganizationCredentials = async (
   password?: string | null,
   jwtToken?: string | null,
   encryptPassword?: string | null,
+  passwordIsEncrypted: boolean = false,
 ) => {
   const prisma = getPrismaClient();
 
   try {
-    if (password) {
+    if (password && !passwordIsEncrypted) {
       password = await encryptData(password, encryptPassword);
     }
 
@@ -288,6 +289,25 @@ export const tryAutoSignIn = async (user_id: string, decryptPassword: string | n
   }
 
   return failedLogins;
+};
+
+/* Encrypts an organization password for local storage.
+ * Surfaces keychain-deny / wrong-personal-password failures up front
+ * so callers can abort before any other side effects. */
+export const encryptOrganizationPassword = async (
+  password: string,
+  encryptPassword?: string | null,
+) => {
+  if (!password) {
+    throw new Error('Password is required to encrypt');
+  }
+
+  try {
+    return await encryptData(password, encryptPassword);
+  } catch (error) {
+    logger.error('Failed to encrypt organization password', { error });
+    throw new Error('Failed to encrypt organization password');
+  }
 };
 
 /* Encrypt data */

--- a/front-end/src/main/services/localUser/organizationCredentials.ts
+++ b/front-end/src/main/services/localUser/organizationCredentials.ts
@@ -293,20 +293,30 @@ export const tryAutoSignIn = async (user_id: string, decryptPassword: string | n
 
 /* Encrypts an organization password for local storage.
  * Surfaces keychain-deny / wrong-personal-password failures up front
- * so callers can abort before any other side effects. */
+ * so callers can abort before any other side effects. The thrown
+ * Error has a mode-specific message so the UI can show the user what
+ * actually went wrong, and preserves the original error as `cause`
+ * so logs retain the underlying stack. */
 export const encryptOrganizationPassword = async (
   password: string,
   encryptPassword?: string | null,
 ) => {
-  if (!password) {
-    throw new Error('Password is required to encrypt');
-  }
+  const useKeychain = await getUseKeychainClaim();
 
   try {
     return await encryptData(password, encryptPassword);
   } catch (error) {
-    logger.error('Failed to encrypt organization password', { error });
-    throw new Error('Failed to encrypt organization password');
+    logger.error('Failed to encrypt organization password', { error, useKeychain });
+
+    if (useKeychain) {
+      throw new Error('Keychain access denied or unavailable', { cause: error });
+    }
+
+    if (encryptPassword) {
+      throw new Error('Failed to encrypt with application password', { cause: error });
+    }
+
+    throw new Error('No encryption method available', { cause: error });
   }
 };
 

--- a/front-end/src/main/services/localUser/organizationCredentials.ts
+++ b/front-end/src/main/services/localUser/organizationCredentials.ts
@@ -296,27 +296,39 @@ export const tryAutoSignIn = async (user_id: string, decryptPassword: string | n
  * so callers can abort before any other side effects. The thrown
  * Error has a mode-specific message so the UI can show the user what
  * actually went wrong, and preserves the original error as `cause`
- * so logs retain the underlying stack. */
+ * so in-process logs retain the underlying stack. */
 export const encryptOrganizationPassword = async (
   password: string,
   encryptPassword?: string | null,
 ) => {
-  const useKeychain = await getUseKeychainClaim();
+  if (!password) {
+    throw new Error('Password is required to encrypt');
+  }
+
+  let useKeychain = false;
+  try {
+    useKeychain = await getUseKeychainClaim();
+  } catch (error) {
+    logger.error('Failed to encrypt organization password', { error });
+    throw new Error('Keychain access denied or unavailable', { cause: error });
+  }
+
+  if (!useKeychain && !encryptPassword) {
+    throw new Error('No encryption method available');
+  }
 
   try {
-    return await encryptData(password, encryptPassword);
+    if (useKeychain) {
+      const buffer = safeStorage.encryptString(password);
+      return buffer.toString('base64');
+    }
+    return encrypt(password, encryptPassword as string);
   } catch (error) {
     logger.error('Failed to encrypt organization password', { error, useKeychain });
-
     if (useKeychain) {
       throw new Error('Keychain access denied or unavailable', { cause: error });
     }
-
-    if (encryptPassword) {
-      throw new Error('Failed to encrypt with application password', { cause: error });
-    }
-
-    throw new Error('No encryption method available', { cause: error });
+    throw new Error('Failed to encrypt with application password', { cause: error });
   }
 };
 

--- a/front-end/src/preload/localUser/organizationCredentials.ts
+++ b/front-end/src/preload/localUser/organizationCredentials.ts
@@ -44,6 +44,7 @@ export default {
       password?: string | null,
       jwtToken?: string | null,
       encryptPassword?: string,
+      passwordIsEncrypted: boolean = false,
     ): Promise<boolean> =>
       ipcRenderer.invoke(
         'organizationCredentials:updateOrganizationCredentials',
@@ -52,6 +53,16 @@ export default {
         email,
         password,
         jwtToken,
+        encryptPassword,
+        passwordIsEncrypted,
+      ),
+    encryptOrganizationPassword: (
+      password: string,
+      encryptPassword?: string | null,
+    ): Promise<string> =>
+      ipcRenderer.invoke(
+        'organizationCredentials:encryptOrganizationPassword',
+        password,
         encryptPassword,
       ),
     deleteOrganizationCredentials: (organization_id: string, user_id: string): Promise<boolean> =>

--- a/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
@@ -40,7 +40,7 @@ const user = useUserStore();
 /* Composables */
 const router = useRouter();
 const withLoader = useLoader();
-const { getPassword, passwordModalOpened } = usePersonalPassword();
+const { getPasswordAsync } = usePersonalPassword();
 
 /* Injected */
 const toastManager = ToastManager.inject();
@@ -79,10 +79,12 @@ const handleChangePassword = async () => {
     if (newPasswordInvalid.value) throw new Error('Password must be at least 10 characters long');
 
     if (isLoggedInOrganization(user.selectedOrganization)) {
-      const personalPassword = getPassword(handleChangePassword, {
+      // Linear flow: confirm modal stays open with isChangingPassword = true while the
+      // personal-password modal is on top. Loading state is visible end-to-end.
+      const personalPassword = await getPasswordAsync({
         subHeading: 'Enter your application password to encrypt your organization credentials',
       });
-      if (passwordModalOpened(personalPassword)) return;
+      if (personalPassword === false) return; // user cancelled the personal-password modal
 
       // Encrypt before the BE rotation so a keychain / personal-password failure aborts before
       // the backend is touched.

--- a/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
@@ -13,7 +13,10 @@ import useLoader from '@renderer/composables/useLoader';
 
 import { changePassword } from '@renderer/services/userService';
 import { changePassword as organizationChangePassword } from '@renderer/services/organization/auth';
-import { updateOrganizationCredentials } from '@renderer/services/organizationCredentials';
+import {
+  encryptOrganizationPassword,
+  updateOrganizationCredentials,
+} from '@renderer/services/organizationCredentials';
 import { logout } from '@renderer/services/organization';
 
 import {
@@ -81,6 +84,13 @@ const handleChangePassword = async () => {
       });
       if (passwordModalOpened(personalPassword)) return;
 
+      /* Encrypt-first: surface keychain-deny / wrong-personal-password failures
+       * before the irreversible backend password change. */
+      const encryptedNewPassword = await encryptOrganizationPassword(
+        newPassword.value,
+        personalPassword || undefined,
+      );
+
       await organizationChangePassword(
         user.selectedOrganization.serverUrl,
         currentPassword.value,
@@ -91,9 +101,10 @@ const handleChangePassword = async () => {
         user.selectedOrganization.id,
         user.personal.id,
         undefined,
-        newPassword.value,
+        encryptedNewPassword,
         undefined,
-        personalPassword || undefined,
+        undefined,
+        true,
       );
 
       if (!isUpdated) {
@@ -107,14 +118,14 @@ const handleChangePassword = async () => {
 
     isConfirmModalShown.value = false;
     isSuccessModalShown.value = true;
+    currentPassword.value = '';
+    newPassword.value = '';
 
     await user.refetchAccounts();
   } catch (error) {
     toastManager.error(getErrorMessage(error, 'Failed to change password'));
   } finally {
     isChangingPassword.value = false;
-    currentPassword.value = '';
-    newPassword.value = '';
   }
 };
 

--- a/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
@@ -84,7 +84,8 @@ const handleChangePassword = async () => {
       });
       if (passwordModalOpened(personalPassword)) return;
 
-      // Encrypt before the BE rotation so a keychain failure aborts cleanly with both stores in sync.
+      // Encrypt before the BE rotation so a keychain / personal-password failure aborts before
+      // the backend is touched.
       const encryptedNewPassword = await encryptOrganizationPassword(
         newPassword.value,
         personalPassword || undefined,

--- a/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
@@ -84,8 +84,7 @@ const handleChangePassword = async () => {
       });
       if (passwordModalOpened(personalPassword)) return;
 
-      /* Encrypt-first: surface keychain-deny / wrong-personal-password failures
-       * before the irreversible backend password change. */
+      // Encrypt before the BE rotation so a keychain failure aborts cleanly with both stores in sync.
       const encryptedNewPassword = await encryptOrganizationPassword(
         newPassword.value,
         personalPassword || undefined,

--- a/front-end/src/renderer/services/organizationCredentials.ts
+++ b/front-end/src/renderer/services/organizationCredentials.ts
@@ -53,6 +53,7 @@ export const updateOrganizationCredentials = async (
   password?: string | null,
   jwtToken?: string | null,
   encryptPassword?: string,
+  passwordIsEncrypted: boolean = false,
 ) =>
   commonIPCHandler(async () => {
     return await window.electronAPI.local.organizationCredentials.updateOrganizationCredentials(
@@ -62,8 +63,23 @@ export const updateOrganizationCredentials = async (
       password,
       jwtToken,
       encryptPassword,
+      passwordIsEncrypted,
     );
   }, 'Failed to store organization credentials');
+
+/* Encrypts a password for organization credentials storage.
+ * Use this to surface keychain/personal-password failures up front,
+ * before any irreversible side effects (e.g. backend password change). */
+export const encryptOrganizationPassword = async (
+  password: string,
+  encryptPassword?: string | null,
+) =>
+  commonIPCHandler(async () => {
+    return await window.electronAPI.local.organizationCredentials.encryptOrganizationPassword(
+      password,
+      encryptPassword,
+    );
+  }, 'Failed to encrypt organization password');
 
 /* Deletes the organization credentials */
 export const deleteOrganizationCredentials = async (organization_id: string, user_id: string) =>

--- a/front-end/src/renderer/services/organizationCredentials.ts
+++ b/front-end/src/renderer/services/organizationCredentials.ts
@@ -67,9 +67,6 @@ export const updateOrganizationCredentials = async (
     );
   }, 'Failed to store organization credentials');
 
-/* Encrypts a password for organization credentials storage.
- * Use this to surface keychain/personal-password failures up front,
- * before any irreversible side effects (e.g. backend password change). */
 export const encryptOrganizationPassword = async (
   password: string,
   encryptPassword?: string | null,

--- a/front-end/src/tests/main/services/localUser/organizationCredentials.spec.ts
+++ b/front-end/src/tests/main/services/localUser/organizationCredentials.spec.ts
@@ -7,6 +7,7 @@ import prisma from '@main/db/__mocks__/prisma';
 import {
   addOrganizationCredentials,
   deleteOrganizationCredentials,
+  encryptOrganizationPassword,
   getAccessToken,
   getOrganizationTokens,
   getCurrentUser,
@@ -576,6 +577,154 @@ describe('Services Local User Organization Credentials', () => {
       expect(() => updateOrganizationCredentials('123', '321', email, password)).rejects.toThrow(
         'Failed to update organization credentials',
       );
+    });
+
+    test('Should write the password as-is when passwordIsEncrypted is true (skips encryption)', async () => {
+      const email = 'email';
+      const alreadyEncryptedPassword = 'already-encrypted-blob';
+
+      prisma.organizationCredentials.findFirst.mockResolvedValue(organizationCredentials);
+
+      const result = await updateOrganizationCredentials(
+        '123',
+        '321',
+        email,
+        alreadyEncryptedPassword,
+        undefined,
+        undefined,
+        true,
+      );
+
+      expect(result).toBe(true);
+      expect(getUseKeychainClaim).not.toHaveBeenCalled();
+      expect(safeStorage.encryptString).not.toHaveBeenCalled();
+      expect(encrypt).not.toHaveBeenCalled();
+      expect(prisma.organizationCredentials.update).toHaveBeenCalledWith({
+        where: { id: organizationCredentials.id },
+        data: {
+          email,
+          password: alreadyEncryptedPassword,
+          jwtToken: organizationCredentials.jwtToken,
+        },
+      });
+    });
+
+    test('Should still encrypt when passwordIsEncrypted is explicitly false', async () => {
+      const email = 'email';
+      const password = 'password';
+      const encryptPassword = 'password for encryption';
+      const encryptedPassword = 'the encryption of password with encryptPassword';
+
+      vi.mocked(encrypt).mockReturnValue(encryptedPassword);
+      prisma.organizationCredentials.findFirst.mockResolvedValue(organizationCredentials);
+
+      await updateOrganizationCredentials(
+        '123',
+        '321',
+        email,
+        password,
+        undefined,
+        encryptPassword,
+        false,
+      );
+
+      expect(encrypt).toHaveBeenCalledWith(password, encryptPassword);
+      expect(prisma.organizationCredentials.update).toHaveBeenCalledWith({
+        where: { id: organizationCredentials.id },
+        data: { email, password: encryptedPassword, jwtToken: organizationCredentials.jwtToken },
+      });
+    });
+
+    test('Should not run the encrypt branch when password is empty even with passwordIsEncrypted=true', async () => {
+      const email = 'email';
+
+      prisma.organizationCredentials.findFirst.mockResolvedValue(organizationCredentials);
+
+      await updateOrganizationCredentials('123', '321', email, '', undefined, undefined, true);
+
+      // Empty string is the "clear the stored password" signal used by logout —
+      // we just need to confirm we did not run any encryption path on it.
+      expect(safeStorage.encryptString).not.toHaveBeenCalled();
+      expect(encrypt).not.toHaveBeenCalled();
+      expect(prisma.organizationCredentials.update).toHaveBeenCalledWith({
+        where: { id: organizationCredentials.id },
+        data: {
+          email,
+          password: '',
+          jwtToken: organizationCredentials.jwtToken,
+        },
+      });
+    });
+  });
+
+  describe('encryptOrganizationPassword', () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    test('Should encrypt with keychain when useKeychain claim is true', async () => {
+      const password = 'newPassword';
+      const encryptedBuffer = Buffer.from('keychain-encrypted-blob');
+
+      vi.mocked(getUseKeychainClaim).mockResolvedValue(true);
+      vi.mocked(safeStorage.encryptString).mockReturnValue(encryptedBuffer);
+
+      const result = await encryptOrganizationPassword(password, undefined);
+
+      expect(safeStorage.encryptString).toHaveBeenCalledWith(password);
+      expect(encrypt).not.toHaveBeenCalled();
+      expect(result).toEqual(encryptedBuffer.toString('base64'));
+    });
+
+    test('Should encrypt with the personal password when useKeychain claim is false', async () => {
+      const password = 'newPassword';
+      const personalPassword = 'personal-password';
+      const encryptedPassword = 'aes-encrypted-blob';
+
+      vi.mocked(getUseKeychainClaim).mockResolvedValue(false);
+      vi.mocked(encrypt).mockReturnValue(encryptedPassword);
+
+      const result = await encryptOrganizationPassword(password, personalPassword);
+
+      expect(encrypt).toHaveBeenCalledWith(password, personalPassword);
+      expect(safeStorage.encryptString).not.toHaveBeenCalled();
+      expect(result).toEqual(encryptedPassword);
+    });
+
+    test('Should throw if password is empty (caller bug - guards against silent no-op)', async () => {
+      await expect(encryptOrganizationPassword('', 'anything')).rejects.toThrow(
+        'Password is required to encrypt',
+      );
+      expect(getUseKeychainClaim).not.toHaveBeenCalled();
+      expect(safeStorage.encryptString).not.toHaveBeenCalled();
+      expect(encrypt).not.toHaveBeenCalled();
+    });
+
+    test('Should rethrow as a domain error when keychain encrypt throws (Deny scenario)', async () => {
+      const password = 'newPassword';
+
+      vi.mocked(getUseKeychainClaim).mockResolvedValue(true);
+      vi.mocked(safeStorage.encryptString).mockImplementation(() => {
+        throw new Error(
+          'Error while encrypting the text provided to safeStorage.encryptString. Encryption is not available.',
+        );
+      });
+
+      await expect(encryptOrganizationPassword(password, null)).rejects.toThrow(
+        'Failed to encrypt organization password',
+      );
+    });
+
+    test('Should rethrow as a domain error when no encryption method is available', async () => {
+      const password = 'newPassword';
+
+      vi.mocked(getUseKeychainClaim).mockResolvedValue(false);
+
+      await expect(encryptOrganizationPassword(password, null)).rejects.toThrow(
+        'Failed to encrypt organization password',
+      );
+      expect(safeStorage.encryptString).not.toHaveBeenCalled();
+      expect(encrypt).not.toHaveBeenCalled();
     });
   });
 

--- a/front-end/src/tests/main/services/localUser/organizationCredentials.spec.ts
+++ b/front-end/src/tests/main/services/localUser/organizationCredentials.spec.ts
@@ -640,10 +640,10 @@ describe('Services Local User Organization Credentials', () => {
 
       prisma.organizationCredentials.findFirst.mockResolvedValue(organizationCredentials);
 
+      // An empty password string is the "clear stored credential" signal used by logout — it must
+      // bypass the encryption branches and write through as-is.
       await updateOrganizationCredentials('123', '321', email, '', undefined, undefined, true);
 
-      // Empty string is the "clear the stored password" signal used by logout —
-      // we just need to confirm we did not run any encryption path on it.
       expect(safeStorage.encryptString).not.toHaveBeenCalled();
       expect(encrypt).not.toHaveBeenCalled();
       expect(prisma.organizationCredentials.update).toHaveBeenCalledWith({
@@ -689,13 +689,15 @@ describe('Services Local User Organization Credentials', () => {
       expect(encrypt).toHaveBeenCalledWith(password, personalPassword);
       expect(safeStorage.encryptString).not.toHaveBeenCalled();
       expect(result).toEqual(encryptedPassword);
+      expect(getUseKeychainClaim).toHaveBeenCalledTimes(1);
     });
 
-    test('Should reject with empty-password guard before touching getUseKeychainClaim', async () => {
-      await expect(encryptOrganizationPassword('', 'anything')).rejects.toThrow(
-        'Password is required to encrypt',
-      );
-      expect(getUseKeychainClaim).not.toHaveBeenCalled();
+    test('Should reject empty password without invoking encryption side effects', async () => {
+      const err = await encryptOrganizationPassword('', 'anything').catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toBe('Password is required to encrypt');
+      expect(err).not.toHaveProperty('cause');
       expect(safeStorage.encryptString).not.toHaveBeenCalled();
       expect(encrypt).not.toHaveBeenCalled();
     });
@@ -704,18 +706,16 @@ describe('Services Local User Organization Credentials', () => {
       const underlying = new Error('Keychain mode not initialized');
       vi.mocked(getUseKeychainClaim).mockRejectedValue(underlying);
 
-      const promise = encryptOrganizationPassword('newPassword', null);
+      const err = await encryptOrganizationPassword('newPassword', null).catch((e: unknown) => e);
 
-      await expect(promise).rejects.toThrow('Keychain access denied or unavailable');
-      // toHaveProperty uses Object.is — verifies the exact original reference was preserved as cause.
-      await expect(promise).rejects.toHaveProperty('cause', underlying);
-      // We must not reach the actual encryption attempt when claim resolution fails.
+      expect((err as Error).message).toBe('Keychain access denied or unavailable');
+      // toBe uses Object.is — locks in that the original reference is preserved on `cause`.
+      expect((err as Error).cause).toBe(underlying);
       expect(safeStorage.encryptString).not.toHaveBeenCalled();
       expect(encrypt).not.toHaveBeenCalled();
     });
 
     test('Should rethrow with the keychain-specific message when keychain encrypt throws (Deny scenario)', async () => {
-      const password = 'newPassword';
       const underlying = new Error(
         'Error while encrypting the text provided to safeStorage.encryptString. Encryption is not available.',
       );
@@ -725,15 +725,13 @@ describe('Services Local User Organization Credentials', () => {
         throw underlying;
       });
 
-      const promise = encryptOrganizationPassword(password, null);
+      const err = await encryptOrganizationPassword('newPassword', null).catch((e: unknown) => e);
 
-      await expect(promise).rejects.toThrow('Keychain access denied or unavailable');
-      await expect(promise).rejects.toHaveProperty('cause', underlying);
+      expect((err as Error).message).toBe('Keychain access denied or unavailable');
+      expect((err as Error).cause).toBe(underlying);
     });
 
     test('Should rethrow with the application-password message when AES encrypt throws', async () => {
-      const password = 'newPassword';
-      const personalPassword = 'personal-password';
       const underlying = new Error('AES failure');
 
       vi.mocked(getUseKeychainClaim).mockResolvedValue(false);
@@ -741,18 +739,21 @@ describe('Services Local User Organization Credentials', () => {
         throw underlying;
       });
 
-      const promise = encryptOrganizationPassword(password, personalPassword);
+      const err = await encryptOrganizationPassword('newPassword', 'personal-password').catch(
+        (e: unknown) => e,
+      );
 
-      await expect(promise).rejects.toThrow('Failed to encrypt with application password');
-      await expect(promise).rejects.toHaveProperty('cause', underlying);
+      expect((err as Error).message).toBe('Failed to encrypt with application password');
+      expect((err as Error).cause).toBe(underlying);
     });
 
-    test('Should reject with the no-method-available message before any encrypt call', async () => {
+    test('Should reject with the no-method-available message before any encrypt call (no cause)', async () => {
       vi.mocked(getUseKeychainClaim).mockResolvedValue(false);
 
-      await expect(encryptOrganizationPassword('newPassword', null)).rejects.toThrow(
-        'No encryption method available',
-      );
+      const err = await encryptOrganizationPassword('newPassword', null).catch((e: unknown) => e);
+
+      expect((err as Error).message).toBe('No encryption method available');
+      expect(err).not.toHaveProperty('cause');
       expect(safeStorage.encryptString).not.toHaveBeenCalled();
       expect(encrypt).not.toHaveBeenCalled();
     });

--- a/front-end/src/tests/main/services/localUser/organizationCredentials.spec.ts
+++ b/front-end/src/tests/main/services/localUser/organizationCredentials.spec.ts
@@ -27,6 +27,33 @@ import { decrypt, encrypt } from '@main/utils/crypto';
 import { login } from '@main/services/organization';
 import { getUseKeychainClaim } from '@main/services/localUser/claim';
 
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('@main/modules/logger', () => ({
+  default: vi.fn(),
+  createLogger: () => loggerMock,
+  getAppUpdateLogger: () => loggerMock,
+  getDatabaseLogger: () => loggerMock,
+  getLogsDirectoryPath: () => '/tmp/test-logs',
+  getLogFilePath: () => '/tmp/test-logs/app.log',
+  getLoggerSettings: () => ({
+    archiveCount: 5,
+    directory: '/tmp/test-logs',
+    fileName: 'app.log',
+    level: 'info',
+    maxSizeBytes: 5 * 1024 * 1024,
+  }),
+  logRendererMessage: vi.fn(),
+}));
+
 vi.mock('@main/db/prisma');
 vi.mock('electron', () => ({
   session: { fromPartition: vi.fn() },
@@ -708,6 +735,7 @@ describe('Services Local User Organization Credentials', () => {
 
       const err = await encryptOrganizationPassword('newPassword', null).catch((e: unknown) => e);
 
+      expect(err).toBeInstanceOf(Error);
       expect((err as Error).message).toBe('Keychain access denied or unavailable');
       // toBe uses Object.is — locks in that the original reference is preserved on `cause`.
       expect((err as Error).cause).toBe(underlying);
@@ -727,6 +755,7 @@ describe('Services Local User Organization Credentials', () => {
 
       const err = await encryptOrganizationPassword('newPassword', null).catch((e: unknown) => e);
 
+      expect(err).toBeInstanceOf(Error);
       expect((err as Error).message).toBe('Keychain access denied or unavailable');
       expect((err as Error).cause).toBe(underlying);
     });
@@ -743,22 +772,28 @@ describe('Services Local User Organization Credentials', () => {
         (e: unknown) => e,
       );
 
+      expect(err).toBeInstanceOf(Error);
       expect((err as Error).message).toBe('Failed to encrypt with application password');
       expect((err as Error).cause).toBe(underlying);
     });
 
-    test('Should reject with the no-method-available message before any encrypt call (no cause)', async () => {
+    test('Should reject with the no-method-available message before any encrypt call (no cause) and emit a warn for observability', async () => {
       vi.mocked(getUseKeychainClaim).mockResolvedValue(false);
 
       const err = await encryptOrganizationPassword('newPassword', null).catch((e: unknown) => e);
 
+      expect(err).toBeInstanceOf(Error);
       expect((err as Error).message).toBe('No encryption method available');
       expect(err).not.toHaveProperty('cause');
       expect(safeStorage.encryptString).not.toHaveBeenCalled();
       expect(encrypt).not.toHaveBeenCalled();
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        'encryptOrganizationPassword called without a viable encryption method',
+        { useKeychain: false },
+      );
     });
 
-    test('Should call getUseKeychainClaim exactly once on the success path (no duplicate DB hit)', async () => {
+    test('Should call getUseKeychainClaim exactly once on the success path (no duplicate DB hit) and not emit the no-method warn', async () => {
       const buffer = Buffer.from('encrypted');
       vi.mocked(getUseKeychainClaim).mockResolvedValue(true);
       vi.mocked(safeStorage.encryptString).mockReturnValue(buffer);
@@ -766,6 +801,7 @@ describe('Services Local User Organization Credentials', () => {
       await encryptOrganizationPassword('newPassword', null);
 
       expect(getUseKeychainClaim).toHaveBeenCalledTimes(1);
+      expect(loggerMock.warn).not.toHaveBeenCalled();
     });
   });
 

--- a/front-end/src/tests/main/services/localUser/organizationCredentials.spec.ts
+++ b/front-end/src/tests/main/services/localUser/organizationCredentials.spec.ts
@@ -691,6 +691,29 @@ describe('Services Local User Organization Credentials', () => {
       expect(result).toEqual(encryptedPassword);
     });
 
+    test('Should reject with empty-password guard before touching getUseKeychainClaim', async () => {
+      await expect(encryptOrganizationPassword('', 'anything')).rejects.toThrow(
+        'Password is required to encrypt',
+      );
+      expect(getUseKeychainClaim).not.toHaveBeenCalled();
+      expect(safeStorage.encryptString).not.toHaveBeenCalled();
+      expect(encrypt).not.toHaveBeenCalled();
+    });
+
+    test('Should rethrow as the keychain-specific message when getUseKeychainClaim itself throws', async () => {
+      const underlying = new Error('Keychain mode not initialized');
+      vi.mocked(getUseKeychainClaim).mockRejectedValue(underlying);
+
+      const promise = encryptOrganizationPassword('newPassword', null);
+
+      await expect(promise).rejects.toThrow('Keychain access denied or unavailable');
+      // toHaveProperty uses Object.is — verifies the exact original reference was preserved as cause.
+      await expect(promise).rejects.toHaveProperty('cause', underlying);
+      // We must not reach the actual encryption attempt when claim resolution fails.
+      expect(safeStorage.encryptString).not.toHaveBeenCalled();
+      expect(encrypt).not.toHaveBeenCalled();
+    });
+
     test('Should rethrow with the keychain-specific message when keychain encrypt throws (Deny scenario)', async () => {
       const password = 'newPassword';
       const underlying = new Error(
@@ -705,8 +728,7 @@ describe('Services Local User Organization Credentials', () => {
       const promise = encryptOrganizationPassword(password, null);
 
       await expect(promise).rejects.toThrow('Keychain access denied or unavailable');
-      // cause must be preserved so logs retain the underlying stack chain
-      await expect(promise).rejects.toMatchObject({ cause: underlying });
+      await expect(promise).rejects.toHaveProperty('cause', underlying);
     });
 
     test('Should rethrow with the application-password message when AES encrypt throws', async () => {
@@ -722,19 +744,27 @@ describe('Services Local User Organization Credentials', () => {
       const promise = encryptOrganizationPassword(password, personalPassword);
 
       await expect(promise).rejects.toThrow('Failed to encrypt with application password');
-      await expect(promise).rejects.toMatchObject({ cause: underlying });
+      await expect(promise).rejects.toHaveProperty('cause', underlying);
     });
 
-    test('Should rethrow with the no-method-available message when neither keychain nor personal password is available', async () => {
-      const password = 'newPassword';
-
+    test('Should reject with the no-method-available message before any encrypt call', async () => {
       vi.mocked(getUseKeychainClaim).mockResolvedValue(false);
 
-      await expect(encryptOrganizationPassword(password, null)).rejects.toThrow(
+      await expect(encryptOrganizationPassword('newPassword', null)).rejects.toThrow(
         'No encryption method available',
       );
       expect(safeStorage.encryptString).not.toHaveBeenCalled();
       expect(encrypt).not.toHaveBeenCalled();
+    });
+
+    test('Should call getUseKeychainClaim exactly once on the success path (no duplicate DB hit)', async () => {
+      const buffer = Buffer.from('encrypted');
+      vi.mocked(getUseKeychainClaim).mockResolvedValue(true);
+      vi.mocked(safeStorage.encryptString).mockReturnValue(buffer);
+
+      await encryptOrganizationPassword('newPassword', null);
+
+      expect(getUseKeychainClaim).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/front-end/src/tests/main/services/localUser/organizationCredentials.spec.ts
+++ b/front-end/src/tests/main/services/localUser/organizationCredentials.spec.ts
@@ -691,37 +691,47 @@ describe('Services Local User Organization Credentials', () => {
       expect(result).toEqual(encryptedPassword);
     });
 
-    test('Should throw if password is empty (caller bug - guards against silent no-op)', async () => {
-      await expect(encryptOrganizationPassword('', 'anything')).rejects.toThrow(
-        'Password is required to encrypt',
-      );
-      expect(getUseKeychainClaim).not.toHaveBeenCalled();
-      expect(safeStorage.encryptString).not.toHaveBeenCalled();
-      expect(encrypt).not.toHaveBeenCalled();
-    });
-
-    test('Should rethrow as a domain error when keychain encrypt throws (Deny scenario)', async () => {
+    test('Should rethrow with the keychain-specific message when keychain encrypt throws (Deny scenario)', async () => {
       const password = 'newPassword';
+      const underlying = new Error(
+        'Error while encrypting the text provided to safeStorage.encryptString. Encryption is not available.',
+      );
 
       vi.mocked(getUseKeychainClaim).mockResolvedValue(true);
       vi.mocked(safeStorage.encryptString).mockImplementation(() => {
-        throw new Error(
-          'Error while encrypting the text provided to safeStorage.encryptString. Encryption is not available.',
-        );
+        throw underlying;
       });
 
-      await expect(encryptOrganizationPassword(password, null)).rejects.toThrow(
-        'Failed to encrypt organization password',
-      );
+      const promise = encryptOrganizationPassword(password, null);
+
+      await expect(promise).rejects.toThrow('Keychain access denied or unavailable');
+      // cause must be preserved so logs retain the underlying stack chain
+      await expect(promise).rejects.toMatchObject({ cause: underlying });
     });
 
-    test('Should rethrow as a domain error when no encryption method is available', async () => {
+    test('Should rethrow with the application-password message when AES encrypt throws', async () => {
+      const password = 'newPassword';
+      const personalPassword = 'personal-password';
+      const underlying = new Error('AES failure');
+
+      vi.mocked(getUseKeychainClaim).mockResolvedValue(false);
+      vi.mocked(encrypt).mockImplementation(() => {
+        throw underlying;
+      });
+
+      const promise = encryptOrganizationPassword(password, personalPassword);
+
+      await expect(promise).rejects.toThrow('Failed to encrypt with application password');
+      await expect(promise).rejects.toMatchObject({ cause: underlying });
+    });
+
+    test('Should rethrow with the no-method-available message when neither keychain nor personal password is available', async () => {
       const password = 'newPassword';
 
       vi.mocked(getUseKeychainClaim).mockResolvedValue(false);
 
       await expect(encryptOrganizationPassword(password, null)).rejects.toThrow(
-        'Failed to encrypt organization password',
+        'No encryption method available',
       );
       expect(safeStorage.encryptString).not.toHaveBeenCalled();
       expect(encrypt).not.toHaveBeenCalled();

--- a/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
+++ b/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
@@ -241,7 +241,11 @@ describe('settings profile coverage', () => {
       mocks.userStore.selectedOrganization = { ...ORG };
     });
 
-    test('happy path: encrypts first, then rotates BE, then writes encrypted blob to local DB', async () => {
+    test('happy path (keychain mode): encrypts first, then rotates BE, then writes encrypted blob to local DB', async () => {
+      // Realistic state: keychain users have no cached personal password,
+      // so getPassword returns null and the second arg to encrypt is undefined.
+      mocks.userStore.personal = { id: 'local-user-id', useKeychain: true };
+
       const encryptedBlob = 'encrypted-blob';
       mocks.getPassword.mockReturnValueOnce(null);
       mocks.encryptOrganizationPassword.mockResolvedValueOnce(encryptedBlob);
@@ -253,7 +257,7 @@ describe('settings profile coverage', () => {
       await openConfirm(wrapper);
       await clickConfirm(wrapper);
 
-      // Encrypt is called BEFORE the BE rotation.
+      // Encrypt is called BEFORE the BE rotation, which is BEFORE the local DB write.
       const encryptOrder = mocks.encryptOrganizationPassword.mock.invocationCallOrder[0];
       const beOrder = mocks.organizationChangePassword.mock.invocationCallOrder[0];
       const dbOrder = mocks.updateOrganizationCredentials.mock.invocationCallOrder[0];
@@ -287,7 +291,7 @@ describe('settings profile coverage', () => {
       expect(mocks.toastError).not.toHaveBeenCalled();
     });
 
-    test('happy path: forwards the personal password as encryption key when keychain is off', async () => {
+    test('happy path (non-keychain): forwards the cached personal password as encryption key', async () => {
       mocks.userStore.personal = { id: 'local-user-id', useKeychain: false };
       mocks.getPassword.mockReturnValueOnce('cached-personal-password');
       mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted');
@@ -308,7 +312,7 @@ describe('settings profile coverage', () => {
     test('keychain Deny: encrypt throws -> BE never called, DB never called, fields preserved, modal stays open', async () => {
       mocks.getPassword.mockReturnValueOnce(null);
       mocks.encryptOrganizationPassword.mockRejectedValueOnce(
-        new Error('Failed to encrypt organization password'),
+        new Error('Keychain access denied or unavailable'),
       );
 
       const wrapper = mountProfile();
@@ -318,7 +322,7 @@ describe('settings profile coverage', () => {
 
       expect(mocks.organizationChangePassword).not.toHaveBeenCalled();
       expect(mocks.updateOrganizationCredentials).not.toHaveBeenCalled();
-      expect(mocks.toastError).toHaveBeenCalledWith('Failed to encrypt organization password');
+      expect(mocks.toastError).toHaveBeenCalledWith('Keychain access denied or unavailable');
 
       expect(
         (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,
@@ -371,6 +375,29 @@ describe('settings profile coverage', () => {
       ).toBe(STRONG_NEW);
     });
 
+    test('DB write rejects (IPC error) -> surfaces the thrown message and preserves fields', async () => {
+      mocks.getPassword.mockReturnValueOnce(null);
+      mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted');
+      mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
+      mocks.updateOrganizationCredentials.mockRejectedValueOnce(
+        new Error('Failed to store organization credentials'),
+      );
+
+      const wrapper = mountProfile();
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+      await clickConfirm(wrapper);
+
+      expect(mocks.toastError).toHaveBeenCalledWith('Failed to store organization credentials');
+      expect(wrapper.text()).not.toContain('Password Changed Successfully');
+      expect(
+        (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_OLD);
+      expect(
+        (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_NEW);
+    });
+
     test('personal-password modal opens (early return): no encrypt, no BE, no DB; fields stay populated for the callback', async () => {
       mocks.getPassword.mockReturnValueOnce(false);
 
@@ -390,6 +417,56 @@ describe('settings profile coverage', () => {
       expect(
         (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
       ).toBe(STRONG_NEW);
+    });
+
+    test('modal callback re-invocation: second call sees populated fields and runs the full flow', async () => {
+      // First invocation: personal-password modal opens, getPassword returns false → early return.
+      // Second invocation (driven by the modal's onSubmitted callback): cached password is now available.
+      mocks.getPassword.mockReturnValueOnce(false).mockReturnValueOnce('entered-personal-password');
+      mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted-blob');
+      mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
+      mocks.updateOrganizationCredentials.mockResolvedValueOnce(true);
+
+      const wrapper = mountProfile();
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+
+      // First confirm click — early return path, fields must survive.
+      await clickConfirm(wrapper);
+      expect(mocks.encryptOrganizationPassword).not.toHaveBeenCalled();
+      expect(
+        (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_OLD);
+      expect(
+        (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_NEW);
+
+      // Simulate the personal-password modal's submit callback re-entering handleChangePassword.
+      // The composable's contract is that `getPassword(callback, …)` invokes `callback(password)`
+      // when the modal is submitted — that callback is `handleChangePassword` itself, which we
+      // trigger here by clicking confirm a second time.
+      await clickConfirm(wrapper);
+
+      expect(mocks.encryptOrganizationPassword).toHaveBeenCalledTimes(1);
+      expect(mocks.encryptOrganizationPassword).toHaveBeenCalledWith(
+        STRONG_NEW,
+        'entered-personal-password',
+      );
+      expect(mocks.organizationChangePassword).toHaveBeenCalledWith(
+        ORG.serverUrl,
+        STRONG_OLD,
+        STRONG_NEW,
+      );
+      expect(mocks.updateOrganizationCredentials).toHaveBeenCalledWith(
+        ORG.id,
+        'local-user-id',
+        undefined,
+        'encrypted-blob',
+        undefined,
+        undefined,
+        true,
+      );
+      expect(wrapper.text()).toContain('Password Changed Successfully');
     });
 
     test('clicking Confirm with empty fields throws "Password cannot be empty" without side effects', async () => {

--- a/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
+++ b/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
@@ -1,19 +1,36 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 
 import ProfileTab from '@renderer/pages/Settings/components/ProfileTab.vue';
 
 const mocks = vi.hoisted(() => ({
   routerPush: vi.fn(),
   userStore: {
-    personal: { id: 'local-user-id', useKeychain: false },
-    selectedOrganization: null as any,
+    personal: { id: 'local-user-id', useKeychain: false } as {
+      id: string;
+      useKeychain: boolean;
+    } | null,
+    selectedOrganization: null as null | {
+      id: string;
+      nickname: string;
+      serverUrl: string;
+      key: string;
+    },
     logout: vi.fn(),
     refetchAccounts: vi.fn(),
     refetchKeys: vi.fn(),
     setPassword: vi.fn(),
+    selectOrganization: vi.fn(),
   },
+  getPassword: vi.fn(),
+  passwordModalOpened: vi.fn((value: unknown) => value === false),
+  changePasswordUser: vi.fn(),
+  organizationChangePassword: vi.fn(),
+  encryptOrganizationPassword: vi.fn(),
+  updateOrganizationCredentials: vi.fn(),
+  organizationLogout: vi.fn(),
+  toastError: vi.fn(),
 }));
 
 vi.mock('vue-router', () => ({
@@ -32,31 +49,32 @@ vi.mock('@renderer/composables/useLoader', () => ({
 
 vi.mock('@renderer/composables/usePersonalPassword', () => ({
   default: vi.fn(() => ({
-    getPassword: vi.fn(),
-    passwordModalOpened: vi.fn(() => false),
+    getPassword: mocks.getPassword,
+    passwordModalOpened: mocks.passwordModalOpened,
   })),
 }));
 
 vi.mock('@renderer/services/userService', () => ({
-  changePassword: vi.fn(),
+  changePassword: mocks.changePasswordUser,
 }));
 
 vi.mock('@renderer/services/organization/auth', () => ({
-  changePassword: vi.fn(),
+  changePassword: mocks.organizationChangePassword,
 }));
 
 vi.mock('@renderer/services/organizationCredentials', () => ({
-  updateOrganizationCredentials: vi.fn(),
+  encryptOrganizationPassword: mocks.encryptOrganizationPassword,
+  updateOrganizationCredentials: mocks.updateOrganizationCredentials,
 }));
 
 vi.mock('@renderer/services/organization', () => ({
-  logout: vi.fn(),
+  logout: mocks.organizationLogout,
 }));
 
 vi.mock('@renderer/utils/ToastManager', () => ({
   ToastManager: {
     inject: vi.fn(() => ({
-      error: vi.fn(),
+      error: mocks.toastError,
     })),
   },
 }));
@@ -97,63 +115,386 @@ const stubs = {
   },
 };
 
+const ORG = {
+  id: 'org-1',
+  nickname: 'Acme',
+  serverUrl: 'https://acme.example',
+  key: 'org-key',
+};
+
+const STRONG_OLD = 'old-password';
+const STRONG_NEW = 'new-strong-password';
+
+const mountProfile = () => mount(ProfileTab, { global: { stubs } });
+
+const setPasswords = async (wrapper: ReturnType<typeof mountProfile>, current: string, next: string) => {
+  await wrapper.find('[data-testid="input-current-password"]').setValue(current);
+  await wrapper.find('[data-testid="input-new-password"]').setValue(next);
+};
+
+const openConfirm = async (wrapper: ReturnType<typeof mountProfile>) => {
+  await wrapper.find('form').trigger('submit');
+};
+
+const clickConfirm = async (wrapper: ReturnType<typeof mountProfile>) => {
+  await wrapper.find('[data-testid="button-confirm-change-password"]').trigger('click');
+  await flushPromises();
+};
+
 describe('settings profile coverage', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mocks.userStore.personal = { id: 'local-user-id', useKeychain: false };
     mocks.userStore.selectedOrganization = null;
+    mocks.passwordModalOpened.mockImplementation((value: unknown) => value === false);
   });
 
-  test('renders password form for email/password users', () => {
-    const wrapper = mount(ProfileTab, {
-      global: {
-        stubs,
-      },
+  describe('local user (no organization) flow', () => {
+    test('renders password form for email/password users', () => {
+      const wrapper = mountProfile();
+
+      expect(wrapper.find('[data-testid="input-current-password"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="input-new-password"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="button-change-password"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="button-logout"]').exists()).toBe(true);
     });
 
-    expect(wrapper.find('[data-testid="input-current-password"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="input-new-password"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="button-change-password"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="button-logout"]').exists()).toBe(true);
+    test('keeps change password disabled for weak new password', async () => {
+      const wrapper = mountProfile();
+
+      await setPasswords(wrapper, STRONG_OLD, '123456789');
+
+      expect(
+        wrapper.find('[data-testid="button-change-password"]').attributes('disabled'),
+      ).toBeDefined();
+    });
+
+    test('shows invalid password inline message on blur', async () => {
+      const wrapper = mountProfile();
+
+      await wrapper.find('[data-testid="input-new-password"]').setValue('123456789');
+      await wrapper.find('[data-testid="input-new-password"]').trigger('blur');
+
+      expect(wrapper.text()).toContain('Invalid password');
+    });
+
+    test('opens confirmation modal when password form is valid', async () => {
+      const wrapper = mountProfile();
+
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+
+      expect(wrapper.text()).toContain('Change Password?');
+      expect(wrapper.find('[data-testid="button-confirm-change-password"]').exists()).toBe(true);
+    });
+
+    test('happy path: calls user changePassword, refetches keys, clears fields, opens success modal', async () => {
+      mocks.changePasswordUser.mockResolvedValueOnce(undefined);
+      mocks.userStore.refetchKeys.mockResolvedValueOnce(undefined);
+      mocks.userStore.refetchAccounts.mockResolvedValueOnce(undefined);
+
+      const wrapper = mountProfile();
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+      await clickConfirm(wrapper);
+
+      expect(mocks.changePasswordUser).toHaveBeenCalledWith(
+        'local-user-id',
+        STRONG_OLD,
+        STRONG_NEW,
+      );
+      expect(mocks.userStore.setPassword).toHaveBeenCalledWith(STRONG_NEW);
+      expect(mocks.userStore.refetchKeys).toHaveBeenCalled();
+      expect(mocks.userStore.refetchAccounts).toHaveBeenCalled();
+      expect(
+        (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,
+      ).toBe('');
+      expect(
+        (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
+      ).toBe('');
+      expect(wrapper.text()).toContain('Password Changed Successfully');
+      expect(mocks.toastError).not.toHaveBeenCalled();
+    });
+
+    test('error path: surfaces toast and preserves the form when changePassword throws', async () => {
+      mocks.changePasswordUser.mockRejectedValueOnce(new Error('Wrong current password'));
+
+      const wrapper = mountProfile();
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+      await clickConfirm(wrapper);
+
+      expect(mocks.toastError).toHaveBeenCalledWith('Wrong current password');
+      expect(mocks.userStore.setPassword).not.toHaveBeenCalled();
+      expect(
+        (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_OLD);
+      expect(
+        (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_NEW);
+      expect(wrapper.text()).not.toContain('Password Changed Successfully');
+    });
   });
 
-  test('keeps change password disabled for weak new password', async () => {
-    const wrapper = mount(ProfileTab, {
-      global: {
-        stubs,
-      },
+  describe('organization flow', () => {
+    beforeEach(() => {
+      mocks.userStore.selectedOrganization = { ...ORG };
     });
 
-    await wrapper.find('[data-testid="input-current-password"]').setValue('current-password');
-    await wrapper.find('[data-testid="input-new-password"]').setValue('123456789');
+    test('happy path: encrypts first, then rotates BE, then writes encrypted blob to local DB', async () => {
+      const encryptedBlob = 'encrypted-blob';
+      mocks.getPassword.mockReturnValueOnce(null);
+      mocks.encryptOrganizationPassword.mockResolvedValueOnce(encryptedBlob);
+      mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
+      mocks.updateOrganizationCredentials.mockResolvedValueOnce(true);
 
-    expect(wrapper.find('[data-testid="button-change-password"]').attributes('disabled')).toBeDefined();
+      const wrapper = mountProfile();
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+      await clickConfirm(wrapper);
+
+      // Encrypt is called BEFORE the BE rotation.
+      const encryptOrder = mocks.encryptOrganizationPassword.mock.invocationCallOrder[0];
+      const beOrder = mocks.organizationChangePassword.mock.invocationCallOrder[0];
+      const dbOrder = mocks.updateOrganizationCredentials.mock.invocationCallOrder[0];
+      expect(encryptOrder).toBeLessThan(beOrder);
+      expect(beOrder).toBeLessThan(dbOrder);
+
+      expect(mocks.encryptOrganizationPassword).toHaveBeenCalledWith(STRONG_NEW, undefined);
+      expect(mocks.organizationChangePassword).toHaveBeenCalledWith(
+        ORG.serverUrl,
+        STRONG_OLD,
+        STRONG_NEW,
+      );
+      // DB write must use the already-encrypted blob and pass passwordIsEncrypted=true.
+      expect(mocks.updateOrganizationCredentials).toHaveBeenCalledWith(
+        ORG.id,
+        'local-user-id',
+        undefined,
+        encryptedBlob,
+        undefined,
+        undefined,
+        true,
+      );
+
+      expect(wrapper.text()).toContain('Password Changed Successfully');
+      expect(
+        (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,
+      ).toBe('');
+      expect(
+        (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
+      ).toBe('');
+      expect(mocks.toastError).not.toHaveBeenCalled();
+    });
+
+    test('happy path: forwards the personal password as encryption key when keychain is off', async () => {
+      mocks.userStore.personal = { id: 'local-user-id', useKeychain: false };
+      mocks.getPassword.mockReturnValueOnce('cached-personal-password');
+      mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted');
+      mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
+      mocks.updateOrganizationCredentials.mockResolvedValueOnce(true);
+
+      const wrapper = mountProfile();
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+      await clickConfirm(wrapper);
+
+      expect(mocks.encryptOrganizationPassword).toHaveBeenCalledWith(
+        STRONG_NEW,
+        'cached-personal-password',
+      );
+    });
+
+    test('keychain Deny: encrypt throws -> BE never called, DB never called, fields preserved, modal stays open', async () => {
+      mocks.getPassword.mockReturnValueOnce(null);
+      mocks.encryptOrganizationPassword.mockRejectedValueOnce(
+        new Error('Failed to encrypt organization password'),
+      );
+
+      const wrapper = mountProfile();
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+      await clickConfirm(wrapper);
+
+      expect(mocks.organizationChangePassword).not.toHaveBeenCalled();
+      expect(mocks.updateOrganizationCredentials).not.toHaveBeenCalled();
+      expect(mocks.toastError).toHaveBeenCalledWith('Failed to encrypt organization password');
+
+      expect(
+        (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_OLD);
+      expect(
+        (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_NEW);
+      expect(wrapper.text()).toContain('Change Password?');
+      expect(wrapper.text()).not.toContain('Password Changed Successfully');
+    });
+
+    test('BE rotation failure after encrypt: DB never written, fields preserved', async () => {
+      mocks.getPassword.mockReturnValueOnce(null);
+      mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted');
+      mocks.organizationChangePassword.mockRejectedValueOnce(new Error('Invalid old password'));
+
+      const wrapper = mountProfile();
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+      await clickConfirm(wrapper);
+
+      expect(mocks.encryptOrganizationPassword).toHaveBeenCalled();
+      expect(mocks.updateOrganizationCredentials).not.toHaveBeenCalled();
+      expect(mocks.toastError).toHaveBeenCalledWith('Invalid old password');
+      expect(
+        (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_OLD);
+      expect(
+        (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_NEW);
+    });
+
+    test('DB write returns false -> raises domain error toast and preserves fields', async () => {
+      mocks.getPassword.mockReturnValueOnce(null);
+      mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted');
+      mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
+      mocks.updateOrganizationCredentials.mockResolvedValueOnce(false);
+
+      const wrapper = mountProfile();
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+      await clickConfirm(wrapper);
+
+      expect(mocks.toastError).toHaveBeenCalledWith('Failed to update organization credentials');
+      expect(
+        (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_OLD);
+      expect(
+        (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_NEW);
+    });
+
+    test('personal-password modal opens (early return): no encrypt, no BE, no DB; fields stay populated for the callback', async () => {
+      mocks.getPassword.mockReturnValueOnce(false);
+
+      const wrapper = mountProfile();
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+      await clickConfirm(wrapper);
+
+      expect(mocks.encryptOrganizationPassword).not.toHaveBeenCalled();
+      expect(mocks.organizationChangePassword).not.toHaveBeenCalled();
+      expect(mocks.updateOrganizationCredentials).not.toHaveBeenCalled();
+      expect(mocks.toastError).not.toHaveBeenCalled();
+      // Field state must survive — the personal-password modal callback re-invokes the handler and needs the values.
+      expect(
+        (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_OLD);
+      expect(
+        (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
+      ).toBe(STRONG_NEW);
+    });
+
+    test('clicking Confirm with empty fields throws "Password cannot be empty" without side effects', async () => {
+      const wrapper = mountProfile();
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+
+      // Simulate the legacy bug shape: fields somehow ended up empty while the confirm modal is open.
+      await wrapper.find('[data-testid="input-current-password"]').setValue('');
+      await wrapper.find('[data-testid="input-new-password"]').setValue('');
+
+      await clickConfirm(wrapper);
+
+      expect(mocks.encryptOrganizationPassword).not.toHaveBeenCalled();
+      expect(mocks.organizationChangePassword).not.toHaveBeenCalled();
+      expect(mocks.updateOrganizationCredentials).not.toHaveBeenCalled();
+      expect(mocks.toastError).toHaveBeenCalledWith('Password cannot be empty');
+    });
+
+    test('clicking Confirm after the new password becomes invalid raises the strength error', async () => {
+      const wrapper = mountProfile();
+      // Open the modal with a strong new password.
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+
+      // Then degrade the new password to a weak one and blur to mark it invalid.
+      const newPasswordInput = wrapper.find('[data-testid="input-new-password"]');
+      await newPasswordInput.setValue('short');
+      await newPasswordInput.trigger('blur');
+
+      await clickConfirm(wrapper);
+
+      expect(mocks.encryptOrganizationPassword).not.toHaveBeenCalled();
+      expect(mocks.organizationChangePassword).not.toHaveBeenCalled();
+      expect(mocks.updateOrganizationCredentials).not.toHaveBeenCalled();
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        'Password must be at least 10 characters long',
+      );
+    });
   });
 
-  test('shows invalid password inline message on blur', async () => {
-    const wrapper = mount(ProfileTab, {
-      global: {
-        stubs,
-      },
+  describe('logout flow', () => {
+    test('organization logout: logs out, clears local credentials, re-selects the org', async () => {
+      mocks.userStore.selectedOrganization = { ...ORG };
+      mocks.organizationLogout.mockResolvedValueOnce(undefined);
+      mocks.updateOrganizationCredentials.mockResolvedValueOnce(true);
+
+      const wrapper = mountProfile();
+      await wrapper.find('[data-testid="button-logout"]').trigger('click');
+      await flushPromises();
+
+      expect(mocks.organizationLogout).toHaveBeenCalledWith(ORG.serverUrl);
+      expect(mocks.updateOrganizationCredentials).toHaveBeenCalledWith(
+        ORG.id,
+        'local-user-id',
+        undefined,
+        '',
+        null,
+      );
+      expect(mocks.userStore.selectOrganization).toHaveBeenCalledWith({
+        id: ORG.id,
+        nickname: ORG.nickname,
+        serverUrl: ORG.serverUrl,
+        key: ORG.key,
+      });
     });
 
-    await wrapper.find('[data-testid="input-new-password"]').setValue('123456789');
-    await wrapper.find('[data-testid="input-new-password"]').trigger('blur');
+    test('local-user logout: clears HTX_USER from localStorage, calls store.logout, pushes to login route', async () => {
+      mocks.userStore.selectedOrganization = null;
+      const removeItemSpy = vi.spyOn(window.localStorage, 'removeItem');
 
-    expect(wrapper.text()).toContain('Invalid password');
+      const wrapper = mountProfile();
+      await wrapper.find('[data-testid="button-logout"]').trigger('click');
+      await flushPromises();
+
+      expect(removeItemSpy).toHaveBeenCalledWith('htx_user');
+      expect(mocks.userStore.logout).toHaveBeenCalled();
+      expect(mocks.routerPush).toHaveBeenCalledWith({ name: 'login' });
+      expect(mocks.organizationLogout).not.toHaveBeenCalled();
+    });
+
+    test('organization logout no-ops when there is no logged-in personal user', async () => {
+      mocks.userStore.selectedOrganization = { ...ORG };
+      mocks.userStore.personal = null;
+
+      const wrapper = mountProfile();
+      await wrapper.find('[data-testid="button-logout"]').trigger('click');
+      await flushPromises();
+
+      expect(mocks.organizationLogout).not.toHaveBeenCalled();
+      expect(mocks.updateOrganizationCredentials).not.toHaveBeenCalled();
+      expect(mocks.userStore.selectOrganization).not.toHaveBeenCalled();
+    });
   });
 
-  test('opens confirmation modal when password form is valid', async () => {
-    const wrapper = mount(ProfileTab, {
-      global: {
-        stubs,
-      },
+  describe('keychain-only personal user (no organization)', () => {
+    test('renders the Reset Application form instead of the password change form', () => {
+      mocks.userStore.personal = { id: 'local-user-id', useKeychain: true };
+      mocks.userStore.selectedOrganization = null;
+
+      const wrapper = mountProfile();
+
+      expect(wrapper.text()).toContain('Reset Application');
+      expect(wrapper.find('[data-testid="input-current-password"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="input-new-password"]').exists()).toBe(false);
     });
-
-    await wrapper.find('[data-testid="input-current-password"]').setValue('current-password');
-    await wrapper.find('[data-testid="input-new-password"]').setValue('new-password');
-    await wrapper.find('form').trigger('submit');
-
-    expect(wrapper.text()).toContain('Change Password?');
-    expect(wrapper.find('[data-testid="button-confirm-change-password"]').exists()).toBe(true);
   });
 });

--- a/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
+++ b/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
@@ -242,8 +242,6 @@ describe('settings profile coverage', () => {
     });
 
     test('happy path (keychain mode): encrypts first, then rotates BE, then writes encrypted blob to local DB', async () => {
-      // Realistic state: keychain users have no cached personal password,
-      // so getPassword returns null and the second arg to encrypt is undefined.
       mocks.userStore.personal = { id: 'local-user-id', useKeychain: true };
 
       const encryptedBlob = 'encrypted-blob';
@@ -257,7 +255,6 @@ describe('settings profile coverage', () => {
       await openConfirm(wrapper);
       await clickConfirm(wrapper);
 
-      // Encrypt is called BEFORE the BE rotation, which is BEFORE the local DB write.
       const encryptOrder = mocks.encryptOrganizationPassword.mock.invocationCallOrder[0];
       const beOrder = mocks.organizationChangePassword.mock.invocationCallOrder[0];
       const dbOrder = mocks.updateOrganizationCredentials.mock.invocationCallOrder[0];
@@ -270,7 +267,6 @@ describe('settings profile coverage', () => {
         STRONG_OLD,
         STRONG_NEW,
       );
-      // DB write must use the already-encrypted blob and pass passwordIsEncrypted=true.
       expect(mocks.updateOrganizationCredentials).toHaveBeenCalledWith(
         ORG.id,
         'local-user-id',
@@ -309,30 +305,36 @@ describe('settings profile coverage', () => {
       );
     });
 
-    test('keychain Deny: encrypt throws -> BE never called, DB never called, fields preserved, modal stays open', async () => {
-      mocks.getPassword.mockReturnValueOnce(null);
-      mocks.encryptOrganizationPassword.mockRejectedValueOnce(
-        new Error('Keychain access denied or unavailable'),
-      );
+    test.each([
+      ['Keychain access denied or unavailable'],
+      ['Failed to encrypt with application password'],
+      ['No encryption method available'],
+    ])(
+      'encrypt failure mode "%s" surfaces to the toast and aborts before BE / DB',
+      async message => {
+        mocks.getPassword.mockReturnValueOnce(null);
+        mocks.encryptOrganizationPassword.mockRejectedValueOnce(new Error(message));
 
-      const wrapper = mountProfile();
-      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
-      await openConfirm(wrapper);
-      await clickConfirm(wrapper);
+        const wrapper = mountProfile();
+        await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+        await openConfirm(wrapper);
+        await clickConfirm(wrapper);
 
-      expect(mocks.organizationChangePassword).not.toHaveBeenCalled();
-      expect(mocks.updateOrganizationCredentials).not.toHaveBeenCalled();
-      expect(mocks.toastError).toHaveBeenCalledWith('Keychain access denied or unavailable');
+        expect(mocks.organizationChangePassword).not.toHaveBeenCalled();
+        expect(mocks.updateOrganizationCredentials).not.toHaveBeenCalled();
+        expect(mocks.toastError).toHaveBeenCalledWith(message);
 
-      expect(
-        (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,
-      ).toBe(STRONG_OLD);
-      expect(
-        (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
-      ).toBe(STRONG_NEW);
-      expect(wrapper.text()).toContain('Change Password?');
-      expect(wrapper.text()).not.toContain('Password Changed Successfully');
-    });
+        expect(
+          (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement)
+            .value,
+        ).toBe(STRONG_OLD);
+        expect(
+          (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
+        ).toBe(STRONG_NEW);
+        expect(wrapper.text()).toContain('Change Password?');
+        expect(wrapper.text()).not.toContain('Password Changed Successfully');
+      },
+    );
 
     test('BE rotation failure after encrypt: DB never written, fields preserved', async () => {
       mocks.getPassword.mockReturnValueOnce(null);
@@ -379,9 +381,6 @@ describe('settings profile coverage', () => {
       mocks.getPassword.mockReturnValueOnce(null);
       mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted');
       mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
-      // The renderer-side commonIPCHandler parses the main-thrown message out of the IPC error
-      // payload and rethrows it. The main service throws 'Failed to update organization credentials'
-      // (organizationCredentials.ts:237), so that's what the renderer sees and surfaces to the toast.
       mocks.updateOrganizationCredentials.mockRejectedValueOnce(
         new Error('Failed to update organization credentials'),
       );
@@ -413,7 +412,6 @@ describe('settings profile coverage', () => {
       expect(mocks.organizationChangePassword).not.toHaveBeenCalled();
       expect(mocks.updateOrganizationCredentials).not.toHaveBeenCalled();
       expect(mocks.toastError).not.toHaveBeenCalled();
-      // Field state must survive — the personal-password modal callback re-invokes the handler and needs the values.
       expect(
         (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,
       ).toBe(STRONG_OLD);
@@ -423,8 +421,6 @@ describe('settings profile coverage', () => {
     });
 
     test('modal callback re-invocation: second call sees populated fields and runs the full flow', async () => {
-      // First invocation: personal-password modal opens, getPassword returns false → early return.
-      // Second invocation (driven by the modal's onSubmitted callback): cached password is now available.
       mocks.getPassword.mockReturnValueOnce(false).mockReturnValueOnce('entered-personal-password');
       mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted-blob');
       mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
@@ -434,7 +430,6 @@ describe('settings profile coverage', () => {
       await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
       await openConfirm(wrapper);
 
-      // First confirm click — early return path, fields must survive.
       await clickConfirm(wrapper);
       expect(mocks.encryptOrganizationPassword).not.toHaveBeenCalled();
       expect(
@@ -444,10 +439,6 @@ describe('settings profile coverage', () => {
         (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
       ).toBe(STRONG_NEW);
 
-      // Simulate the personal-password modal's submit callback re-entering handleChangePassword.
-      // The composable's contract is that `getPassword(callback, …)` invokes `callback(password)`
-      // when the modal is submitted — that callback is `handleChangePassword` itself, which we
-      // trigger here by clicking confirm a second time.
       await clickConfirm(wrapper);
 
       expect(mocks.encryptOrganizationPassword).toHaveBeenCalledTimes(1);
@@ -477,7 +468,6 @@ describe('settings profile coverage', () => {
       await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
       await openConfirm(wrapper);
 
-      // Simulate the legacy bug shape: fields somehow ended up empty while the confirm modal is open.
       await wrapper.find('[data-testid="input-current-password"]').setValue('');
       await wrapper.find('[data-testid="input-new-password"]').setValue('');
 
@@ -495,7 +485,6 @@ describe('settings profile coverage', () => {
       await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
       await openConfirm(wrapper);
 
-      // Then degrade the new password to a weak one and blur to mark it invalid.
       const newPasswordInput = wrapper.find('[data-testid="input-new-password"]');
       await newPasswordInput.setValue('short');
       await newPasswordInput.trigger('blur');

--- a/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
+++ b/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
@@ -379,8 +379,11 @@ describe('settings profile coverage', () => {
       mocks.getPassword.mockReturnValueOnce(null);
       mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted');
       mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
+      // The renderer-side commonIPCHandler parses the main-thrown message out of the IPC error
+      // payload and rethrows it. The main service throws 'Failed to update organization credentials'
+      // (organizationCredentials.ts:237), so that's what the renderer sees and surfaces to the toast.
       mocks.updateOrganizationCredentials.mockRejectedValueOnce(
-        new Error('Failed to store organization credentials'),
+        new Error('Failed to update organization credentials'),
       );
 
       const wrapper = mountProfile();
@@ -388,7 +391,7 @@ describe('settings profile coverage', () => {
       await openConfirm(wrapper);
       await clickConfirm(wrapper);
 
-      expect(mocks.toastError).toHaveBeenCalledWith('Failed to store organization credentials');
+      expect(mocks.toastError).toHaveBeenCalledWith('Failed to update organization credentials');
       expect(wrapper.text()).not.toContain('Password Changed Successfully');
       expect(
         (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,

--- a/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
+++ b/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
@@ -23,8 +23,7 @@ const mocks = vi.hoisted(() => ({
     setPassword: vi.fn(),
     selectOrganization: vi.fn(),
   },
-  getPassword: vi.fn(),
-  passwordModalOpened: vi.fn((value: unknown) => value === false),
+  getPasswordAsync: vi.fn(),
   changePasswordUser: vi.fn(),
   organizationChangePassword: vi.fn(),
   encryptOrganizationPassword: vi.fn(),
@@ -49,8 +48,7 @@ vi.mock('@renderer/composables/useLoader', () => ({
 
 vi.mock('@renderer/composables/usePersonalPassword', () => ({
   default: vi.fn(() => ({
-    getPassword: mocks.getPassword,
-    passwordModalOpened: mocks.passwordModalOpened,
+    getPasswordAsync: mocks.getPasswordAsync,
   })),
 }));
 
@@ -146,7 +144,6 @@ describe('settings profile coverage', () => {
     vi.clearAllMocks();
     mocks.userStore.personal = { id: 'local-user-id', useKeychain: false };
     mocks.userStore.selectedOrganization = null;
-    mocks.passwordModalOpened.mockImplementation((value: unknown) => value === false);
   });
 
   describe('local user (no organization) flow', () => {
@@ -245,7 +242,7 @@ describe('settings profile coverage', () => {
       mocks.userStore.personal = { id: 'local-user-id', useKeychain: true };
 
       const encryptedBlob = 'encrypted-blob';
-      mocks.getPassword.mockReturnValueOnce(null);
+      mocks.getPasswordAsync.mockResolvedValueOnce(null);
       mocks.encryptOrganizationPassword.mockResolvedValueOnce(encryptedBlob);
       mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
       mocks.updateOrganizationCredentials.mockResolvedValueOnce(true);
@@ -289,7 +286,7 @@ describe('settings profile coverage', () => {
 
     test('happy path (non-keychain): forwards the cached personal password as encryption key', async () => {
       mocks.userStore.personal = { id: 'local-user-id', useKeychain: false };
-      mocks.getPassword.mockReturnValueOnce('cached-personal-password');
+      mocks.getPasswordAsync.mockResolvedValueOnce('cached-personal-password');
       mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted');
       mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
       mocks.updateOrganizationCredentials.mockResolvedValueOnce(true);
@@ -312,7 +309,7 @@ describe('settings profile coverage', () => {
     ])(
       'encrypt failure mode "%s" surfaces to the toast and aborts before BE / DB',
       async message => {
-        mocks.getPassword.mockReturnValueOnce(null);
+        mocks.getPasswordAsync.mockResolvedValueOnce(null);
         mocks.encryptOrganizationPassword.mockRejectedValueOnce(new Error(message));
 
         const wrapper = mountProfile();
@@ -337,7 +334,7 @@ describe('settings profile coverage', () => {
     );
 
     test('BE rotation failure after encrypt: DB never written, fields preserved', async () => {
-      mocks.getPassword.mockReturnValueOnce(null);
+      mocks.getPasswordAsync.mockResolvedValueOnce(null);
       mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted');
       mocks.organizationChangePassword.mockRejectedValueOnce(new Error('Invalid old password'));
 
@@ -358,7 +355,7 @@ describe('settings profile coverage', () => {
     });
 
     test('DB write returns false -> raises domain error toast and preserves fields', async () => {
-      mocks.getPassword.mockReturnValueOnce(null);
+      mocks.getPasswordAsync.mockResolvedValueOnce(null);
       mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted');
       mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
       mocks.updateOrganizationCredentials.mockResolvedValueOnce(false);
@@ -378,7 +375,7 @@ describe('settings profile coverage', () => {
     });
 
     test('DB write rejects (IPC error) -> surfaces the thrown message and preserves fields', async () => {
-      mocks.getPassword.mockReturnValueOnce(null);
+      mocks.getPasswordAsync.mockResolvedValueOnce(null);
       mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted');
       mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
       mocks.updateOrganizationCredentials.mockRejectedValueOnce(
@@ -400,8 +397,8 @@ describe('settings profile coverage', () => {
       ).toBe(STRONG_NEW);
     });
 
-    test('personal-password modal opens (early return): no encrypt, no BE, no DB; fields stay populated for the callback', async () => {
-      mocks.getPassword.mockReturnValueOnce(false);
+    test('user cancels the personal-password modal: no encrypt / BE / DB, no toast, fields preserved', async () => {
+      mocks.getPasswordAsync.mockResolvedValueOnce(false);
 
       const wrapper = mountProfile();
       await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
@@ -420,8 +417,8 @@ describe('settings profile coverage', () => {
       ).toBe(STRONG_NEW);
     });
 
-    test('modal callback re-invocation: second call sees populated fields and runs the full flow', async () => {
-      mocks.getPassword.mockReturnValueOnce(false).mockReturnValueOnce('entered-personal-password');
+    test('personal-password modal submit: linear flow runs the full encrypt / BE / DB sequence', async () => {
+      mocks.getPasswordAsync.mockResolvedValueOnce('entered-personal-password');
       mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted-blob');
       mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
       mocks.updateOrganizationCredentials.mockResolvedValueOnce(true);
@@ -429,19 +426,8 @@ describe('settings profile coverage', () => {
       const wrapper = mountProfile();
       await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
       await openConfirm(wrapper);
-
-      await clickConfirm(wrapper);
-      expect(mocks.encryptOrganizationPassword).not.toHaveBeenCalled();
-      expect(
-        (wrapper.find('[data-testid="input-current-password"]').element as HTMLInputElement).value,
-      ).toBe(STRONG_OLD);
-      expect(
-        (wrapper.find('[data-testid="input-new-password"]').element as HTMLInputElement).value,
-      ).toBe(STRONG_NEW);
-
       await clickConfirm(wrapper);
 
-      expect(mocks.encryptOrganizationPassword).toHaveBeenCalledTimes(1);
       expect(mocks.encryptOrganizationPassword).toHaveBeenCalledWith(
         STRONG_NEW,
         'entered-personal-password',
@@ -460,6 +446,36 @@ describe('settings profile coverage', () => {
         undefined,
         true,
       );
+      expect(wrapper.text()).toContain('Password Changed Successfully');
+    });
+
+    test('confirm modal stays in loading state while getPasswordAsync is pending (no flicker between modals)', async () => {
+      // Arrange: getPasswordAsync hangs until we resolve it manually, simulating the
+      // personal-password modal being open on top of the confirm modal.
+      let resolvePersonal: (value: string | false | null) => void = () => {};
+      mocks.getPasswordAsync.mockReturnValueOnce(
+        new Promise(resolve => {
+          resolvePersonal = resolve;
+        }),
+      );
+      mocks.encryptOrganizationPassword.mockResolvedValueOnce('encrypted');
+      mocks.organizationChangePassword.mockResolvedValueOnce(undefined);
+      mocks.updateOrganizationCredentials.mockResolvedValueOnce(true);
+
+      const wrapper = mountProfile();
+      await setPasswords(wrapper, STRONG_OLD, STRONG_NEW);
+      await openConfirm(wrapper);
+
+      wrapper.find('[data-testid="button-confirm-change-password"]').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.text()).toContain('Change Password?');
+      const confirmButton = wrapper.find('[data-testid="button-confirm-change-password"]');
+      expect(confirmButton.attributes('disabled')).toBeDefined();
+
+      resolvePersonal('entered-personal-password');
+      await flushPromises();
+
       expect(wrapper.text()).toContain('Password Changed Successfully');
     });
 


### PR DESCRIPTION
Fixes: [2749](https://github.com/hashgraph/hedera-transaction-tool/issues/2749)

## Summary

The change-password flow in **Settings → Profile** could be left in a broken state after a failed attempt — fields appeared empty, retries returned `"Password cannot be empty"`, and on a keychain Deny the backend was rotated to the new password while the local credentials store kept the old one.

## Root causes

1. `handleChangePassword` cleared the password fields in its `finally` block — including the early-return path when the personal-password modal opened. The modal's submit callback then re-invoked the handler with empty fields.
2. The backend password rotation ran **before** the local keychain encryption. Denying the keychain prompt failed only the local step, leaving backend and local DB out of sync.

## Fix

- Moved the field reset onto the success path; `finally` only resets the loading flag.
- New `encryptOrganizationPassword` IPC + service runs the keychain prompt in isolation. The handler now encrypts first → rotates the backend → writes the already-encrypted blob locally via a new `passwordIsEncrypted` flag on `updateOrganizationCredentials`. A keychain Deny aborts before the backend is touched.
- Three distinct failure-mode messages (`"Keychain access denied or unavailable"`, `"Failed to encrypt with application password"`, `"No encryption method available"`) reach the toast with the original error preserved as `cause`.

## Tests

Unit tests across `organizationCredentials.spec.ts` and `SettingsProfile.spec.ts` covering the encrypt-first ordering, all three failure modes, the form-state preservation, the personal-password modal callback re-invocation, and the no-method-available `logger.warn` for observability.

## Out of scope — tracked separately

After a macOS keychain Deny, all subsequent `safeStorage.encrypt`/`decrypt` calls fail until the app restarts (a Chromium + macOS Keychain Services behavior). This affects org login, auto-sign-in, and key signing — a follow-up sub-issue will address the recovery UX.