### PR TITLE
fix: inconsistent visibility of save complex key

### DIFF
--- a/front-end/src/renderer/components/ComplexKey/ComplexKeyModal.vue
+++ b/front-end/src/renderer/components/ComplexKey/ComplexKeyModal.vue
@@ -49,10 +49,6 @@ const matchingSavedKey = computed<SavedComplexKey | null>(() => {
   return props.savedComplexKeys.find(k => k.protobufEncoded === encoded) ?? null;
 });
 
-const isSingleKey = computed(
-  () => currentKey.value instanceof KeyList && currentKey.value.toArray().length < 2,
-);
-
 /* Handlers */
 const handleShowUpdate = (show: boolean) => emit('update:show', show);
 
@@ -120,7 +116,7 @@ const modalContentContainerStyle = { padding: '0 10%', height: '80%' };
               >{{ summaryMode ? 'Edit Mode' : 'View Summary' }}</AppButton
             >
             <AppButton
-              v-if="onSaveComplexKey && !currentKeyInvalid && !matchingSavedKey && !isSingleKey"
+              v-if="onSaveComplexKey && !currentKeyInvalid && !matchingSavedKey"
               type="button"
               color="primary"
               class="ms-3"

--- a/front-end/src/renderer/components/ComplexKey/ComplexKeyModal.vue
+++ b/front-end/src/renderer/components/ComplexKey/ComplexKeyModal.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import type { ComplexKey as SavedComplexKey } from '@prisma/client';
+
 import { computed, ref, watch } from 'vue';
 
 import { Key, KeyList } from '@hiero-ledger/sdk';
 
-import { isKeyListValid } from '@renderer/utils';
+import { encodeKey, isKeyListValid } from '@renderer/utils';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppModal from '@renderer/components/ui/AppModal.vue';
@@ -18,9 +20,11 @@ const props = withDefaults(
     show: boolean;
     onSaveComplexKey?: () => void;
     noThreshold?: boolean;
+    savedComplexKeys?: SavedComplexKey[];
   }>(),
   {
     noThreshold: false,
+    savedComplexKeys: () => [],
   },
 );
 
@@ -37,6 +41,16 @@ const currentKeyInvalid = computed(
   () =>
     currentKey.value === null ||
     (currentKey.value instanceof KeyList && !isKeyListValid(currentKey.value)),
+);
+
+const matchingSavedKey = computed<SavedComplexKey | null>(() => {
+  if (!(currentKey.value instanceof KeyList) || !isKeyListValid(currentKey.value)) return null;
+  const encoded = encodeKey(currentKey.value).toString();
+  return props.savedComplexKeys.find(k => k.protobufEncoded === encoded) ?? null;
+});
+
+const isSingleKey = computed(
+  () => currentKey.value instanceof KeyList && currentKey.value.toArray().length < 2,
 );
 
 /* Handlers */
@@ -88,6 +102,16 @@ const modalContentContainerStyle = { padding: '0 10%', height: '80%' };
         <h1 class="text-title text-semi-bold text-center">Complex Key</h1>
         <div :style="modalContentContainerStyle">
           <div class="text-end">
+            <span
+              v-if="matchingSavedKey && onSaveComplexKey"
+              class="text-warning text-small me-3"
+              data-testid="span-complex-key-already-exists"
+            >
+              <i class="bi bi-exclamation-triangle-fill me-2"></i>
+              Complex key already exists{{
+                matchingSavedKey.nickname ? ` ("${matchingSavedKey.nickname}")` : ''
+              }}
+            </span>
             <AppButton
               color="borderless"
               type="button"
@@ -96,7 +120,7 @@ const modalContentContainerStyle = { padding: '0 10%', height: '80%' };
               >{{ summaryMode ? 'Edit Mode' : 'View Summary' }}</AppButton
             >
             <AppButton
-              v-if="onSaveComplexKey && !currentKeyInvalid"
+              v-if="onSaveComplexKey && !currentKeyInvalid && !matchingSavedKey && !isSingleKey"
               type="button"
               color="primary"
               class="ms-3"

--- a/front-end/src/renderer/components/KeyField.vue
+++ b/front-end/src/renderer/components/KeyField.vue
@@ -180,9 +180,10 @@ const handleComplexKeyUpdate = async (keyList: KeyList) => {
       error instanceof Error ? error.message : 'Failed to update complex key',
     );
   } finally {
-    // Hold the in-flight flag through one tick so any pre-flush watcher queued during
-    // this handler (e.g. from the parent's v-model setProps) fires before the flag flips.
-    // If watcher at line 232 is ever switched to flush: 'post', this invariant breaks.
+    // Hold updateInFlight through one tick so the pre-flush watcher of
+    // [props.modelKey, savedComplexKeys] (below) — which assigns selectedComplexKey
+    // from findSavedKeyMatching — fires while the guard is still on and bails out.
+    // If that watcher is ever switched to flush: 'post', this invariant breaks.
     await nextTick();
     updateInFlight.value = false;
   }

--- a/front-end/src/renderer/components/KeyField.vue
+++ b/front-end/src/renderer/components/KeyField.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ComplexKey } from '@prisma/client';
 
-import { ref, watch } from 'vue';
+import { onMounted, ref, watch } from 'vue';
 
 import { Key, KeyList, PublicKey } from '@hiero-ledger/sdk';
 
@@ -9,7 +9,7 @@ import useUserStore from '@renderer/stores/storeUser';
 
 import { ToastManager } from '@renderer/utils/ToastManager';
 
-import { getComplexKey, updateComplexKey } from '@renderer/services/complexKeysService';
+import { getComplexKeys, updateComplexKey } from '@renderer/services/complexKeysService';
 
 import {
   isPublicKey,
@@ -65,12 +65,23 @@ const publicKeyOwnerCache = AppCache.inject().backendPublicKeyOwner;
 const currentTab = ref(Tabs.SIGNLE);
 const publicKeyInputRef = ref<InstanceType<typeof AppPublicKeyInput> | null>(null);
 const selectedComplexKey = ref<ComplexKey | null>(null);
+const savedComplexKeys = ref<ComplexKey[]>([]);
 const complexKeyModalShown = ref(false);
 const addPublicKeyModalShown = ref(false);
 const selectSavedKeyModalShown = ref(false);
 const saveKeyListModalShown = ref(false);
 const formattedKey = ref('');
 const identifier = ref<string | null | undefined>(null);
+
+const findSavedKeyMatching = (keyList: KeyList): ComplexKey | null => {
+  const encoded = encodeKey(keyList).toString();
+  return savedComplexKeys.value.find(k => k.protobufEncoded === encoded) ?? null;
+};
+
+const loadSavedComplexKeys = async () => {
+  if (!ush.isUserLoggedIn(user.personal)) return;
+  savedComplexKeys.value = await getComplexKeys(user.personal.id);
+};
 
 /* Handlers */
 const handleTabChange = (tab: Tabs) => {
@@ -111,6 +122,7 @@ const handleSaveKeyList = async (complexKey: ComplexKey) => {
   selectedComplexKey.value = complexKey;
   complexKeyModalShown.value = false;
   saveKeyListModalShown.value = false;
+  await loadSavedComplexKeys();
 };
 
 const handleEditComplexKey = () => {
@@ -158,7 +170,7 @@ watch(
   { immediate: true },
 );
 
-watch([() => props.modelKey, publicKeyInputRef], async ([newKey, newInputRef]) => {
+watch([() => props.modelKey, publicKeyInputRef, savedComplexKeys], ([newKey, newInputRef]) => {
   if (!ush.isUserLoggedIn(user.personal)) {
     throw new Error('User is not logged in');
   }
@@ -166,12 +178,14 @@ watch([() => props.modelKey, publicKeyInputRef], async ([newKey, newInputRef]) =
   if (newKey instanceof PublicKey && newInputRef?.inputRef?.inputRef) {
     newInputRef.inputRef.inputRef.value = newKey.toStringRaw();
   } else if (newKey instanceof KeyList) {
-    selectedComplexKey.value = (await getComplexKey(user.personal.id, newKey)) || null;
+    selectedComplexKey.value = findSavedKeyMatching(newKey);
     currentTab.value = Tabs.COMPLEX;
   } else if (newInputRef?.inputRef?.inputRef) {
     newInputRef.inputRef.inputRef.value = '';
   }
 });
+
+onMounted(loadSavedComplexKeys);
 </script>
 <template>
   <div class="border rounded p-4">
@@ -227,6 +241,7 @@ watch([() => props.modelKey, publicKeyInputRef], async ([newKey, newInputRef]) =
           @update:model-key="handleComplexKeyUpdate"
           :on-save-complex-key="selectedComplexKey ? undefined : handleSaveComplexKeyButtonClick"
           :no-threshold="noThreshold"
+          :saved-complex-keys="savedComplexKeys"
         >
           <ComplexKeySaveKeyModal
             v-if="saveKeyListModalShown && modelKey instanceof KeyList && true"

--- a/front-end/src/renderer/components/KeyField.vue
+++ b/front-end/src/renderer/components/KeyField.vue
@@ -73,6 +73,7 @@ const saveKeyListModalShown = ref(false);
 const formattedKey = ref('');
 const identifier = ref<string | null | undefined>(null);
 
+/* Functions */
 const findSavedKeyMatching = (keyList: KeyList): ComplexKey | null => {
   const encoded = encodeKey(keyList).toString();
   return savedComplexKeys.value.find(k => k.protobufEncoded === encoded) ?? null;
@@ -80,7 +81,13 @@ const findSavedKeyMatching = (keyList: KeyList): ComplexKey | null => {
 
 const loadSavedComplexKeys = async () => {
   if (!ush.isUserLoggedIn(user.personal)) return;
-  savedComplexKeys.value = await getComplexKeys(user.personal.id);
+  try {
+    savedComplexKeys.value = await getComplexKeys(user.personal.id);
+  } catch (error) {
+    toastManager.error(
+      error instanceof Error ? error.message : 'Failed to load saved complex keys',
+    );
+  }
 };
 
 /* Handlers */
@@ -130,13 +137,31 @@ const handleEditComplexKey = () => {
 };
 
 const handleComplexKeyUpdate = async (keyList: KeyList) => {
+  if (!selectedComplexKey.value) {
+    emit('update:modelKey', keyList);
+    return;
+  }
+
+  const keyListBytes = encodeKey(keyList);
+  const targetId = selectedComplexKey.value.id;
+  const idx = savedComplexKeys.value.findIndex(k => k.id === targetId);
+  if (idx !== -1) {
+    savedComplexKeys.value[idx] = {
+      ...savedComplexKeys.value[idx],
+      protobufEncoded: keyListBytes.toString(),
+    };
+  }
+
   emit('update:modelKey', keyList);
 
-  if (selectedComplexKey.value) {
-    const keyListBytes = encodeKey(keyList);
-    selectedComplexKey.value = await updateComplexKey(selectedComplexKey.value.id, keyListBytes);
-    toastManager.success('Key list updated successfully');
+  const updated = await updateComplexKey(targetId, keyListBytes);
+  selectedComplexKey.value = updated;
+  if (idx !== -1) {
+    savedComplexKeys.value[idx] = updated;
+  } else {
+    await loadSavedComplexKeys();
   }
+  toastManager.success('Key list updated successfully');
 };
 
 const handleSaveComplexKeyButtonClick = () => {
@@ -170,21 +195,29 @@ watch(
   { immediate: true },
 );
 
-watch([() => props.modelKey, publicKeyInputRef, savedComplexKeys], ([newKey, newInputRef]) => {
-  if (!ush.isUserLoggedIn(user.personal)) {
-    throw new Error('User is not logged in');
-  }
+watch([() => props.modelKey, publicKeyInputRef], ([newKey, newInputRef]) => {
+  if (!ush.isUserLoggedIn(user.personal)) return;
 
   if (newKey instanceof PublicKey && newInputRef?.inputRef?.inputRef) {
     newInputRef.inputRef.inputRef.value = newKey.toStringRaw();
   } else if (newKey instanceof KeyList) {
-    selectedComplexKey.value = findSavedKeyMatching(newKey);
     currentTab.value = Tabs.COMPLEX;
   } else if (newInputRef?.inputRef?.inputRef) {
     newInputRef.inputRef.inputRef.value = '';
   }
 });
 
+watch([() => props.modelKey, savedComplexKeys], ([newKey]) => {
+  if (newKey instanceof KeyList) {
+    selectedComplexKey.value = findSavedKeyMatching(newKey);
+  }
+});
+
+watch(selectSavedKeyModalShown, open => {
+  if (!open) loadSavedComplexKeys();
+});
+
+/* Hooks */
 onMounted(loadSavedComplexKeys);
 </script>
 <template>

--- a/front-end/src/renderer/components/KeyField.vue
+++ b/front-end/src/renderer/components/KeyField.vue
@@ -145,6 +145,7 @@ const handleComplexKeyUpdate = async (keyList: KeyList) => {
   const keyListBytes = encodeKey(keyList);
   const targetId = selectedComplexKey.value.id;
   const idx = savedComplexKeys.value.findIndex(k => k.id === targetId);
+  const snapshot = idx !== -1 ? savedComplexKeys.value[idx] : null;
   if (idx !== -1) {
     savedComplexKeys.value[idx] = {
       ...savedComplexKeys.value[idx],
@@ -154,14 +155,23 @@ const handleComplexKeyUpdate = async (keyList: KeyList) => {
 
   emit('update:modelKey', keyList);
 
-  const updated = await updateComplexKey(targetId, keyListBytes);
-  selectedComplexKey.value = updated;
-  if (idx !== -1) {
-    savedComplexKeys.value[idx] = updated;
-  } else {
-    await loadSavedComplexKeys();
+  try {
+    const updated = await updateComplexKey(targetId, keyListBytes);
+    selectedComplexKey.value = updated;
+    if (idx !== -1) {
+      savedComplexKeys.value[idx] = updated;
+    } else {
+      await loadSavedComplexKeys();
+    }
+    toastManager.success('Key list updated successfully');
+  } catch (error) {
+    if (snapshot && idx !== -1) {
+      savedComplexKeys.value[idx] = snapshot;
+    }
+    toastManager.error(
+      error instanceof Error ? error.message : 'Failed to update complex key',
+    );
   }
-  toastManager.success('Key list updated successfully');
 };
 
 const handleSaveComplexKeyButtonClick = () => {

--- a/front-end/src/renderer/components/KeyField.vue
+++ b/front-end/src/renderer/components/KeyField.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ComplexKey } from '@prisma/client';
 
-import { onMounted, ref, watch } from 'vue';
+import { nextTick, onMounted, ref, watch } from 'vue';
 
 import { Key, KeyList, PublicKey } from '@hiero-ledger/sdk';
 
@@ -70,6 +70,7 @@ const complexKeyModalShown = ref(false);
 const addPublicKeyModalShown = ref(false);
 const selectSavedKeyModalShown = ref(false);
 const saveKeyListModalShown = ref(false);
+const updateInFlight = ref(false);
 const formattedKey = ref('');
 const identifier = ref<string | null | undefined>(null);
 
@@ -141,36 +142,46 @@ const handleComplexKeyUpdate = async (keyList: KeyList) => {
     emit('update:modelKey', keyList);
     return;
   }
+  if (updateInFlight.value) return;
 
   const keyListBytes = encodeKey(keyList);
   const targetId = selectedComplexKey.value.id;
-  const idx = savedComplexKeys.value.findIndex(k => k.id === targetId);
-  const snapshot = idx !== -1 ? savedComplexKeys.value[idx] : null;
-  if (idx !== -1) {
-    savedComplexKeys.value[idx] = {
-      ...savedComplexKeys.value[idx],
+  const initialIdx = savedComplexKeys.value.findIndex(k => k.id === targetId);
+  const snapshot = initialIdx !== -1 ? savedComplexKeys.value[initialIdx] : null;
+  if (initialIdx !== -1) {
+    savedComplexKeys.value[initialIdx] = {
+      ...savedComplexKeys.value[initialIdx],
       protobufEncoded: keyListBytes.toString(),
     };
   }
 
   emit('update:modelKey', keyList);
+  updateInFlight.value = true;
 
   try {
     const updated = await updateComplexKey(targetId, keyListBytes);
     selectedComplexKey.value = updated;
-    if (idx !== -1) {
-      savedComplexKeys.value[idx] = updated;
+    const successIdx = savedComplexKeys.value.findIndex(k => k.id === targetId);
+    if (successIdx !== -1) {
+      savedComplexKeys.value[successIdx] = updated;
     } else {
       await loadSavedComplexKeys();
     }
     toastManager.success('Key list updated successfully');
   } catch (error) {
-    if (snapshot && idx !== -1) {
-      savedComplexKeys.value[idx] = snapshot;
+    if (snapshot) {
+      const rejectIdx = savedComplexKeys.value.findIndex(k => k.id === targetId);
+      if (rejectIdx !== -1) {
+        savedComplexKeys.value[rejectIdx] = snapshot;
+      }
+      selectedComplexKey.value = snapshot;
     }
     toastManager.error(
       error instanceof Error ? error.message : 'Failed to update complex key',
     );
+  } finally {
+    await nextTick();
+    updateInFlight.value = false;
   }
 };
 
@@ -218,6 +229,7 @@ watch([() => props.modelKey, publicKeyInputRef], ([newKey, newInputRef]) => {
 });
 
 watch([() => props.modelKey, savedComplexKeys], ([newKey]) => {
+  if (updateInFlight.value) return;
   if (newKey instanceof KeyList) {
     selectedComplexKey.value = findSavedKeyMatching(newKey);
   }

--- a/front-end/src/renderer/components/KeyField.vue
+++ b/front-end/src/renderer/components/KeyField.vue
@@ -180,6 +180,9 @@ const handleComplexKeyUpdate = async (keyList: KeyList) => {
       error instanceof Error ? error.message : 'Failed to update complex key',
     );
   } finally {
+    // Hold the in-flight flag through one tick so any pre-flush watcher queued during
+    // this handler (e.g. from the parent's v-model setProps) fires before the flag flips.
+    // If watcher at line 232 is ever switched to flush: 'post', this invariant breaks.
     await nextTick();
     updateInFlight.value = false;
   }

--- a/front-end/src/tests/renderer/components/ComplexKey/ComplexKeyModal.spec.ts
+++ b/front-end/src/tests/renderer/components/ComplexKey/ComplexKeyModal.spec.ts
@@ -1,0 +1,322 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { KeyList, PrivateKey } from '@hiero-ledger/sdk';
+import { proto } from '@hiero-ledger/proto';
+import type { ComplexKey } from '@prisma/client';
+
+import ComplexKeyModal from '@renderer/components/ComplexKey/ComplexKeyModal.vue';
+
+const mocks = vi.hoisted(() => ({
+  encodeKey: vi.fn(),
+  isKeyListValid: vi.fn(),
+}));
+
+vi.mock('@renderer/utils', () => ({
+  encodeKey: mocks.encodeKey,
+  isKeyListValid: mocks.isKeyListValid,
+}));
+
+const realEncodeKey = (k: KeyList) => proto.Key.encode(k._toProtobufKey()).finish();
+
+const realIsKeyListValid = (kl: KeyList): boolean => {
+  const keys = kl.toArray();
+  if (keys.length === 0) return false;
+  if (kl.threshold && kl.threshold > keys.length) return false;
+  for (const k of keys) {
+    if (k instanceof KeyList && !realIsKeyListValid(k)) return false;
+  }
+  return true;
+};
+
+const globalStubs = {
+  AppModal: {
+    props: ['show', 'closeOnClickOutside', 'closeOnEscape'],
+    template: '<div data-stub="app-modal"><slot /></div>',
+  },
+  AppButton: {
+    props: ['color', 'type', 'disabled'],
+    template:
+      '<button :data-color="color" :type="type || \'button\'" v-bind="$attrs"><slot /></button>',
+    inheritAttrs: false,
+  },
+  AppCustomIcon: { props: ['name'], template: '<div data-stub="app-custom-icon" />' },
+  ComplexKey: {
+    name: 'ComplexKey',
+    props: ['modelKey', 'noThreshold'],
+    emits: ['update:model-key'],
+    template: '<div data-stub="complex-key" />',
+  },
+  KeyStructure: {
+    props: ['keyList', 'noThreshold'],
+    template: '<div data-stub="key-structure" />',
+  },
+};
+
+const pk1 = PrivateKey.generateED25519().publicKey;
+const pk2 = PrivateKey.generateED25519().publicKey;
+const pk3 = PrivateKey.generateED25519().publicKey;
+
+const makeSavedKey = (keyList: KeyList, overrides: Partial<ComplexKey> = {}): ComplexKey => ({
+  id: 'saved-1',
+  user_id: 'user-1',
+  protobufEncoded: realEncodeKey(keyList).toString(),
+  nickname: 'Saved Key',
+  created_at: new Date('2025-01-01T00:00:00Z'),
+  updated_at: new Date('2025-01-01T00:00:00Z'),
+  ...overrides,
+});
+
+const SAVE_BTN = '[data-testid="button-complex-key-save"]';
+const DONE_BTN = '[data-testid="button-complex-key-done"]';
+const WARN_SPAN = '[data-testid="span-complex-key-already-exists"]';
+
+describe('ComplexKeyModal.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.encodeKey.mockImplementation(realEncodeKey);
+    mocks.isKeyListValid.mockImplementation(realIsKeyListValid);
+  });
+
+  function mountModal(props: Record<string, unknown> = {}) {
+    return mount(ComplexKeyModal, {
+      props: {
+        modelKey: null,
+        show: true,
+        ...props,
+      },
+      global: { stubs: globalStubs },
+    });
+  }
+
+  describe('"Save Complex Key" button visibility', () => {
+    it('renders when valid multi-key list, no match, callback defined', () => {
+      const wrapper = mountModal({
+        modelKey: new KeyList([pk1, pk2]),
+        onSaveComplexKey: vi.fn(),
+        savedComplexKeys: [],
+      });
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(true);
+    });
+
+    it('hides when onSaveComplexKey is undefined (edit-existing flow)', () => {
+      const wrapper = mountModal({
+        modelKey: new KeyList([pk1, pk2]),
+        savedComplexKeys: [],
+      });
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(false);
+    });
+
+    it('hides when modelKey is null (currentKeyInvalid)', () => {
+      const wrapper = mountModal({
+        modelKey: null,
+        onSaveComplexKey: vi.fn(),
+      });
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(false);
+    });
+
+    it('hides when KeyList contains a single key (isSingleKey)', () => {
+      const wrapper = mountModal({
+        modelKey: new KeyList([pk1]),
+        onSaveComplexKey: vi.fn(),
+        savedComplexKeys: [],
+      });
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(false);
+    });
+
+    it('hides when KeyList is empty', () => {
+      const wrapper = mountModal({
+        modelKey: new KeyList([]),
+        onSaveComplexKey: vi.fn(),
+        savedComplexKeys: [],
+      });
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(false);
+    });
+
+    it('hides when the current keys match an existing saved complex key', () => {
+      const keyList = new KeyList([pk1, pk2]);
+      const wrapper = mountModal({
+        modelKey: keyList,
+        onSaveComplexKey: vi.fn(),
+        savedComplexKeys: [makeSavedKey(keyList)],
+      });
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(false);
+    });
+
+    it('remains visible when saved keys exist but none match current keys', () => {
+      const wrapper = mountModal({
+        modelKey: new KeyList([pk1, pk2]),
+        onSaveComplexKey: vi.fn(),
+        savedComplexKeys: [makeSavedKey(new KeyList([pk1, pk3]))],
+      });
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(true);
+    });
+
+    it('hides when KeyList has a threshold higher than its key count (invalid structure)', () => {
+      const invalidList = new KeyList([pk1, pk2]);
+      invalidList.setThreshold(5);
+      const wrapper = mountModal({
+        modelKey: invalidList,
+        onSaveComplexKey: vi.fn(),
+        savedComplexKeys: [],
+      });
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(false);
+    });
+  });
+
+  describe('"Complex key already exists" warning span', () => {
+    it('renders with the saved key nickname in create mode when there is a match', () => {
+      const keyList = new KeyList([pk1, pk2]);
+      const wrapper = mountModal({
+        modelKey: keyList,
+        onSaveComplexKey: vi.fn(),
+        savedComplexKeys: [makeSavedKey(keyList, { nickname: 'My Saved Key' })],
+      });
+      const span = wrapper.find(WARN_SPAN);
+      expect(span.exists()).toBe(true);
+      expect(span.text()).toContain('Complex key already exists');
+      expect(span.text()).toContain('"My Saved Key"');
+    });
+
+    it('renders without quoted nickname when the saved key has an empty nickname', () => {
+      const keyList = new KeyList([pk1, pk2]);
+      const wrapper = mountModal({
+        modelKey: keyList,
+        onSaveComplexKey: vi.fn(),
+        savedComplexKeys: [makeSavedKey(keyList, { nickname: '' })],
+      });
+      const span = wrapper.find(WARN_SPAN);
+      expect(span.exists()).toBe(true);
+      expect(span.text()).toContain('Complex key already exists');
+      expect(span.text()).not.toContain('""');
+    });
+
+    it('does not render when there is no match', () => {
+      const wrapper = mountModal({
+        modelKey: new KeyList([pk1, pk2]),
+        onSaveComplexKey: vi.fn(),
+        savedComplexKeys: [],
+      });
+      expect(wrapper.find(WARN_SPAN).exists()).toBe(false);
+    });
+
+    it('does not render in edit mode (onSaveComplexKey undefined) even when a match exists', () => {
+      const keyList = new KeyList([pk1, pk2]);
+      const wrapper = mountModal({
+        modelKey: keyList,
+        savedComplexKeys: [makeSavedKey(keyList)],
+      });
+      expect(wrapper.find(WARN_SPAN).exists()).toBe(false);
+    });
+
+    it('does not render when the current key list is invalid', () => {
+      const empty = new KeyList([]);
+      const wrapper = mountModal({
+        modelKey: empty,
+        onSaveComplexKey: vi.fn(),
+        savedComplexKeys: [makeSavedKey(empty)],
+      });
+      expect(wrapper.find(WARN_SPAN).exists()).toBe(false);
+    });
+  });
+
+  describe('Done button', () => {
+    it('is always rendered regardless of state', () => {
+      const wrapper = mountModal({ modelKey: null });
+      expect(wrapper.find(DONE_BTN).exists()).toBe(true);
+    });
+
+    it('is rendered alongside Save Complex Key when the state is valid', () => {
+      const wrapper = mountModal({
+        modelKey: new KeyList([pk1, pk2]),
+        onSaveComplexKey: vi.fn(),
+      });
+      expect(wrapper.find(DONE_BTN).exists()).toBe(true);
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(true);
+    });
+  });
+
+  describe('Save Complex Key click', () => {
+    it('emits update:modelKey and invokes onSaveComplexKey when valid', async () => {
+      const onSave = vi.fn();
+      const keyList = new KeyList([pk1, pk2]);
+      const wrapper = mountModal({
+        modelKey: keyList,
+        onSaveComplexKey: onSave,
+        savedComplexKeys: [],
+      });
+
+      await wrapper.find(SAVE_BTN).trigger('click');
+
+      expect(onSave).toHaveBeenCalledTimes(1);
+      const emitted = wrapper.emitted('update:modelKey');
+      expect(emitted).toBeTruthy();
+      expect(emitted![0][0]).toStrictEqual(keyList);
+    });
+  });
+
+  describe('savedComplexKeys prop default', () => {
+    it('defaults to an empty array when omitted (Save button shown, warning hidden)', () => {
+      const wrapper = mountModal({
+        modelKey: new KeyList([pk1, pk2]),
+        onSaveComplexKey: vi.fn(),
+      });
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(true);
+      expect(wrapper.find(WARN_SPAN).exists()).toBe(false);
+    });
+  });
+
+  describe('reactivity to inner ComplexKey updates', () => {
+    it('hides Save button after the inner key list is updated to match a saved key', async () => {
+      const initial = new KeyList([pk1, pk3]);
+      const matching = new KeyList([pk1, pk2]);
+      const wrapper = mountModal({
+        modelKey: initial,
+        onSaveComplexKey: vi.fn(),
+        savedComplexKeys: [makeSavedKey(matching)],
+      });
+
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(true);
+      expect(wrapper.find(WARN_SPAN).exists()).toBe(false);
+
+      const innerComplexKey = wrapper.findComponent({ name: 'ComplexKey' });
+      await innerComplexKey.vm.$emit('update:model-key', matching);
+
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(false);
+      expect(wrapper.find(WARN_SPAN).exists()).toBe(true);
+    });
+
+    it('hides Save button after the inner key list is reduced to a single key', async () => {
+      const wrapper = mountModal({
+        modelKey: new KeyList([pk1, pk2]),
+        onSaveComplexKey: vi.fn(),
+        savedComplexKeys: [],
+      });
+
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(true);
+
+      const innerComplexKey = wrapper.findComponent({ name: 'ComplexKey' });
+      await innerComplexKey.vm.$emit('update:model-key', new KeyList([pk1]));
+
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(false);
+    });
+
+    it('re-shows Save button after a previously matching key list is mutated away from the match', async () => {
+      const matching = new KeyList([pk1, pk2]);
+      const wrapper = mountModal({
+        modelKey: matching,
+        onSaveComplexKey: vi.fn(),
+        savedComplexKeys: [makeSavedKey(matching)],
+      });
+
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(false);
+      expect(wrapper.find(WARN_SPAN).exists()).toBe(true);
+
+      const innerComplexKey = wrapper.findComponent({ name: 'ComplexKey' });
+      await innerComplexKey.vm.$emit('update:model-key', new KeyList([pk1, pk3]));
+
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(true);
+      expect(wrapper.find(WARN_SPAN).exists()).toBe(false);
+    });
+  });
+});

--- a/front-end/src/tests/renderer/components/ComplexKey/ComplexKeyModal.spec.ts
+++ b/front-end/src/tests/renderer/components/ComplexKey/ComplexKeyModal.spec.ts
@@ -115,13 +115,13 @@ describe('ComplexKeyModal.vue', () => {
       expect(wrapper.find(SAVE_BTN).exists()).toBe(false);
     });
 
-    it('hides when KeyList contains a single key (isSingleKey)', () => {
+    it('renders when KeyList contains a single key', () => {
       const wrapper = mountModal({
         modelKey: new KeyList([pk1]),
         onSaveComplexKey: vi.fn(),
         savedComplexKeys: [],
       });
-      expect(wrapper.find(SAVE_BTN).exists()).toBe(false);
+      expect(wrapper.find(SAVE_BTN).exists()).toBe(true);
     });
 
     it('hides when KeyList is empty', () => {
@@ -284,21 +284,6 @@ describe('ComplexKeyModal.vue', () => {
 
       expect(wrapper.find(SAVE_BTN).exists()).toBe(false);
       expect(wrapper.find(WARN_SPAN).exists()).toBe(true);
-    });
-
-    it('hides Save button after the inner key list is reduced to a single key', async () => {
-      const wrapper = mountModal({
-        modelKey: new KeyList([pk1, pk2]),
-        onSaveComplexKey: vi.fn(),
-        savedComplexKeys: [],
-      });
-
-      expect(wrapper.find(SAVE_BTN).exists()).toBe(true);
-
-      const innerComplexKey = wrapper.findComponent({ name: 'ComplexKey' });
-      await innerComplexKey.vm.$emit('update:model-key', new KeyList([pk1]));
-
-      expect(wrapper.find(SAVE_BTN).exists()).toBe(false);
     });
 
     it('re-shows Save button after a previously matching key list is mutated away from the match', async () => {

--- a/front-end/src/tests/renderer/components/KeyField.spec.ts
+++ b/front-end/src/tests/renderer/components/KeyField.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
-import { KeyList, PrivateKey } from '@hiero-ledger/sdk';
+import { Key, KeyList, PrivateKey } from '@hiero-ledger/sdk';
 import { proto } from '@hiero-ledger/proto';
 import type { ComplexKey } from '@prisma/client';
 
@@ -133,7 +133,10 @@ describe('KeyField.vue — complex key pre-fetch and pass-through', () => {
     );
     mocks.encodeKey.mockImplementation(realEncodeKey);
     mocks.isPublicKey.mockReturnValue(false);
-    mocks.decodeKeyList.mockImplementation((b: string) => b);
+    mocks.decodeKeyList.mockImplementation((b: string) => {
+      const bytes = Uint8Array.from(b.split(',').map(n => Number(n)));
+      return Key._fromProtobufKey(proto.Key.decode(bytes));
+    });
     mocks.formatPublicKey.mockImplementation(async (raw: string) => raw);
     mocks.extractIdentifier.mockReturnValue({ identifier: 'id' });
     mocks.getComplexKeys.mockResolvedValue([]);
@@ -277,6 +280,81 @@ describe('KeyField.vue — complex key pre-fetch and pass-through', () => {
 
       const modal = wrapper.findComponent(ComplexKeyModalStub);
       expect(modal.props('onSaveComplexKey')).toBeUndefined();
+    });
+  });
+
+  describe('handleComplexKeyUpdate (in-place edit of a saved complex key)', () => {
+    it('calls updateComplexKey, refreshes the cache row, and shows a success toast', async () => {
+      const original = new KeyList([pk1, pk2]);
+      const edited = new KeyList([pk1, pk3]);
+      const savedOriginal = makeSavedKey(original, { id: 'saved-1', nickname: 'Edited Key' });
+      mocks.getComplexKeys.mockResolvedValue([savedOriginal]);
+
+      const editedSaved: ComplexKey = {
+        ...savedOriginal,
+        protobufEncoded: realEncodeKey(edited).toString(),
+      };
+      mocks.updateComplexKey.mockResolvedValueOnce(editedSaved);
+
+      const wrapper = mountField({ modelKey: original });
+      await flushPromises();
+
+      const modal = wrapper.findComponent(ComplexKeyModalStub);
+      modal.vm.$emit('update:modelKey', edited);
+      await wrapper.setProps({ modelKey: edited });
+      await flushPromises();
+
+      expect(mocks.updateComplexKey).toHaveBeenCalledTimes(1);
+      expect(mocks.updateComplexKey).toHaveBeenCalledWith(
+        'saved-1',
+        expect.any(Uint8Array),
+      );
+      expect(modal.props('savedComplexKeys')).toEqual([editedSaved]);
+      expect(mocks.toastManager.success).toHaveBeenCalledWith('Key list updated successfully');
+      expect(mocks.toastManager.error).not.toHaveBeenCalled();
+    });
+
+    it('reverts the cache and shows an error toast when updateComplexKey rejects', async () => {
+      const original = new KeyList([pk1, pk2]);
+      const edited = new KeyList([pk1, pk3]);
+      const savedOriginal = makeSavedKey(original, { id: 'saved-1', nickname: 'Edited Key' });
+      mocks.getComplexKeys.mockResolvedValue([savedOriginal]);
+      mocks.updateComplexKey.mockRejectedValueOnce(new Error('Complex key not found!'));
+
+      const wrapper = mountField({ modelKey: original });
+      await flushPromises();
+
+      const modal = wrapper.findComponent(ComplexKeyModalStub);
+      modal.vm.$emit('update:modelKey', edited);
+      await wrapper.setProps({ modelKey: edited });
+      await flushPromises();
+
+      expect(mocks.updateComplexKey).toHaveBeenCalledTimes(1);
+      expect(modal.props('savedComplexKeys')).toEqual([savedOriginal]);
+      expect(mocks.toastManager.error).toHaveBeenCalledWith('Complex key not found!');
+      expect(mocks.toastManager.success).not.toHaveBeenCalled();
+    });
+
+    it('preserves selectedComplexKey while updateComplexKey is pending (optimistic cache write)', async () => {
+      const original = new KeyList([pk1, pk2]);
+      const edited = new KeyList([pk1, pk3]);
+      const savedOriginal = makeSavedKey(original, { id: 'saved-1', nickname: 'Pending Edit' });
+      mocks.getComplexKeys.mockResolvedValue([savedOriginal]);
+      mocks.updateComplexKey.mockReturnValueOnce(new Promise(() => {}));
+
+      const wrapper = mountField({ modelKey: original });
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="key-list-item"]').text()).toContain('Pending Edit');
+
+      const modal = wrapper.findComponent(ComplexKeyModalStub);
+      modal.vm.$emit('update:modelKey', edited);
+      await wrapper.setProps({ modelKey: edited });
+      await flushPromises();
+
+      const listItem = wrapper.find('[data-testid="key-list-item"]');
+      expect(listItem.text()).toContain('Pending Edit');
+      expect(listItem.text()).not.toContain('Unsaved Key List');
     });
   });
 });

--- a/front-end/src/tests/renderer/components/KeyField.spec.ts
+++ b/front-end/src/tests/renderer/components/KeyField.spec.ts
@@ -333,6 +333,36 @@ describe('KeyField.vue — complex key pre-fetch and pass-through', () => {
       expect(modal.props('savedComplexKeys')).toEqual([savedOriginal]);
       expect(mocks.toastManager.error).toHaveBeenCalledWith('Complex key not found!');
       expect(mocks.toastManager.success).not.toHaveBeenCalled();
+
+      const listItem = wrapper.find('[data-testid="key-list-item"]');
+      expect(listItem.exists()).toBe(true);
+      expect(listItem.text()).toContain('Edited Key');
+      expect(listItem.text()).not.toContain('Unsaved Key List');
+    });
+
+    it('ignores concurrent handleComplexKeyUpdate calls while one is in flight', async () => {
+      const original = new KeyList([pk1, pk2]);
+      const edited1 = new KeyList([pk1, pk3]);
+      const edited2 = new KeyList([pk2, pk3]);
+      const savedOriginal = makeSavedKey(original, { id: 'saved-1' });
+      mocks.getComplexKeys.mockResolvedValue([savedOriginal]);
+      mocks.updateComplexKey.mockReturnValue(new Promise(() => {}));
+
+      const wrapper = mountField({ modelKey: original });
+      await flushPromises();
+
+      const modal = wrapper.findComponent(ComplexKeyModalStub);
+      modal.vm.$emit('update:modelKey', edited1);
+      await wrapper.setProps({ modelKey: edited1 });
+      await flushPromises();
+
+      expect(mocks.updateComplexKey).toHaveBeenCalledTimes(1);
+
+      modal.vm.$emit('update:modelKey', edited2);
+      await wrapper.setProps({ modelKey: edited2 });
+      await flushPromises();
+
+      expect(mocks.updateComplexKey).toHaveBeenCalledTimes(1);
     });
 
     it('preserves selectedComplexKey while updateComplexKey is pending (optimistic cache write)', async () => {

--- a/front-end/src/tests/renderer/components/KeyField.spec.ts
+++ b/front-end/src/tests/renderer/components/KeyField.spec.ts
@@ -1,0 +1,282 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { KeyList, PrivateKey } from '@hiero-ledger/sdk';
+import { proto } from '@hiero-ledger/proto';
+import type { ComplexKey } from '@prisma/client';
+
+import KeyField from '@renderer/components/KeyField.vue';
+
+const mocks = vi.hoisted(() => ({
+  userPersonal: { id: 'user-1', isLoggedIn: true } as { id: string; isLoggedIn: boolean } | null,
+  isUserLoggedIn: vi.fn(),
+  getComplexKeys: vi.fn(),
+  updateComplexKey: vi.fn(),
+  toastManager: { error: vi.fn(), success: vi.fn() },
+  appCache: { backendPublicKeyOwner: { get: vi.fn(), set: vi.fn() } },
+  encodeKey: vi.fn(),
+  isPublicKey: vi.fn(),
+  decodeKeyList: vi.fn(),
+  formatPublicKey: vi.fn(),
+  extractIdentifier: vi.fn(),
+}));
+
+vi.mock('@renderer/stores/storeUser', () => ({
+  default: vi.fn(() => ({ personal: mocks.userPersonal })),
+}));
+
+vi.mock('@renderer/utils/ToastManager', () => ({
+  ToastManager: { inject: vi.fn(() => mocks.toastManager) },
+}));
+
+vi.mock('@renderer/services/complexKeysService', () => ({
+  getComplexKeys: mocks.getComplexKeys,
+  updateComplexKey: mocks.updateComplexKey,
+}));
+
+vi.mock('@renderer/utils', () => ({
+  isPublicKey: mocks.isPublicKey,
+  decodeKeyList: mocks.decodeKeyList,
+  encodeKey: mocks.encodeKey,
+  formatPublicKey: mocks.formatPublicKey,
+  extractIdentifier: mocks.extractIdentifier,
+}));
+
+vi.mock('@renderer/utils/userStoreHelpers', () => ({
+  isUserLoggedIn: mocks.isUserLoggedIn,
+}));
+
+vi.mock('@renderer/caches/AppCache', () => ({
+  AppCache: { inject: vi.fn(() => mocks.appCache) },
+}));
+
+const realEncodeKey = (k: KeyList) => proto.Key.encode(k._toProtobufKey()).finish();
+
+const ComplexKeyModalStub = {
+  name: 'ComplexKeyModal',
+  props: ['show', 'modelKey', 'onSaveComplexKey', 'noThreshold', 'savedComplexKeys'],
+  emits: ['update:show', 'update:modelKey'],
+  template: '<div data-testid="complex-key-modal-stub"><slot /></div>',
+};
+
+const ComplexKeySaveKeyModalStub = {
+  name: 'ComplexKeySaveKeyModal',
+  props: ['show', 'keyList', 'onComplexKeySave'],
+  emits: ['update:show'],
+  template: '<div data-testid="save-key-modal-stub" />',
+};
+
+const ComplexKeyAddPublicKeyModalStub = {
+  name: 'ComplexKeyAddPublicKeyModal',
+  props: ['show'],
+  emits: ['update:show', 'selected:single'],
+  template: '<div data-testid="add-public-key-modal-stub" />',
+};
+
+const ComplexKeySelectSavedKeyStub = {
+  name: 'ComplexKeySelectSavedKey',
+  props: ['show', 'onKeyListSelect', 'noThreshold'],
+  emits: ['update:show'],
+  template: '<div data-testid="select-saved-key-stub" />',
+};
+
+const AppPublicKeyInputStub = {
+  name: 'AppPublicKeyInput',
+  props: ['filled', 'label'],
+  emits: ['update:model-value'],
+  template: '<input data-testid="public-key-input" />',
+};
+
+const AppButtonStub = {
+  name: 'AppButton',
+  props: ['color', 'type', 'size'],
+  template: '<button v-bind="$attrs"><slot /></button>',
+  inheritAttrs: false,
+};
+
+const AppListItemStub = {
+  name: 'AppListItem',
+  props: ['selected'],
+  template: '<div data-testid="key-list-item"><slot /></div>',
+};
+
+const globalStubs = {
+  AppButton: AppButtonStub,
+  AppPublicKeyInput: AppPublicKeyInputStub,
+  AppListItem: AppListItemStub,
+  ComplexKeyModal: ComplexKeyModalStub,
+  ComplexKeyAddPublicKeyModal: ComplexKeyAddPublicKeyModalStub,
+  ComplexKeySelectSavedKey: ComplexKeySelectSavedKeyStub,
+  ComplexKeySaveKeyModal: ComplexKeySaveKeyModalStub,
+};
+
+const pk1 = PrivateKey.generateED25519().publicKey;
+const pk2 = PrivateKey.generateED25519().publicKey;
+const pk3 = PrivateKey.generateED25519().publicKey;
+
+const makeSavedKey = (keyList: KeyList, overrides: Partial<ComplexKey> = {}): ComplexKey => ({
+  id: 'saved-1',
+  user_id: 'user-1',
+  protobufEncoded: realEncodeKey(keyList).toString(),
+  nickname: 'Saved Key',
+  created_at: new Date('2025-01-01T00:00:00Z'),
+  updated_at: new Date('2025-01-01T00:00:00Z'),
+  ...overrides,
+});
+
+describe('KeyField.vue — complex key pre-fetch and pass-through', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.userPersonal = { id: 'user-1', isLoggedIn: true };
+    mocks.isUserLoggedIn.mockImplementation(
+      (u: unknown) => !!u && (u as { isLoggedIn?: boolean }).isLoggedIn === true,
+    );
+    mocks.encodeKey.mockImplementation(realEncodeKey);
+    mocks.isPublicKey.mockReturnValue(false);
+    mocks.decodeKeyList.mockImplementation((b: string) => b);
+    mocks.formatPublicKey.mockImplementation(async (raw: string) => raw);
+    mocks.extractIdentifier.mockReturnValue({ identifier: 'id' });
+    mocks.getComplexKeys.mockResolvedValue([]);
+  });
+
+  function mountField(props: Record<string, unknown> = {}) {
+    return mount(KeyField, {
+      props: { modelKey: null, ...props },
+      global: {
+        stubs: globalStubs,
+        config: { errorHandler: () => {} },
+      },
+    });
+  }
+
+  describe('initial complex key fetch (onMounted)', () => {
+    it('loads saved complex keys for the logged-in user on mount', async () => {
+      mountField();
+      await flushPromises();
+
+      expect(mocks.getComplexKeys).toHaveBeenCalledTimes(1);
+      expect(mocks.getComplexKeys).toHaveBeenCalledWith('user-1');
+    });
+
+    it('does not call getComplexKeys when the user is not logged in', async () => {
+      mocks.isUserLoggedIn.mockReturnValue(false);
+
+      mountField();
+      await flushPromises();
+
+      expect(mocks.getComplexKeys).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('passing savedComplexKeys to ComplexKeyModal', () => {
+    it('hands the loaded saved keys to the modal as a prop', async () => {
+      const keyList = new KeyList([pk1, pk2]);
+      const saved = [makeSavedKey(keyList, { nickname: 'A' })];
+      mocks.getComplexKeys.mockResolvedValue(saved);
+
+      const wrapper = mountField({ modelKey: new KeyList([pk1, pk3]) });
+      await flushPromises();
+
+      const modal = wrapper.findComponent(ComplexKeyModalStub);
+      expect(modal.exists()).toBe(true);
+      expect(modal.props('savedComplexKeys')).toEqual(saved);
+    });
+
+    it('passes an empty array before fetch resolves', async () => {
+      mocks.getComplexKeys.mockReturnValue(new Promise(() => {}));
+
+      const wrapper = mountField({ modelKey: new KeyList([pk1, pk2]) });
+      await flushPromises();
+
+      const modal = wrapper.findComponent(ComplexKeyModalStub);
+      expect(modal.exists()).toBe(true);
+      expect(modal.props('savedComplexKeys')).toEqual([]);
+    });
+  });
+
+  describe('synchronous match lookup', () => {
+    it('sets selectedComplexKey to the matching saved record when modelKey matches', async () => {
+      const matching = new KeyList([pk1, pk2]);
+      const saved = makeSavedKey(matching, { nickname: 'Matched Key' });
+      mocks.getComplexKeys.mockResolvedValue([saved]);
+
+      const wrapper = mountField({ modelKey: matching });
+      await flushPromises();
+
+      const listItem = wrapper.find('[data-testid="key-list-item"]');
+      expect(listItem.exists()).toBe(true);
+      expect(listItem.text()).toContain('Matched Key');
+      expect(listItem.text()).not.toContain('Unsaved Key List');
+    });
+
+    it('leaves selectedComplexKey null when no saved record matches the modelKey', async () => {
+      const modelKey = new KeyList([pk1, pk2]);
+      const otherSaved = makeSavedKey(new KeyList([pk1, pk3]), { nickname: 'Other' });
+      mocks.getComplexKeys.mockResolvedValue([otherSaved]);
+
+      const wrapper = mountField({ modelKey });
+      await flushPromises();
+
+      const listItem = wrapper.find('[data-testid="key-list-item"]');
+      expect(listItem.exists()).toBe(true);
+      expect(listItem.text()).toContain('Unsaved Key List');
+      expect(listItem.text()).not.toContain('Other');
+    });
+  });
+
+  describe('refresh after handleSaveKeyList', () => {
+    it('re-fetches saved complex keys after a new complex key is saved', async () => {
+      const matching = new KeyList([pk1, pk2]);
+      const afterSave = [makeSavedKey(matching, { id: 'new', nickname: 'Just Saved' })];
+
+      mocks.getComplexKeys.mockResolvedValueOnce([]);
+      mocks.getComplexKeys.mockResolvedValueOnce(afterSave);
+
+      const wrapper = mountField({ modelKey: matching });
+      await flushPromises();
+
+      expect(mocks.getComplexKeys).toHaveBeenCalledTimes(1);
+
+      const modal = wrapper.findComponent(ComplexKeyModalStub);
+      const onSaveComplexKey = modal.props('onSaveComplexKey') as (() => void) | undefined;
+      expect(onSaveComplexKey).toBeTypeOf('function');
+      onSaveComplexKey?.();
+      await flushPromises();
+
+      const saveModal = wrapper.findComponent(ComplexKeySaveKeyModalStub);
+      expect(saveModal.exists()).toBe(true);
+      const onComplexKeySave = saveModal.props('onComplexKeySave') as
+        | ((k: ComplexKey) => Promise<void>)
+        | undefined;
+      expect(onComplexKeySave).toBeTypeOf('function');
+      await onComplexKeySave?.(afterSave[0]);
+      await flushPromises();
+
+      expect(mocks.getComplexKeys).toHaveBeenCalledTimes(2);
+      expect(modal.props('savedComplexKeys')).toEqual(afterSave);
+    });
+  });
+
+  describe('onSaveComplexKey wiring (selectedComplexKey gate)', () => {
+    it('passes onSaveComplexKey when no saved key matches (create-new flow)', async () => {
+      mocks.getComplexKeys.mockResolvedValue([]);
+
+      const wrapper = mountField({ modelKey: new KeyList([pk1, pk2]) });
+      await flushPromises();
+
+      const modal = wrapper.findComponent(ComplexKeyModalStub);
+      expect(modal.props('onSaveComplexKey')).toBeTypeOf('function');
+    });
+
+    it('omits onSaveComplexKey when an existing saved key matches (edit-existing flow)', async () => {
+      const matching = new KeyList([pk1, pk2]);
+      mocks.getComplexKeys.mockResolvedValue([makeSavedKey(matching)]);
+
+      const wrapper = mountField({ modelKey: matching });
+      await flushPromises();
+
+      const modal = wrapper.findComponent(ComplexKeyModalStub);
+      expect(modal.props('onSaveComplexKey')).toBeUndefined();
+    });
+  });
+});

--- a/front-end/src/tests/renderer/components/KeyField.spec.ts
+++ b/front-end/src/tests/renderer/components/KeyField.spec.ts
@@ -340,6 +340,38 @@ describe('KeyField.vue — complex key pre-fetch and pass-through', () => {
       expect(listItem.text()).not.toContain('Unsaved Key List');
     });
 
+    it('restores selectedComplexKey from snapshot when it was cleared during in-flight rejection', async () => {
+      const original = new KeyList([pk1, pk2]);
+      const edited = new KeyList([pk1, pk3]);
+      const savedOriginal = makeSavedKey(original, { id: 'saved-1', nickname: 'Defensive Key' });
+      mocks.getComplexKeys.mockResolvedValue([savedOriginal]);
+
+      let rejectUpdate!: (e: Error) => void;
+      mocks.updateComplexKey.mockReturnValueOnce(
+        new Promise((_, reject) => {
+          rejectUpdate = reject;
+        }),
+      );
+
+      const wrapper = mountField({ modelKey: original });
+      await flushPromises();
+
+      const modal = wrapper.findComponent(ComplexKeyModalStub);
+      modal.vm.$emit('update:modelKey', edited);
+      await wrapper.setProps({ modelKey: edited });
+      await flushPromises();
+
+      await wrapper.find('.bi-x-lg').trigger('click');
+
+      rejectUpdate(new Error('Complex key not found!'));
+      await flushPromises();
+
+      const listItem = wrapper.find('[data-testid="key-list-item"]');
+      expect(listItem.exists()).toBe(true);
+      expect(listItem.text()).toContain('Defensive Key');
+      expect(listItem.text()).not.toContain('Unsaved Key List');
+    });
+
     it('ignores concurrent handleComplexKeyUpdate calls while one is in flight', async () => {
       const original = new KeyList([pk1, pk2]);
       const edited1 = new KeyList([pk1, pk3]);


### PR DESCRIPTION
Fixes: #2681

## Summary

The "Save Complex Key" button was visible when a user rebuilt an
already-saved complex key. Clicking it produced a "Complex key already
exists" error from the backend.

## What changed

- `KeyField.vue` pre-fetches the user's saved complex keys on mount and
  passes them down to `ComplexKeyModal.vue`.
- The modal hides "Save Complex Key" when the current keys match a
  saved entry, and shows a "Complex key already exists" warning next
  to "View Summary".
- In-place edits of an existing complex key keep the local cache in
  sync. On IPC failure, the cache and selected key are rolled back and
  an error toast is shown.
- Concurrent edits are ignored while a save is in flight to prevent
  cache corruption.
- The cache is refreshed when the "Add Existing" picker closes, so
  deletions there are reflected immediately.

## Tests

Added two new spec files. 

- `ComplexKeyModal.spec.ts`: button visibility matrix,
  warning span content, reactivity to inner key changes.
- `KeyField.spec.ts`: pre-fetch on mount, prop pass-through,
  synchronous match lookup, refresh after save, in-place edit
  success/rejection/concurrency, defensive rollback.

## Test plan

- [ ] Create a Complex Key with at least two public keys, save it,
      close.
- [ ] Add a second new key. "Save Complex Key" appears.
- [ ] Replace those with the two existing keys from step 1. "Save
      Complex Key" disappears and a warning shows the saved key's
      nickname.
- [ ] Remove one of the existing keys. The warning disappears.
- [ ] Click Done. The existing key is assigned to the field.