### PR TITLE
fix: saving description and AccountUpdate transaction properties for group items

### DIFF
--- a/front-end/src/main/services/localUser/auth.ts
+++ b/front-end/src/main/services/localUser/auth.ts
@@ -17,7 +17,6 @@ export const register = async (email: string, password: string) => {
   });
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const login = async (email: string, password: string, _autoRegister?: boolean) => {
   const prisma = getPrismaClient();
 

--- a/front-end/src/renderer/components/Transaction/Create/AccountData/AccountDataFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/AccountData/AccountDataFormData.vue
@@ -148,7 +148,6 @@ const columnClass = 'col-4 col-xxxl-3';
             <option
               value="unselected"
               :selected="data.stakedNodeId === null"
-              default
               data-testid="option-no-node-selected"
             >
               No node selected

--- a/front-end/src/renderer/components/Transaction/Create/AccountUpdate/AccountUpdate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/AccountUpdate/AccountUpdate.vue
@@ -108,6 +108,9 @@ watch(
   },
 );
 watch(accountData.accountInfo, accountInfo => {
+  const isBrandNewDraft =
+    route.query.group === 'true' ? !route.query.groupIndex : !route.query.draftId;
+
   if (!accountInfo) {
     data.receiverSignatureRequired = false;
     data.maxAutomaticTokenAssociations = 0;
@@ -117,7 +120,7 @@ watch(accountData.accountInfo, accountInfo => {
     data.declineStakingReward = false;
     data.accountMemo = '';
     data.ownerKey = null;
-  } else if (!route.query.draftId) {
+  } else if (isBrandNewDraft) {
     data.receiverSignatureRequired = accountInfo.receiverSignatureRequired;
     data.maxAutomaticTokenAssociations = accountInfo.maxAutomaticTokenAssociations || 0;
     data.stakedAccountId = accountInfo.stakedAccountId?.toString() || '';

--- a/front-end/src/renderer/components/Transaction/Details/AccountDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/AccountDetails.vue
@@ -288,7 +288,7 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
         {{
           transaction.stakedAccountId && transaction.stakedAccountId.toString() !== '0.0.0'
             ? `Account ${transaction.stakedAccountId.toString()}`
-            : transaction.stakedNodeId && isAccountId(transaction.stakedNodeId.toString())
+            : transaction.stakedNodeId !== null && isAccountId(transaction.stakedNodeId.toString())
               ? `Node ${transaction.stakedNodeId.toString()}`
               : transaction instanceof AccountCreateTransaction
                 ? 'None'

--- a/front-end/src/renderer/components/Transaction/TransactionHeaderControls.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionHeaderControls.vue
@@ -121,7 +121,7 @@ watch(showAddReminder, show => {
             :disabled="createButtonDisabled"
           >
             <span class="bi bi-plus-lg" />
-            {{ $route.params.seq ? 'Edit Group Item' : 'Add to Group' }}
+            {{ $route.params.seq ? 'Save Group Item' : 'Add to Group' }}
           </AppButton>
         </div>
       </template>

--- a/front-end/src/renderer/composables/useAccountId.ts
+++ b/front-end/src/renderer/composables/useAccountId.ts
@@ -121,7 +121,7 @@ export default function useAccountId() {
   }
 
   function getStakedToString() {
-    if (accountInfo.value?.stakedNodeId) {
+    if (accountInfo.value?.stakedNodeId != null) {
       return `Node ${accountInfo.value?.stakedNodeId}`;
     } else if (accountInfo.value?.stakedAccountId) {
       return `Account ${accountInfo.value?.stakedAccountId}`;

--- a/front-end/src/renderer/services/transactionGroupsService.ts
+++ b/front-end/src/renderer/services/transactionGroupsService.ts
@@ -64,7 +64,7 @@ export const addGroupWithDrafts = async (
         user_id: userId,
         transactionBytes: item.transactionBytes.toString(),
         type: getTransactionType(item.transactionBytes),
-        description: '', //TO DO: Add description
+        description: item.description,
         details: details || null,
       };
       const draft = await window.electronAPI.local.transactionDrafts.addDraft(transactionDraft);
@@ -138,6 +138,7 @@ export async function updateGroup(
         created_at: new Date(),
         updated_at: new Date(),
         user_id: userId,
+        description: item.description,
         transactionBytes: item.transactionBytes.toString(),
         type: getTransactionType(item.transactionBytes),
       };
@@ -152,7 +153,7 @@ export async function updateGroup(
           created_at: new Date(),
           updated_at: new Date(),
           user_id: userId,
-          description: '', //TO DO: Add description
+          description: item.description,
           transactionBytes: item.transactionBytes.toString(),
           type: getTransactionType(item.transactionBytes),
         };

--- a/front-end/src/renderer/utils/sdk/getData.ts
+++ b/front-end/src/renderer/utils/sdk/getData.ts
@@ -101,9 +101,13 @@ const getAccountData = (transaction: Transaction): AccountData => {
     receiverSignatureRequired: transaction.receiverSignatureRequired || false,
     declineStakingReward: transaction.declineStakingRewards || false,
     maxAutomaticTokenAssociations: transaction.maxAutomaticTokenAssociations?.toNumber() || 0,
-    stakeType: transaction.stakedAccountId ? 'Account' : transaction.stakedNodeId ? 'Node' : 'None',
+    stakeType: transaction.stakedAccountId
+      ? 'Account'
+      : transaction.stakedNodeId !== null
+        ? 'Node'
+        : 'None',
     stakedAccountId: transaction.stakedAccountId?.toString() || '',
-    stakedNodeId: transaction.stakedNodeId?.toNumber() || null,
+    stakedNodeId: transaction.stakedNodeId !== null ? transaction.stakedNodeId.toNumber() : null,
     accountMemo: transaction.accountMemo || '',
     ownerKey: transaction.key || null,
   };

--- a/front-end/src/renderer/utils/sdk/getData.ts
+++ b/front-end/src/renderer/utils/sdk/getData.ts
@@ -43,7 +43,7 @@ import type {
   SystemUndeleteData,
   TransactionCommonData,
   TransferHbarData,
-} from './createTransactions';
+} from '@renderer/utils';
 import { getMaximumExpirationTime, getMinimumExpirationTime } from '.';
 import { uint8ToHex } from '..';
 

--- a/front-end/src/tests/main/windows/mainWindow.spec.ts
+++ b/front-end/src/tests/main/windows/mainWindow.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import type { MockedClass, MockedObject } from 'vitest';
 import { vi } from 'vitest';
 


### PR DESCRIPTION
**Description**:

- For transaction group items:
   - fix saving of description
   - fix saving of all properties specific to AccountUpdate transaction (like key, staking, max # of associations, etc...)
- For AccountUpdate transaction (whether single or in a group): fix saving of stakingNodeId when == 0
- Rename button label from `Edit Group Item` to `Save Group Item`.

**Related issue(s)**:

Fixes #2700

