### PR TITLE
fix: enable wait on first connect for NATS JetStream service

### DIFF
--- a/back-end/libs/common/src/nats/nats-jetstream.service.ts
+++ b/back-end/libs/common/src/nats/nats-jetstream.service.ts
@@ -60,6 +60,7 @@ export class NatsJetStreamService implements OnModuleDestroy {
       name: 'nestjs-service',
       maxReconnectAttempts: -1,
       reconnectTimeWait: 1000,
+      waitOnFirstConnect: true,
     });
 
     this.js = this.nc.jetstream();


### PR DESCRIPTION
**Description**:
This pull request introduces a configuration improvement to the NATS JetStream service. The main change ensures that the service will wait for the first connection to be established before proceeding, which can help prevent race conditions or errors on startup. 

If the connection is not established within 30 seconds, the service will continue to attempt to connect in the background, and will not prevent the pod from starting up.

**Related issue(s)**:

Fixes #2775 

**Checklist**

- [x] Tested (unit, integration, etc.)
