### PR TITLE
fix: ensure addNodeKeys is called for node ID zero

### DIFF
--- a/back-end/libs/common/src/transaction-signature/transaction-signature.service.spec.ts
+++ b/back-end/libs/common/src/transaction-signature/transaction-signature.service.spec.ts
@@ -339,6 +339,22 @@ describe('TransactionSignatureService', () => {
 
       expect(nodeCacheMock.getNodeInfoForTransaction).toHaveBeenCalledWith(expect.anything(), 5);
     });
+
+    it('calls addNodeKeys when nodeId is 0 (node ID zero must not be skipped)', async () => {
+      (SDKTransaction.fromBytes as jest.Mock).mockReturnValue({});
+      (TransactionFactory.fromTransaction as jest.Mock).mockReturnValue(
+        makeTransactionModel({ getNodeId: jest.fn().mockReturnValue(0) }),
+      );
+      accountCacheMock.getAccountInfoForTransaction.mockResolvedValue(
+        makeAccountInfo('fee-payer-key'),
+      );
+      nodeCacheMock.getNodeInfoForTransaction.mockResolvedValue(makeNodeInfo('admin-key'));
+
+      const result = await service.computeSignatureKey(makeTransaction());
+
+      expect(nodeCacheMock.getNodeInfoForTransaction).toHaveBeenCalledWith(expect.anything(), 0);
+      expect((result as unknown as AsMockKeyList).getItems()).toContainEqual(mockKey('admin-key'));
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/back-end/libs/common/src/transaction-signature/transaction-signature.service.ts
+++ b/back-end/libs/common/src/transaction-signature/transaction-signature.service.ts
@@ -52,7 +52,7 @@ export class TransactionSignatureService {
     await this.addSigningAccountKeys(signatureKey, transaction, requirements.signingAccounts);
     await this.addReceiverAccountKeys(signatureKey, transaction, requirements.receiverAccounts, showAll);
 
-    if (requirements.nodeId) {
+    if (requirements.nodeId !== null) {
       await this.addNodeKeys(signatureKey, transaction, requirements.nodeId);
     }
 


### PR DESCRIPTION
**Description**:
This pull request addresses a bug related to handling node IDs when computing signature keys in the `TransactionSignatureService`. The main focus is to ensure that a node ID of zero is not mistakenly skipped, as zero is a valid node ID.

**Test coverage improvements:**

* Added a unit test to verify that `addNodeKeys` is called with node ID zero, confirming that node ID zero is handled correctly and not skipped. (`back-end/libs/common/src/transaction-signature/transaction-signature.service.spec.ts`)

**Related issue(s)**:

Fixes #2436

**Checklist**

- [x] Tested (unit, integration, etc.)
