### PR TITLE
feat: hip-1137 create registered node

### DIFF
--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -13,6 +13,7 @@ import {
   NodeUpdateTransaction,
   PrivateKey,
   PublicKey,
+  RegisteredNodeCreateTransaction,
   SignatureMap,
   Timestamp,
   TransactionId,
@@ -1003,6 +1004,50 @@ describe('TransactionsService', () => {
       jest.spyOn(MirrorNetworkGRPC, 'fromBaseURL').mockReturnValueOnce(MirrorNetworkGRPC.TESTNET);
       jest.mocked(getClientFromNetwork).mockResolvedValueOnce(client);
       jest.mocked(getTransactionTypeEnumValue).mockReturnValueOnce(TransactionType.NODE_CREATE);
+      jest.mocked(flattenKeyList).mockReturnValueOnce([adminKey]);
+
+      let capturedTransaction: any;
+      transactionsRepo.create.mockImplementationOnce(((input: DeepPartial<Transaction>) => {
+        capturedTransaction = input;
+        return { ...input } as Transaction;
+      }) as any);
+
+      await service.createTransaction(dto, user as User);
+
+      expect(capturedTransaction.publicKeys).toBeDefined();
+      expect(capturedTransaction.publicKeys).toContain(adminKey.toStringRaw());
+      expect(capturedTransaction.publicKeys).toHaveLength(1);
+
+      client.close();
+    });
+
+    it('should extract publicKeys from RegisteredNodeCreateTransaction with admin key', async () => {
+      const adminKey = PrivateKey.generateECDSA().publicKey;
+      const sdkTransaction = new RegisteredNodeCreateTransaction()
+        .setTransactionId(new TransactionId(AccountId.fromString('0.0.1'), Timestamp.fromDate(new Date())))
+        .setAdminKey(adminKey);
+
+      const dto: CreateTransactionDto = {
+        name: 'Registered Node Create',
+        description: 'Create registered node with admin key',
+        transactionBytes: Buffer.from(sdkTransaction.toBytes()),
+        creatorKeyId: 1,
+        signature: Buffer.from('0xabc02'),
+        mirrorNetwork: 'testnet',
+      };
+
+      const client = Client.forTestnet();
+
+      jest.mocked(attachKeys).mockImplementationOnce(async (usr: User) => {
+        usr.keys = userKeys;
+      });
+      jest.spyOn(PublicKey.prototype, 'verify').mockReturnValueOnce(true);
+      jest.mocked(isExpired).mockReturnValueOnce(false);
+      jest.mocked(isTransactionBodyOverMaxSize).mockReturnValueOnce(false);
+      transactionsRepo.find.mockResolvedValueOnce([]);
+      jest.spyOn(MirrorNetworkGRPC, 'fromBaseURL').mockReturnValueOnce(MirrorNetworkGRPC.TESTNET);
+      jest.mocked(getClientFromNetwork).mockResolvedValueOnce(client);
+      jest.mocked(getTransactionTypeEnumValue).mockReturnValueOnce(TransactionType.REGISTERED_NODE_CREATE);
       jest.mocked(flattenKeyList).mockReturnValueOnce([adminKey]);
 
       let capturedTransaction: any;

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -14,6 +14,7 @@ import {
   NodeCreateTransaction,
   NodeUpdateTransaction,
   PublicKey,
+  RegisteredNodeCreateTransaction,
   Transaction as SDKTransaction,
   TransactionId,
 } from '@hiero-ledger/sdk';
@@ -1127,6 +1128,11 @@ export class TransactionsService {
         keyToExtract = (sdkTransaction as NodeUpdateTransaction).adminKey;
       } else if (transactionType === TransactionType.NODE_CREATE) {
         keyToExtract = (sdkTransaction as NodeCreateTransaction).adminKey;
+      } else if (transactionType === TransactionType.REGISTERED_NODE_CREATE) {
+        // HIP-1137: same shape as NODE_CREATE — the new entry's admin_key
+        // is the signer requirement, so we surface its flattened public keys
+        // for the signer-notification workflow.
+        keyToExtract = (sdkTransaction as RegisteredNodeCreateTransaction).adminKey;
       }
 
       if (keyToExtract) {

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -8,13 +8,8 @@ import {
 import { InjectDataSource, InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
 
 import {
-  AccountUpdateTransaction,
   Client,
-  Key,
-  NodeCreateTransaction,
-  NodeUpdateTransaction,
   PublicKey,
-  RegisteredNodeCreateTransaction,
   Transaction as SDKTransaction,
   TransactionId,
 } from '@hiero-ledger/sdk';
@@ -72,6 +67,8 @@ import {
   getNodeAccountIdsFromClientNetwork,
   isTransactionValidForNodes,
 } from '@app/common';
+
+import TransactionFactory from '@app/common/transaction-signature/model/transaction-factory';
 
 import { CreateTransactionDto, SignatureImportResultDto, UploadSignatureMapDto } from './dto';
 
@@ -1117,26 +1114,17 @@ export class TransactionsService {
     const transactionHash = await sdkTransaction.getTransactionHash();
     const transactionType = getTransactionTypeEnumValue(sdkTransaction);
 
-    // Extract new keys if applicable
+    // Extract the public keys of any "new key" the transaction is introducing
+    // (e.g. the new account/admin key) so the notification subsystem can route
+    // sign requests to the right users. The rule for what counts as a new key
+    // is owned by each transaction model's `getNewKeys()` — adding a new type
+    // therefore only requires registering a model in TransactionFactory, not
+    // editing this service.
     let publicKeys: string[] | null = null;
     try {
-      let keyToExtract: Key | null = null;
-
-      if (transactionType === TransactionType.ACCOUNT_UPDATE) {
-        keyToExtract = (sdkTransaction as AccountUpdateTransaction).key;
-      } else if (transactionType === TransactionType.NODE_UPDATE) {
-        keyToExtract = (sdkTransaction as NodeUpdateTransaction).adminKey;
-      } else if (transactionType === TransactionType.NODE_CREATE) {
-        keyToExtract = (sdkTransaction as NodeCreateTransaction).adminKey;
-      } else if (transactionType === TransactionType.REGISTERED_NODE_CREATE) {
-        // HIP-1137: same shape as NODE_CREATE — the new entry's admin_key
-        // is the signer requirement, so we surface its flattened public keys
-        // for the signer-notification workflow.
-        keyToExtract = (sdkTransaction as RegisteredNodeCreateTransaction).adminKey;
-      }
-
-      if (keyToExtract) {
-        publicKeys = flattenKeyList(keyToExtract).map(pk => pk.toStringRaw());
+      const newKeys = TransactionFactory.fromTransaction(sdkTransaction).getNewKeys();
+      if (newKeys.length > 0) {
+        publicKeys = newKeys.flatMap(k => flattenKeyList(k).map(pk => pk.toStringRaw()));
       }
     } catch (error) {
       // Log but don't fail - publicKeys will remain null

--- a/back-end/apps/api/test/utils/hederaUtils.ts
+++ b/back-end/apps/api/test/utils/hederaUtils.ts
@@ -19,6 +19,7 @@ import {
   NodeUpdateTransaction,
   PrivateKey,
   PublicKey,
+  RegisteredNodeCreateTransaction,
   SignatureMap,
   SystemDeleteTransaction,
   SystemUndeleteTransaction,
@@ -105,6 +106,8 @@ export const getTransactionTypeEnumValue = (transaction: Transaction): Transacti
     return TransactionType.NODE_UPDATE;
   } else if (transaction instanceof NodeDeleteTransaction) {
     return TransactionType.NODE_DELETE;
+  } else if (transaction instanceof RegisteredNodeCreateTransaction) {
+    return TransactionType.REGISTERED_NODE_CREATE;
   } else if (transaction instanceof SystemDeleteTransaction) {
     return TransactionType.SYSTEM_DELETE;
   } else if (transaction instanceof SystemUndeleteTransaction) {

--- a/back-end/libs/common/src/database/entities/transaction.entity.ts
+++ b/back-end/libs/common/src/database/entities/transaction.entity.ts
@@ -41,6 +41,7 @@ export enum TransactionType {
   NODE_CREATE = 'NODE CREATE',
   NODE_UPDATE = 'NODE UPDATE',
   NODE_DELETE = 'NODE DELETE',
+  REGISTERED_NODE_CREATE = 'REGISTERED NODE CREATE',
 }
 
 export enum TransactionStatus {

--- a/back-end/libs/common/src/transaction-signature/model/index.ts
+++ b/back-end/libs/common/src/transaction-signature/model/index.ts
@@ -9,6 +9,7 @@ export * from './freeze-transaction.model';
 export * from './node-create-transaction.model';
 export * from './node-update-transaction.model';
 export * from './node-delete-transaction.model';
+export * from './registered-node-create-transaction.model';
 export * from './system-delete-transaction.model';
 export * from './system-undelete-transaction.model';
 export * from './transfer-transaction.model';

--- a/back-end/libs/common/src/transaction-signature/model/registered-node-create-transaction.model.spec.ts
+++ b/back-end/libs/common/src/transaction-signature/model/registered-node-create-transaction.model.spec.ts
@@ -1,0 +1,45 @@
+import { RegisteredNodeCreateTransaction, Key } from '@hiero-ledger/sdk';
+import { RegisteredNodeCreateTransactionModel } from './registered-node-create-transaction.model';
+
+describe('RegisteredNodeCreateTransactionModel', () => {
+  it('should have TRANSACTION_TYPE defined', () => {
+    expect(RegisteredNodeCreateTransactionModel.TRANSACTION_TYPE).toBe(
+      'RegisteredNodeCreateTransaction',
+    );
+  });
+
+  it('should return the adminKey in an array if present', () => {
+    const adminKey = {} as Key;
+
+    const tx = {
+      adminKey,
+    } as unknown as RegisteredNodeCreateTransaction;
+
+    const model = new RegisteredNodeCreateTransactionModel(tx);
+    const keys = model.getNewKeys();
+
+    expect(keys).toEqual([adminKey]);
+  });
+
+  it('should return empty array if adminKey is null', () => {
+    const tx = {
+      adminKey: null,
+    } as unknown as RegisteredNodeCreateTransaction;
+
+    const model = new RegisteredNodeCreateTransactionModel(tx);
+    const keys = model.getNewKeys();
+
+    expect(keys).toEqual([]);
+  });
+
+  it('should return empty array if adminKey is undefined', () => {
+    const tx = {
+      adminKey: undefined,
+    } as unknown as RegisteredNodeCreateTransaction;
+
+    const model = new RegisteredNodeCreateTransactionModel(tx);
+    const keys = model.getNewKeys();
+
+    expect(keys).toEqual([]);
+  });
+});

--- a/back-end/libs/common/src/transaction-signature/model/registered-node-create-transaction.model.spec.ts
+++ b/back-end/libs/common/src/transaction-signature/model/registered-node-create-transaction.model.spec.ts
@@ -1,4 +1,4 @@
-import { RegisteredNodeCreateTransaction, Key } from '@hiero-ledger/sdk';
+import { KeyList, PrivateKey, RegisteredNodeCreateTransaction } from '@hiero-ledger/sdk';
 import { RegisteredNodeCreateTransactionModel } from './registered-node-create-transaction.model';
 
 describe('RegisteredNodeCreateTransactionModel', () => {
@@ -8,23 +8,48 @@ describe('RegisteredNodeCreateTransactionModel', () => {
     );
   });
 
-  it('should return the adminKey in an array if present', () => {
-    const adminKey = {} as Key;
-
-    const tx = {
-      adminKey,
-    } as unknown as RegisteredNodeCreateTransaction;
+  it('should return the adminKey in an array when a single PublicKey is set', () => {
+    const adminKey = PrivateKey.generateED25519().publicKey;
+    const tx = new RegisteredNodeCreateTransaction().setAdminKey(adminKey);
 
     const model = new RegisteredNodeCreateTransactionModel(tx);
     const keys = model.getNewKeys();
 
-    expect(keys).toEqual([adminKey]);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toBe(adminKey);
   });
 
-  it('should return empty array if adminKey is null', () => {
-    const tx = {
-      adminKey: null,
-    } as unknown as RegisteredNodeCreateTransaction;
+  it('should return the adminKey when it is a KeyList', () => {
+    const member1 = PrivateKey.generateED25519().publicKey;
+    const member2 = PrivateKey.generateED25519().publicKey;
+    const adminKey = new KeyList([member1, member2]);
+
+    const tx = new RegisteredNodeCreateTransaction().setAdminKey(adminKey);
+
+    const model = new RegisteredNodeCreateTransactionModel(tx);
+    const keys = model.getNewKeys();
+
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toBe(adminKey);
+  });
+
+  it('should return the adminKey when it is a ThresholdKey (2-of-3 KeyList)', () => {
+    const member1 = PrivateKey.generateED25519().publicKey;
+    const member2 = PrivateKey.generateED25519().publicKey;
+    const member3 = PrivateKey.generateED25519().publicKey;
+    const adminKey = new KeyList([member1, member2, member3], 2);
+
+    const tx = new RegisteredNodeCreateTransaction().setAdminKey(adminKey);
+
+    const model = new RegisteredNodeCreateTransactionModel(tx);
+    const keys = model.getNewKeys();
+
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toBe(adminKey);
+  });
+
+  it('should return empty array if adminKey is not set on the transaction', () => {
+    const tx = new RegisteredNodeCreateTransaction();
 
     const model = new RegisteredNodeCreateTransactionModel(tx);
     const keys = model.getNewKeys();
@@ -32,10 +57,8 @@ describe('RegisteredNodeCreateTransactionModel', () => {
     expect(keys).toEqual([]);
   });
 
-  it('should return empty array if adminKey is undefined', () => {
-    const tx = {
-      adminKey: undefined,
-    } as unknown as RegisteredNodeCreateTransaction;
+  it('should return empty array if adminKey is explicitly null', () => {
+    const tx = { adminKey: null } as unknown as RegisteredNodeCreateTransaction;
 
     const model = new RegisteredNodeCreateTransactionModel(tx);
     const keys = model.getNewKeys();

--- a/back-end/libs/common/src/transaction-signature/model/registered-node-create-transaction.model.ts
+++ b/back-end/libs/common/src/transaction-signature/model/registered-node-create-transaction.model.ts
@@ -1,0 +1,17 @@
+import { RegisteredNodeCreateTransaction } from '@hiero-ledger/sdk';
+
+import { TransactionBaseModel } from './transaction-base.model';
+
+export class RegisteredNodeCreateTransactionModel
+  extends TransactionBaseModel<RegisteredNodeCreateTransaction> {
+
+  static readonly TRANSACTION_TYPE = 'RegisteredNodeCreateTransaction';
+
+  getNewKeys() {
+    if (this.transaction.adminKey != null) {
+      return [this.transaction.adminKey];
+    }
+
+    return [];
+  }
+}

--- a/back-end/libs/common/src/transaction-signature/model/transaction-factory.ts
+++ b/back-end/libs/common/src/transaction-signature/model/transaction-factory.ts
@@ -12,6 +12,7 @@ import { FreezeTransactionModel } from './freeze-transaction.model';
 import { NodeCreateTransactionModel } from './node-create-transaction.model';
 import { NodeDeleteTransactionModel } from './node-delete-transaction.model';
 import { NodeUpdateTransactionModel } from './node-update-transaction.model';
+import { RegisteredNodeCreateTransactionModel } from './registered-node-create-transaction.model';
 import { SystemDeleteTransactionModel } from './system-delete-transaction.model';
 import { SystemUndeleteTransactionModel } from './system-undelete-transaction.model';
 import { TransferTransactionModel } from './transfer-transaction.model';
@@ -30,6 +31,7 @@ const TRANSACTION_MODEL_MAP = new Map<string, TxModelCtor>([
   ['NodeCreateTransaction', NodeCreateTransactionModel],
   ['NodeDeleteTransaction', NodeDeleteTransactionModel],
   ['NodeUpdateTransaction', NodeUpdateTransactionModel],
+  ['RegisteredNodeCreateTransaction', RegisteredNodeCreateTransactionModel],
   ['SystemDeleteTransaction', SystemDeleteTransactionModel],
   ['SystemUndeleteTransaction', SystemUndeleteTransactionModel],
   ['TransferTransaction', TransferTransactionModel],

--- a/back-end/libs/common/src/transaction-signature/transaction-signature.service.ts
+++ b/back-end/libs/common/src/transaction-signature/transaction-signature.service.ts
@@ -13,6 +13,8 @@ import { TransactionBaseModel } from '@app/common/transaction-signature/model/tr
 import { AccountCacheService } from '@app/common/transaction-signature/account-cache.service';
 import { NodeCacheService } from '@app/common/transaction-signature/node-cache.service';
 import { COUNCIL_ACCOUNTS } from '@app/common/constants';
+// TODO(HIP-1137 diag): remove these once the signer/required mismatch is confirmed and fixed
+import { flattenKeyList, hasValidSignatureKey } from '@app/common/utils/sdk/key';
 
 export interface SignatureRequirements {
   feePayerAccount: string;
@@ -57,6 +59,36 @@ export class TransactionSignatureService {
     }
 
     signatureKey.push(...requirements.newKeys);
+
+    // ============================================================
+    // TODO(HIP-1137 diag): temporary diagnostic — REMOVE before merge.
+    // Logs which signer keys are already on the SDK tx bytes vs. which
+    // public keys we require, so we can pinpoint mismatches between FE
+    // auto-signing and BE expectations.
+    // ============================================================
+    try {
+      const signers = [...sdkTransaction._signerPublicKeys];
+      const requiredLeaves = flattenKeyList(signatureKey).map(pk => pk.toStringRaw());
+      const missing = requiredLeaves.filter(pk => !signers.includes(pk));
+      const extra = signers.filter(pk => !requiredLeaves.includes(pk));
+      const isAble = hasValidSignatureKey(signers, signatureKey);
+
+      this.logger.warn(
+        `[HIP-1137 diag] tx=${transaction.id} ` +
+          `type=${sdkTransaction.constructor?.name} ` +
+          `payer=${requirements.feePayerAccount} ` +
+          `hasValidSignatureKey=${isAble} ` +
+          `signers=${JSON.stringify(signers)} ` +
+          `requiredLeaves=${JSON.stringify(requiredLeaves)} ` +
+          `missing=${JSON.stringify(missing)} ` +
+          `extra=${JSON.stringify(extra)}`,
+      );
+    } catch (diagErr) {
+      this.logger.warn(`[HIP-1137 diag] log failed for tx=${transaction.id}: ${diagErr?.message ?? diagErr}`);
+    }
+    // ============================================================
+    // END diagnostic
+    // ============================================================
 
     return signatureKey;
   }

--- a/back-end/libs/common/src/transaction-signature/transaction-signature.service.ts
+++ b/back-end/libs/common/src/transaction-signature/transaction-signature.service.ts
@@ -13,8 +13,6 @@ import { TransactionBaseModel } from '@app/common/transaction-signature/model/tr
 import { AccountCacheService } from '@app/common/transaction-signature/account-cache.service';
 import { NodeCacheService } from '@app/common/transaction-signature/node-cache.service';
 import { COUNCIL_ACCOUNTS } from '@app/common/constants';
-// TODO(HIP-1137 diag): remove these once the signer/required mismatch is confirmed and fixed
-import { flattenKeyList, hasValidSignatureKey } from '@app/common/utils/sdk/key';
 
 export interface SignatureRequirements {
   feePayerAccount: string;
@@ -59,36 +57,6 @@ export class TransactionSignatureService {
     }
 
     signatureKey.push(...requirements.newKeys);
-
-    // ============================================================
-    // TODO(HIP-1137 diag): temporary diagnostic — REMOVE before merge.
-    // Logs which signer keys are already on the SDK tx bytes vs. which
-    // public keys we require, so we can pinpoint mismatches between FE
-    // auto-signing and BE expectations.
-    // ============================================================
-    try {
-      const signers = [...sdkTransaction._signerPublicKeys];
-      const requiredLeaves = flattenKeyList(signatureKey).map(pk => pk.toStringRaw());
-      const missing = requiredLeaves.filter(pk => !signers.includes(pk));
-      const extra = signers.filter(pk => !requiredLeaves.includes(pk));
-      const isAble = hasValidSignatureKey(signers, signatureKey);
-
-      this.logger.warn(
-        `[HIP-1137 diag] tx=${transaction.id} ` +
-          `type=${sdkTransaction.constructor?.name} ` +
-          `payer=${requirements.feePayerAccount} ` +
-          `hasValidSignatureKey=${isAble} ` +
-          `signers=${JSON.stringify(signers)} ` +
-          `requiredLeaves=${JSON.stringify(requiredLeaves)} ` +
-          `missing=${JSON.stringify(missing)} ` +
-          `extra=${JSON.stringify(extra)}`,
-      );
-    } catch (diagErr) {
-      this.logger.warn(`[HIP-1137 diag] log failed for tx=${transaction.id}: ${diagErr?.message ?? diagErr}`);
-    }
-    // ============================================================
-    // END diagnostic
-    // ============================================================
 
     return signatureKey;
   }

--- a/back-end/libs/common/src/utils/sdk/transaction.ts
+++ b/back-end/libs/common/src/utils/sdk/transaction.ts
@@ -16,6 +16,7 @@ import {
   FileDeleteTransaction,
   FreezeTransaction,
   NodeCreateTransaction,
+  RegisteredNodeCreateTransaction,
   SystemDeleteTransaction,
   SystemUndeleteTransaction,
   FileContentsQuery,
@@ -84,6 +85,8 @@ export const getTransactionType = (
     transactionType = "Node Update Transaction";
   } else if (transaction instanceof NodeDeleteTransaction) {
     transactionType = "Node Delete Transaction";
+  } else if (transaction instanceof RegisteredNodeCreateTransaction) {
+    transactionType = "Registered Node Create Transaction";
   } else if (transaction instanceof SystemDeleteTransaction) {
     transactionType = "System Delete Transaction";
   } else if (transaction instanceof SystemUndeleteTransaction) {
@@ -176,6 +179,8 @@ export const getTransactionTypeEnumValue = (transaction: SDKTransaction): Transa
     return TransactionType.NODE_UPDATE;
   } else if (transaction instanceof NodeDeleteTransaction) {
     return TransactionType.NODE_DELETE;
+  } else if (transaction instanceof RegisteredNodeCreateTransaction) {
+    return TransactionType.REGISTERED_NODE_CREATE;
   } else if (transaction instanceof SystemDeleteTransaction) {
     return TransactionType.SYSTEM_DELETE;
   } else if (transaction instanceof SystemUndeleteTransaction) {

--- a/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserPage.vue
+++ b/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserPage.vue
@@ -12,6 +12,7 @@ import {
   NodeCreateTransaction,
   NodeDeleteTransaction,
   NodeUpdateTransaction,
+  RegisteredNodeCreateTransaction,
   TransferTransaction,
   Transaction as SDKTransaction,
   SystemDeleteTransaction,
@@ -35,6 +36,7 @@ import TransferDetails from '@renderer/components/Transaction/Details/TransferDe
 import FreezeDetails from '@renderer/components/Transaction/Details/FreezeDetails.vue';
 import SystemDetails from '@renderer/components/Transaction/Details/SystemDetails.vue';
 import NodeDetails from '@renderer/components/Transaction/Details/NodeDetails.vue';
+import RegisteredNodeDetails from '@renderer/components/Transaction/Details/RegisteredNodeDetails.vue';
 
 /* Props */
 const props = defineProps<{
@@ -209,6 +211,12 @@ const transactionDetailsTitle = computed(() => transactionType.value!);
                   transaction instanceof NodeUpdateTransaction ||
                   transaction instanceof NodeDeleteTransaction
                 "
+                :organization-transaction="null"
+                :transaction="transaction"
+              />
+
+              <RegisteredNodeDetails
+                v-if="transaction instanceof RegisteredNodeCreateTransaction"
                 :organization-transaction="null"
                 :transaction="transaction"
               />

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
@@ -1,0 +1,215 @@
+<script setup lang="ts">
+import type {
+  ComponentRegisteredServiceEndpoint,
+  RegisteredEndpointType,
+} from '@renderer/utils/sdk';
+
+import { computed } from 'vue';
+
+import { BlockNodeApi } from '@hiero-ledger/sdk';
+
+import AppButton from '@renderer/components/ui/AppButton.vue';
+import AppInput from '@renderer/components/ui/AppInput.vue';
+import AppSwitch from '@renderer/components/ui/AppSwitch.vue';
+import AppTextArea from '@renderer/components/ui/AppTextArea.vue';
+
+/* Props */
+const props = defineProps<{
+  endpoint: ComponentRegisteredServiceEndpoint;
+  index: number;
+  typeOptions: { value: RegisteredEndpointType; label: string }[];
+}>();
+
+/* Emits */
+const emit = defineEmits<{
+  (event: 'update:endpoint', endpoint: ComponentRegisteredServiceEndpoint): void;
+  (event: 'delete'): void;
+}>();
+
+/**
+ * Block-node API options shown to the user.
+ *
+ * Derived at module-evaluation time from the SDK's `BlockNodeApi` static
+ * instances rather than a hand-maintained list — so when the SDK adds a new
+ * enum value in a future release, this UI picks it up automatically.
+ *
+ * `Number(api)` invokes `BlockNodeApi.valueOf()` (which returns the numeric
+ * proto code) without reaching into the underscore-prefixed `_code` field.
+ *
+ * NOTE: keep this in sync with `@hiero-ledger/sdk` `BlockNodeApi`. As of
+ * v2.84.0 the enumerable statics are: OTHER, STATUS, PUBLISH, SUBSCRIBE_STREAM,
+ * STATE_PROOF. If a future SDK build switches those to non-enumerable, this
+ * extraction returns an empty array — `assertHasBlockNodeApiOptions` below
+ * makes that failure loud rather than silently disabling all checkboxes.
+ */
+const BLOCK_NODE_API_OPTIONS: { code: number; label: string }[] = Object.values(
+  BlockNodeApi as unknown as Record<string, unknown>,
+)
+  .filter((v): v is InstanceType<typeof BlockNodeApi> => v instanceof BlockNodeApi)
+  .map(api => ({ code: Number(api), label: api.toString() }))
+  .sort((a, b) => a.code - b.code);
+
+if (BLOCK_NODE_API_OPTIONS.length === 0) {
+  // Loud failure — silent zero-option list would hide the block-node API
+  // checkboxes entirely without any indication something is wrong.
+  // eslint-disable-next-line no-console -- diagnostic only fires on SDK shape regression
+  console.error(
+    '[RegisteredNodeCreate/EndpointRow] No BlockNodeApi enum values discovered ' +
+      'on the SDK class. The SDK build may have changed static enumerability — ' +
+      'block-node API checkboxes will not render. Update the option-derivation ' +
+      'strategy in EndpointRow.vue.',
+  );
+}
+
+const blockNodeApiOptions = computed(() => BLOCK_NODE_API_OPTIONS);
+
+/* Helpers */
+function patch(partial: Partial<ComponentRegisteredServiceEndpoint>) {
+  emit('update:endpoint', { ...props.endpoint, ...partial });
+}
+
+function handleTypeChange(value: RegisteredEndpointType) {
+  // Reset subtype-specific fields when switching type so we don't carry stale data.
+  patch({
+    type: value,
+    endpointApis: value === 'blockNode' ? [] : undefined,
+    endpointDescription: value === 'generalService' ? '' : undefined,
+  });
+}
+
+function handlePortInput(e: Event) {
+  const target = e.target as HTMLInputElement;
+  patch({ port: target.value.replace(/[^0-9]/g, '') });
+}
+
+function toggleApi(code: number, checked: boolean) {
+  const current = new Set(props.endpoint.endpointApis ?? []);
+  if (checked) current.add(code);
+  else current.delete(code);
+  patch({ endpointApis: Array.from(current).sort((a, b) => a - b) });
+}
+
+function isApiSelected(code: number) {
+  return (props.endpoint.endpointApis ?? []).includes(code);
+}
+</script>
+
+<template>
+  <div class="border rounded p-4 mt-4" :data-testid="`registered-endpoint-row-${index}`">
+    <div class="d-flex align-items-center justify-content-between mb-3">
+      <h5 class="text-small fw-bold mb-0">Endpoint #{{ index + 1 }}</h5>
+      <AppButton
+        type="button"
+        color="danger"
+        :data-testid="`button-delete-registered-endpoint-${index}`"
+        @click="emit('delete')"
+      >
+        Delete
+      </AppButton>
+    </div>
+
+    <!-- Type selector -->
+    <div class="form-group">
+      <label class="form-label">Type <span class="text-danger">*</span></label>
+      <select
+        class="form-control is-fill"
+        :value="endpoint.type"
+        :data-testid="`select-registered-endpoint-type-${index}`"
+        @change="
+          handleTypeChange(
+            ($event.target as HTMLSelectElement).value as RegisteredEndpointType,
+          )
+        "
+      >
+        <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">
+          {{ opt.label }}
+        </option>
+      </select>
+    </div>
+
+    <!-- IP / Domain / Port -->
+    <div class="row align-items-end mt-3">
+      <div class="col-4 col-xxxl-3">
+        <label class="form-label">IP Address (IPv4)</label>
+        <AppInput
+          :model-value="endpoint.ipAddressV4 ?? ''"
+          @update:model-value="
+            patch({ ipAddressV4: $event, domainName: $event ? '' : endpoint.domainName })
+          "
+          :filled="true"
+          placeholder="e.g. 10.0.0.1"
+          :data-testid="`input-registered-endpoint-ip-${index}`"
+        />
+      </div>
+      <div class="col-4 col-xxxl-3">
+        <label class="form-label">Domain Name</label>
+        <AppInput
+          :model-value="endpoint.domainName ?? ''"
+          @update:model-value="
+            patch({ domainName: $event, ipAddressV4: $event ? '' : endpoint.ipAddressV4 })
+          "
+          :filled="true"
+          placeholder="e.g. node.example.com"
+          :data-testid="`input-registered-endpoint-domain-${index}`"
+        />
+      </div>
+      <div class="col-4 col-xxxl-3">
+        <label class="form-label">Port <span class="text-danger">*</span></label>
+        <input
+          :value="endpoint.port ?? ''"
+          @input="handlePortInput"
+          class="form-control is-fill"
+          placeholder="0-65535"
+          :data-testid="`input-registered-endpoint-port-${index}`"
+        />
+      </div>
+    </div>
+
+    <!-- TLS switch -->
+    <div class="form-group mt-4">
+      <AppSwitch
+        :checked="endpoint.requiresTls"
+        @update:checked="patch({ requiresTls: $event })"
+        size="md"
+        :name="`registered-endpoint-tls-${index}`"
+        label="Requires TLS"
+        :data-testid="`switch-registered-endpoint-tls-${index}`"
+      />
+    </div>
+
+    <!-- Block Node — endpoint APIs -->
+    <div v-if="endpoint.type === 'blockNode'" class="form-group mt-4">
+      <label class="form-label">Block Node APIs</label>
+      <div class="text-micro text-muted mb-2">
+        Select which block-node APIs this endpoint serves.
+      </div>
+      <div class="d-flex flex-wrap gap-3">
+        <label
+          v-for="opt in blockNodeApiOptions"
+          :key="opt.code"
+          class="d-inline-flex align-items-center gap-2 text-small"
+        >
+          <input
+            type="checkbox"
+            :checked="isApiSelected(opt.code)"
+            :data-testid="`checkbox-registered-endpoint-${index}-api-${opt.code}`"
+            @change="toggleApi(opt.code, ($event.target as HTMLInputElement).checked)"
+          />
+          {{ opt.label }}
+        </label>
+      </div>
+    </div>
+
+    <!-- General Service — description -->
+    <div v-if="endpoint.type === 'generalService'" class="form-group mt-4">
+      <label class="form-label">Endpoint Description</label>
+      <AppTextArea
+        :model-value="endpoint.endpointDescription ?? ''"
+        @update:model-value="patch({ endpointDescription: $event })"
+        :filled="true"
+        placeholder="Describe what this general-service endpoint provides"
+        :data-testid="`textarea-registered-endpoint-general-desc-${index}`"
+      />
+    </div>
+  </div>
+</template>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
@@ -4,7 +4,7 @@ import type {
   RegisteredEndpointType,
 } from '@renderer/utils/sdk';
 
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 
 import { BlockNodeApi } from '@hiero-ledger/sdk';
 
@@ -82,6 +82,32 @@ function handlePortInput(e: Event) {
   patch({ port: target.value.replace(/[^0-9]/g, '') });
 }
 
+/**
+ * IP / Domain are mutually exclusive per the proto `oneof address` rule. We
+ * surface that with an explicit switch + single text field rather than two
+ * inputs whose state silently clears the other on type. Initial mode is
+ * derived from whichever field has data so drafts and round-trips pick up
+ * the correct view.
+ */
+const addressMode = ref<'ipv4' | 'domain'>(
+  props.endpoint.domainName ? 'domain' : 'ipv4',
+);
+
+function handleAddressModeChange(useDomain: boolean) {
+  addressMode.value = useDomain ? 'domain' : 'ipv4';
+  // Clear the now-inactive field so we never carry stale data into the
+  // SDK builder. Not silent — the user just toggled the switch.
+  patch(useDomain ? { ipAddressV4: '' } : { domainName: '' });
+}
+
+function handleAddressInput(value: string) {
+  patch(
+    addressMode.value === 'ipv4'
+      ? { ipAddressV4: value, domainName: '' }
+      : { domainName: value, ipAddressV4: '' },
+  );
+}
+
 function toggleApi(code: number, checked: boolean) {
   const current = new Set(props.endpoint.endpointApis ?? []);
   if (checked) current.add(code);
@@ -127,30 +153,31 @@ function isApiSelected(code: number) {
       </select>
     </div>
 
-    <!-- IP / Domain / Port -->
+    <!-- Address (IPv4 or Domain) / Port -->
     <div class="row align-items-end mt-3">
-      <div class="col-4 col-xxxl-3">
-        <label class="form-label">IP Address (IPv4)</label>
+      <div class="col-8 col-xxxl-6">
+        <div class="d-flex align-items-center justify-content-between mb-2">
+          <label class="form-label mb-0">
+            {{ addressMode === 'ipv4' ? 'IPv4 Address' : 'Domain Name' }}
+            <span class="text-danger">*</span>
+          </label>
+          <AppSwitch
+            :checked="addressMode === 'domain'"
+            @update:checked="handleAddressModeChange"
+            size="sm"
+            :name="`registered-endpoint-address-mode-${index}`"
+            label="Use domain name"
+            :data-testid="`switch-registered-endpoint-address-mode-${index}`"
+          />
+        </div>
         <AppInput
-          :model-value="endpoint.ipAddressV4 ?? ''"
-          @update:model-value="
-            patch({ ipAddressV4: $event, domainName: $event ? '' : endpoint.domainName })
+          :model-value="
+            addressMode === 'ipv4' ? (endpoint.ipAddressV4 ?? '') : (endpoint.domainName ?? '')
           "
+          @update:model-value="handleAddressInput"
           :filled="true"
-          placeholder="e.g. 10.0.0.1"
-          :data-testid="`input-registered-endpoint-ip-${index}`"
-        />
-      </div>
-      <div class="col-4 col-xxxl-3">
-        <label class="form-label">Domain Name</label>
-        <AppInput
-          :model-value="endpoint.domainName ?? ''"
-          @update:model-value="
-            patch({ domainName: $event, ipAddressV4: $event ? '' : endpoint.ipAddressV4 })
-          "
-          :filled="true"
-          placeholder="e.g. node.example.com"
-          :data-testid="`input-registered-endpoint-domain-${index}`"
+          :placeholder="addressMode === 'ipv4' ? 'e.g. 10.0.0.1' : 'e.g. node.example.com'"
+          :data-testid="`input-registered-endpoint-address-${index}`"
         />
       </div>
       <div class="col-4 col-xxxl-3">

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeCreate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeCreate.vue
@@ -1,0 +1,183 @@
+<script setup lang="ts">
+import type { CreateTransactionFunc } from '@renderer/components/Transaction/Create/BaseTransaction';
+import type {
+  ComponentRegisteredServiceEndpoint,
+  RegisteredNodeData,
+} from '@renderer/utils/sdk/createTransactions';
+
+import { computed, reactive, ref, watch } from 'vue';
+import { Transaction } from '@hiero-ledger/sdk';
+
+import { ToastManager } from '@renderer/utils/ToastManager';
+
+import useUserStore from '@renderer/stores/storeUser';
+
+import { exceedsUtf8ByteLimit, getRegisteredNodeData, isUserLoggedIn } from '@renderer/utils';
+import {
+  createRegisteredNodeCreateTransaction,
+  parseIpv4ToBytes,
+  parsePort,
+} from '@renderer/utils/sdk/createTransactions';
+
+import BaseTransaction from '@renderer/components/Transaction/Create/BaseTransaction';
+import RegisteredNodeFormData from './RegisteredNodeFormData.vue';
+
+/* HIP-1137 limits — enforced by the consensus node, mirrored here so we never
+   send a request that we already know will be rejected. */
+const MAX_SERVICE_ENDPOINTS = 50;
+const MAX_DESCRIPTION_BYTES = 100;
+
+/* Stores */
+const user = useUserStore();
+
+/* Composables */
+const toastManager = ToastManager.inject();
+
+/* State */
+const baseTransactionRef = ref<InstanceType<typeof BaseTransaction> | null>(null);
+
+const data = reactive<RegisteredNodeData>({
+  description: '',
+  adminKey: null,
+  serviceEndpoints: [],
+});
+
+/* Computed */
+const createTransaction = computed<CreateTransactionFunc>(() => {
+  return common =>
+    createRegisteredNodeCreateTransaction({
+      ...common,
+      ...(data as RegisteredNodeData),
+    });
+});
+
+const createDisabled = computed(() => {
+  return !data.adminKey || data.serviceEndpoints.length === 0;
+});
+
+/**
+ * `uiId` is a render-side stable key for `<EndpointRow>` (see Vue's list `:key`
+ * rules — never use `index` for editable lists). It lives in the form's data
+ * model but must NEVER leak into the SDK-serialized transaction OR into the
+ * shape returned by `getRegisteredNodeData` (which is JSON-stringified by
+ * `transactionsDataMatch`). So `getRegisteredNodeData` deliberately doesn't
+ * populate `uiId`, and we decorate endpoints with a fresh UUID *only at form
+ * intake* — preserving any uiId the user/Vue already has for that row.
+ */
+const makeUiId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `ep-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+const decorateEndpointsWithUiIds = (
+  endpoints: ComponentRegisteredServiceEndpoint[],
+): ComponentRegisteredServiceEndpoint[] =>
+  endpoints.map(ep => (ep.uiId ? ep : { ...ep, uiId: makeUiId() }));
+
+/* Handlers */
+const handleDraftLoaded = (transaction: Transaction) => {
+  handleUpdateData(getRegisteredNodeData(transaction));
+};
+
+const handleUpdateData = (newData: RegisteredNodeData) => {
+  Object.assign(data, {
+    ...newData,
+    serviceEndpoints: decorateEndpointsWithUiIds(newData.serviceEndpoints),
+  });
+};
+
+const handleExecutedSuccess = async () => {
+  if (!isUserLoggedIn(user.personal)) {
+    throw new Error('User is not logged in');
+  }
+
+  toastManager.success('Registered Node Created');
+};
+
+/* Functions */
+const preCreateAssert = () => {
+  if (!data.adminKey) {
+    throw new Error('Admin Key Required');
+  }
+
+  if (data.serviceEndpoints.length === 0) {
+    throw new Error('At least one Service Endpoint is required');
+  }
+
+  if (data.serviceEndpoints.length > MAX_SERVICE_ENDPOINTS) {
+    throw new Error(`A registered node may have at most ${MAX_SERVICE_ENDPOINTS} service endpoints`);
+  }
+
+  if (data.description && exceedsUtf8ByteLimit(data.description, MAX_DESCRIPTION_BYTES)) {
+    throw new Error(`Description must be ≤ ${MAX_DESCRIPTION_BYTES} bytes`);
+  }
+
+  data.serviceEndpoints.forEach((ep, i) => {
+    if (!ep.type) {
+      throw new Error(`Endpoint ${i + 1}: type is required`);
+    }
+    const hasIp = Boolean(ep.ipAddressV4?.trim());
+    const hasDomain = Boolean(ep.domainName?.trim());
+    if (!hasIp && !hasDomain) {
+      throw new Error(`Endpoint ${i + 1}: IP address or domain name is required`);
+    }
+    if (hasIp && hasDomain) {
+      throw new Error(`Endpoint ${i + 1}: cannot have both IP and domain`);
+    }
+    if (hasIp && parseIpv4ToBytes(ep.ipAddressV4 ?? '') === null) {
+      throw new Error(`Endpoint ${i + 1}: invalid IPv4 address`);
+    }
+    if (parsePort(ep.port ?? '') === null) {
+      throw new Error(`Endpoint ${i + 1}: port must be a number in [0, 65535]`);
+    }
+    if (
+      ep.type === 'generalService' &&
+      ep.endpointDescription &&
+      exceedsUtf8ByteLimit(ep.endpointDescription, MAX_DESCRIPTION_BYTES)
+    ) {
+      throw new Error(
+        `Endpoint ${i + 1}: description must be ≤ ${MAX_DESCRIPTION_BYTES} bytes`,
+      );
+    }
+  });
+
+  return true;
+};
+
+/* Watchers */
+// Only fields that change the network-required *signer set* should trigger
+// `updateTransactionKey()` — which performs a mirror-node round trip via
+// `appCache.computeSignatureKey`. For RegisteredNodeCreate, the signer rule
+// (per HIP-1137) is "the new `admin_key` must sign", so only `data.adminKey`
+// affects the recompute. Endpoint fields (IP, port, TLS, type) and the
+// description never change who has to sign. Matches `NodeCreate.vue`'s
+// narrow watcher shape — a deep watcher here would issue a network call on
+// every keystroke into every endpoint field.
+watch(
+  () => data.adminKey,
+  () => {
+    baseTransactionRef.value?.updateTransactionKey();
+  },
+);
+</script>
+
+<template>
+  <BaseTransaction
+    ref="baseTransactionRef"
+    :create-transaction="createTransaction"
+    :pre-create-assert="preCreateAssert"
+    :create-disabled="createDisabled"
+    @executed:success="handleExecutedSuccess"
+    @draft-loaded="handleDraftLoaded"
+  >
+    <template #default>
+      <RegisteredNodeFormData
+        :data="data as RegisteredNodeData"
+        @update:data="handleUpdateData"
+        required
+      />
+    </template>
+  </BaseTransaction>
+</template>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+import type {
+  ComponentRegisteredServiceEndpoint,
+  RegisteredEndpointType,
+  RegisteredNodeData,
+} from '@renderer/utils/sdk';
+
+import { computed, ref } from 'vue';
+
+import { ToastManager } from '@renderer/utils/ToastManager';
+
+import { exceedsUtf8ByteLimit, utf8ByteLength } from '@renderer/utils';
+
+import AppInput from '@renderer/components/ui/AppInput.vue';
+import AppButton from '@renderer/components/ui/AppButton.vue';
+import KeyField from '@renderer/components/KeyField.vue';
+import EndpointRow from './EndpointRow.vue';
+
+/* Props */
+const props = defineProps<{
+  data: RegisteredNodeData;
+  required?: boolean;
+}>();
+
+/* Emits */
+const emit = defineEmits<{
+  (event: 'update:data', data: RegisteredNodeData): void;
+}>();
+
+/* Composables */
+const toastManager = ToastManager.inject();
+
+/* Constants */
+const DESCRIPTION_MAX_BYTES = 100;
+
+/* State */
+const descriptionError = ref(false);
+
+/* Computed */
+const descriptionByteLength = computed(() => utf8ByteLength(props.data.description ?? ''));
+
+/* Handlers */
+function handleAddEndpoint() {
+  // No `uiId` here — the parent's `decorateEndpointsWithUiIds` (in
+  // RegisteredNodeCreate.vue) is the single owner of uiId generation. That
+  // keeps uiId out of `getRegisteredNodeData`'s output, which keeps
+  // `transactionsDataMatch` deterministic across reloads.
+  const blank: ComponentRegisteredServiceEndpoint = {
+    type: 'blockNode',
+    ipAddressV4: '',
+    domainName: '',
+    port: '',
+    requiresTls: false,
+    endpointApis: [],
+  };
+
+  emit('update:data', {
+    ...props.data,
+    serviceEndpoints: [...props.data.serviceEndpoints, blank],
+  });
+}
+
+function handleUpdateEndpoint(
+  index: number,
+  endpoint: ComponentRegisteredServiceEndpoint,
+) {
+  const next = [...props.data.serviceEndpoints];
+  next[index] = endpoint;
+  emit('update:data', { ...props.data, serviceEndpoints: next });
+}
+
+function handleDeleteEndpoint(index: number) {
+  const next = [...props.data.serviceEndpoints];
+  next.splice(index, 1);
+  emit('update:data', { ...props.data, serviceEndpoints: next });
+}
+
+function handleDescriptionValidation(e: Event) {
+  // HIP-1137 description is ≤100 UTF-8 bytes (not characters). Validate by
+  // byte length so 100 emoji don't silently slip past a char-based check
+  // and only get rejected later in preCreateAssert.
+  const target = e.target as HTMLInputElement;
+  if (exceedsUtf8ByteLimit(target.value, DESCRIPTION_MAX_BYTES)) {
+    toastManager.error(`Description is limited to ${DESCRIPTION_MAX_BYTES} bytes (UTF-8)`);
+    descriptionError.value = true;
+  } else {
+    descriptionError.value = false;
+  }
+}
+
+/** Stable row key — never `index`, since deleting/reordering with `index` keys
+ * causes Vue to re-use DOM nodes from the wrong row (focus jumps, stale state).
+ * Falls back gracefully if `uiId` is somehow missing (legacy drafts). */
+function rowKey(endpoint: ComponentRegisteredServiceEndpoint, index: number): string {
+  return endpoint.uiId ?? `legacy-${index}`;
+}
+
+
+/* Type helper for template */
+const endpointTypeOptions: { value: RegisteredEndpointType; label: string }[] = [
+  { value: 'blockNode', label: 'Block Node' },
+  { value: 'mirrorNode', label: 'Mirror Node' },
+  { value: 'rpcRelay', label: 'RPC Relay' },
+  { value: 'generalService', label: 'General Service' },
+];
+</script>
+
+<template>
+  <!-- Admin Key -->
+  <div class="form-group mt-6 col-8 col-xxxl-6">
+    <KeyField
+      label="Admin Key"
+      :model-key="data.adminKey"
+      @update:model-key="
+        emit('update:data', {
+          ...data,
+          adminKey: $event,
+        })
+      "
+      :is-required="required"
+    />
+  </div>
+
+  <!-- Description -->
+  <div class="form-group mt-6 col-8 col-xxxl-6">
+    <label class="form-label">Description</label>
+    <AppInput
+      @input="handleDescriptionValidation"
+      :model-value="data.description"
+      @update:model-value="
+        emit('update:data', {
+          ...data,
+          description: $event,
+        })
+      "
+      :filled="true"
+      placeholder="Enter Description (optional, ≤ 100 UTF-8 bytes)"
+      :class="[descriptionError ? 'is-invalid' : '']"
+    />
+    <div
+      class="text-micro mt-1"
+      :class="descriptionError ? 'text-danger' : 'text-muted'"
+      data-testid="text-registered-description-byte-counter"
+    >
+      {{ descriptionByteLength }} / {{ DESCRIPTION_MAX_BYTES }} bytes
+    </div>
+  </div>
+
+  <hr class="separator my-5" />
+
+  <!-- Service Endpoints -->
+  <div class="d-flex align-items-center justify-content-between">
+    <label class="form-label mb-0">
+      Service Endpoints
+      <span v-if="required" class="text-danger">*</span>
+    </label>
+    <AppButton
+      color="primary"
+      type="button"
+      data-testid="button-add-registered-endpoint"
+      :disabled="data.serviceEndpoints.length >= 50"
+      @click="handleAddEndpoint"
+    >
+      Add Endpoint
+    </AppButton>
+  </div>
+  <div class="text-micro text-muted mt-1 mb-3">
+    At least one endpoint is required. A registered node may have up to 50 endpoints.
+  </div>
+
+  <div v-if="data.serviceEndpoints.length === 0" class="text-muted text-small">
+    No endpoints added yet — click "Add Endpoint" to create one.
+  </div>
+
+  <EndpointRow
+    v-for="(endpoint, index) in data.serviceEndpoints"
+    :key="rowKey(endpoint, index)"
+    :endpoint="endpoint"
+    :index="index"
+    :type-options="endpointTypeOptions"
+    @update:endpoint="handleUpdateEndpoint(index, $event)"
+    @delete="handleDeleteEndpoint(index)"
+  />
+</template>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue
@@ -79,13 +79,14 @@ function handleDescriptionValidation(e: Event) {
   // HIP-1137 description is ≤100 UTF-8 bytes (not characters). Validate by
   // byte length so 100 emoji don't silently slip past a char-based check
   // and only get rejected later in preCreateAssert.
+  // Toast only on the valid→invalid transition; otherwise typing N extra
+  // characters past the limit fires N stacked toasts on every keystroke.
   const target = e.target as HTMLInputElement;
-  if (exceedsUtf8ByteLimit(target.value, DESCRIPTION_MAX_BYTES)) {
+  const hasDescriptionError = exceedsUtf8ByteLimit(target.value, DESCRIPTION_MAX_BYTES);
+  if (hasDescriptionError && !descriptionError.value) {
     toastManager.error(`Description is limited to ${DESCRIPTION_MAX_BYTES} bytes (UTF-8)`);
-    descriptionError.value = true;
-  } else {
-    descriptionError.value = false;
   }
+  descriptionError.value = hasDescriptionError;
 }
 
 /** Stable row key — never `index`, since deleting/reordering with `index` keys

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/index.ts
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/index.ts
@@ -1,0 +1,2 @@
+import RegisteredNodeCreate from './RegisteredNodeCreate.vue';
+export default RegisteredNodeCreate;

--- a/front-end/src/renderer/components/Transaction/Create/txTypeComponentMapping.ts
+++ b/front-end/src/renderer/components/Transaction/Create/txTypeComponentMapping.ts
@@ -11,6 +11,7 @@ import TransferHbar from './TransferHbar';
 import NodeCreate from './NodeCreate';
 import NodeDelete from './NodeDelete';
 import NodeUpdate from './NodeUpdate';
+import RegisteredNodeCreate from './RegisteredNodeCreate';
 import SystemDelete from './SystemDelete';
 import SystemUndelete from './SystemUndelete';
 
@@ -29,6 +30,7 @@ export const transactionTypeKeys = {
   nodeCreate: 'NodeCreateTransaction',
   nodeDelete: 'NodeDeleteTransaction',
   nodeUpdate: 'NodeUpdateTransaction',
+  registeredNodeCreate: 'RegisteredNodeCreateTransaction',
   systemDelete: 'SystemDeleteTransaction',
   systemUndelete: 'SystemUndeleteTransaction',
 };
@@ -47,6 +49,7 @@ const txTypeComponentMapping = {
   [transactionTypeKeys.nodeCreate]: NodeCreate,
   [transactionTypeKeys.nodeDelete]: NodeDelete,
   [transactionTypeKeys.nodeUpdate]: NodeUpdate,
+  [transactionTypeKeys.registeredNodeCreate]: RegisteredNodeCreate,
   [transactionTypeKeys.systemDelete]: SystemDelete,
   [transactionTypeKeys.systemUndelete]: SystemUndelete,
 };

--- a/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import type { ITransactionFull } from '@shared/interfaces';
+import type { ComponentRegisteredServiceEndpoint } from '@renderer/utils/sdk';
+
+import { computed, onBeforeMount, ref } from 'vue';
+
+import {
+  KeyList,
+  PublicKey,
+  RegisteredNodeCreateTransaction,
+  Transaction,
+} from '@hiero-ledger/sdk';
+
+import { getRegisteredNodeData } from '@renderer/utils';
+
+import KeyStructureModal from '@renderer/components/KeyStructureModal.vue';
+
+/* Props */
+const props = defineProps<{
+  transaction: Transaction;
+  organizationTransaction: ITransactionFull | null;
+}>();
+
+/* State */
+const isKeyStructureModalShown = ref(false);
+
+/* Computed */
+const data = computed(() => {
+  if (!(props.transaction instanceof RegisteredNodeCreateTransaction)) {
+    return null;
+  }
+  return getRegisteredNodeData(props.transaction);
+});
+
+const adminKey = computed(() => data.value?.adminKey ?? null);
+const description = computed(() => data.value?.description ?? '');
+const endpoints = computed<ComponentRegisteredServiceEndpoint[]>(
+  () => data.value?.serviceEndpoints ?? [],
+);
+
+const typeLabel: Record<string, string> = {
+  blockNode: 'Block Node',
+  mirrorNode: 'Mirror Node',
+  rpcRelay: 'RPC Relay',
+  generalService: 'General Service',
+};
+
+/* Hooks */
+onBeforeMount(() => {
+  if (!(props.transaction instanceof RegisteredNodeCreateTransaction)) {
+    throw new Error('Transaction is not Registered Node Create');
+  }
+});
+
+/* Misc */
+const detailItemLabelClass = 'text-micro text-semi-bold text-dark-blue';
+const detailItemValueClass = 'text-small overflow-hidden mt-1';
+const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
+</script>
+
+<template>
+  <div
+    v-if="transaction instanceof RegisteredNodeCreateTransaction"
+    class="mt-5 row flex-wrap"
+  >
+    <!-- Description -->
+    <div v-if="description" :class="commonColClass">
+      <h4 :class="detailItemLabelClass">Description</h4>
+      <p :class="detailItemValueClass" data-testid="p-registered-node-details-description">
+        {{ description }}
+      </p>
+    </div>
+
+    <!-- Admin Key -->
+    <div v-if="adminKey" class="col-12 my-3">
+      <h4 :class="detailItemLabelClass">Admin Key</h4>
+      <p :class="detailItemValueClass" data-testid="p-registered-node-details-admin-key">
+        <template v-if="adminKey instanceof KeyList">
+          <span class="link-primary cursor-pointer" @click="isKeyStructureModalShown = true">
+            See details
+          </span>
+        </template>
+        <template v-else-if="adminKey instanceof PublicKey">
+          <span class="overflow-hidden">
+            <span class="text-semi-bold text-pink">
+              {{ adminKey._key._type }}
+            </span>
+            {{ adminKey.toStringRaw() }}
+          </span>
+        </template>
+        <template v-else>None</template>
+      </p>
+    </div>
+
+    <!-- Service Endpoints -->
+    <div v-if="endpoints.length > 0" class="col-12 my-3">
+      <h4 :class="detailItemLabelClass">Service Endpoints</h4>
+      <table class="table-custom">
+        <thead class="thin">
+          <tr>
+            <th class="text-start">Type</th>
+            <th class="text-start">IP Address</th>
+            <th class="text-start">Domain Name</th>
+            <th class="text-start">Port</th>
+            <th class="text-start">TLS</th>
+            <th class="text-start">Extra</th>
+          </tr>
+        </thead>
+        <tbody class="thin">
+          <!--
+            `:key="index"` is intentional here. The list is rendered read-only
+            (no inputs, no focus, no editable state), so Vue's "don't use index
+            as key" rule — which exists to avoid swapping DOM around the wrong
+            data when items are inserted/deleted/edited — doesn't apply. The
+            editable form (`EndpointRow` in RegisteredNodeFormData) uses the
+            `uiId`-based key for that reason.
+          -->
+          <tr v-for="(endpoint, index) of endpoints" :key="index">
+            <td class="col text-start">{{ typeLabel[endpoint.type] ?? endpoint.type }}</td>
+            <td class="col text-start">{{ endpoint.ipAddressV4 }}</td>
+            <td class="col text-start">{{ endpoint.domainName }}</td>
+            <td class="col text-start">{{ endpoint.port }}</td>
+            <td class="col text-start">{{ endpoint.requiresTls ? 'Yes' : 'No' }}</td>
+            <td class="col text-start">
+              <template v-if="endpoint.type === 'blockNode'">
+                {{ (endpoint.endpointApis ?? []).length }} API(s)
+              </template>
+              <template v-else-if="endpoint.type === 'generalService'">
+                {{ endpoint.endpointDescription || '' }}
+              </template>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <KeyStructureModal
+      v-if="adminKey"
+      v-model:show="isKeyStructureModalShown"
+      :account-key="adminKey"
+    />
+  </div>
+</template>

--- a/front-end/src/renderer/components/Transaction/Details/txTypeComponentMapping.ts
+++ b/front-end/src/renderer/components/Transaction/Details/txTypeComponentMapping.ts
@@ -4,6 +4,7 @@ import DeleteAccountDetails from './DeleteAccountDetails.vue';
 import FileDetails from './FileDetails.vue';
 import FreezeDetails from './FreezeDetails.vue';
 import NodeDetails from './NodeDetails.vue';
+import RegisteredNodeDetails from './RegisteredNodeDetails.vue';
 import SystemDetails from './SystemDetails.vue';
 import TransferDetails from './TransferDetails.vue';
 
@@ -24,6 +25,7 @@ export const transactionTypeKeys = {
   nodeCreate: 'NodeCreateTransaction',
   nodeUpdate: 'NodeUpdateTransaction',
   nodeDelete: 'NodeDeleteTransaction',
+  registeredNodeCreate: 'RegisteredNodeCreateTransaction',
 };
 
 const txTypeComponentMapping = {
@@ -41,6 +43,7 @@ const txTypeComponentMapping = {
   [transactionTypeKeys.nodeCreate]: NodeDetails,
   [transactionTypeKeys.nodeUpdate]: NodeDetails,
   [transactionTypeKeys.nodeDelete]: NodeDetails,
+  [transactionTypeKeys.registeredNodeCreate]: RegisteredNodeDetails,
 };
 
 export default txTypeComponentMapping;

--- a/front-end/src/renderer/components/TransactionSelectionModal.vue
+++ b/front-end/src/renderer/components/TransactionSelectionModal.vue
@@ -48,6 +48,11 @@ const transactionGroups = computed(() => {
         { label: 'Node Create', name: transactionTypeKeys.nodeCreate },
         { label: 'Node Delete', name: transactionTypeKeys.nodeDelete },
         { label: 'Node Update', name: transactionTypeKeys.nodeUpdate },
+        { separator: true },
+        {
+          label: 'Registered Node Create',
+          name: transactionTypeKeys.registeredNodeCreate,
+        },
       ],
     },
     {
@@ -91,8 +96,17 @@ const transactionGroups = computed(() => {
         </div>
         <div class="col-7">
           <div class="border-start ps-2">
-            <template v-for="item in transactionGroups[activeGroupIndex].items" :key="item.name">
+            <template
+              v-for="(item, idx) in transactionGroups[activeGroupIndex].items"
+              :key="'separator' in item ? `sep-${idx}` : item.name"
+            >
+              <hr
+                v-if="'separator' in item && item.separator"
+                class="separator my-2"
+                data-testid="menu-sub-separator"
+              />
               <a
+                v-else-if="'name' in item"
                 :data-testid="`menu-sub-link-${item.name.toLowerCase()}`"
                 class="link-menu cursor-pointer"
                 @click="

--- a/front-end/src/renderer/components/TransactionSelectionModal.vue
+++ b/front-end/src/renderer/components/TransactionSelectionModal.vue
@@ -5,6 +5,15 @@ import { transactionTypeKeys } from '@renderer/components/Transaction/Create/txT
 
 import AppModal from '@renderer/components/ui/AppModal.vue';
 
+/* Types */
+type MenuLinkItem = { label: string; name: string };
+type MenuSeparatorItem = { separator: true };
+type MenuItem = MenuLinkItem | MenuSeparatorItem;
+type MenuGroup = { groupTitle: string; items: MenuItem[] };
+
+/** Type guard so vue-tsc can narrow `item` inside template branches. */
+const isLinkItem = (item: MenuItem): item is MenuLinkItem => 'name' in item;
+
 /* Props */
 defineProps<{
   group?: boolean;
@@ -17,8 +26,8 @@ const show = defineModel<boolean>('show', { required: true });
 const activeGroupIndex = ref(0);
 
 /* Computed */
-const transactionGroups = computed(() => {
-  const groups = [
+const transactionGroups = computed<MenuGroup[]>(() => {
+  const groups: MenuGroup[] = [
     {
       groupTitle: 'Account',
       items: [
@@ -98,15 +107,15 @@ const transactionGroups = computed(() => {
           <div class="border-start ps-2">
             <template
               v-for="(item, idx) in transactionGroups[activeGroupIndex].items"
-              :key="'separator' in item ? `sep-${idx}` : item.name"
+              :key="isLinkItem(item) ? item.name : `sep-${idx}`"
             >
               <hr
-                v-if="'separator' in item && item.separator"
+                v-if="!isLinkItem(item)"
                 class="separator my-2"
                 data-testid="menu-sub-separator"
               />
               <a
-                v-else-if="'name' in item"
+                v-else
                 :data-testid="`menu-sub-link-${item.name.toLowerCase()}`"
                 class="link-menu cursor-pointer"
                 @click="

--- a/front-end/src/renderer/utils/sdk/createTransactions.ts
+++ b/front-end/src/renderer/utils/sdk/createTransactions.ts
@@ -6,19 +6,26 @@ import {
   AccountDeleteTransaction,
   AccountId,
   AccountUpdateTransaction,
+  BlockNodeApi,
+  BlockNodeServiceEndpoint,
   FileAppendTransaction,
   FileCreateTransaction,
   FileId,
   FileUpdateTransaction,
   FreezeTransaction,
   FreezeType,
+  GeneralServiceEndpoint,
   Hbar,
   Key,
   KeyList,
   Long,
+  MirrorNodeServiceEndpoint,
   NodeCreateTransaction,
   NodeDeleteTransaction,
   NodeUpdateTransaction,
+  RegisteredNodeCreateTransaction,
+  RegisteredServiceEndpoint,
+  RpcRelayServiceEndpoint,
   ServiceEndpoint,
   SystemDeleteTransaction,
   SystemUndeleteTransaction,
@@ -132,6 +139,35 @@ export type NodeUpdateData = NodeData & {
 
 export type NodeDeleteData = {
   nodeId: string;
+};
+
+/* HIP-1137 — Registered Node */
+export type RegisteredEndpointType =
+  | 'blockNode'
+  | 'mirrorNode'
+  | 'rpcRelay'
+  | 'generalService';
+
+export interface ComponentRegisteredServiceEndpoint extends ComponentServiceEndpoint {
+  type: RegisteredEndpointType;
+  requiresTls: boolean;
+  /** Block-node APIs (codes from `BlockNodeApi` static instances). Only used when `type === 'blockNode'`. */
+  endpointApis?: number[];
+  /** Free-text description for general-service endpoints. Only used when `type === 'generalService'`. */
+  endpointDescription?: string;
+  /**
+   * Client-side-only stable identity used as the Vue list `:key`. Never
+   * serialized to the proto wire. Generated once when the row is added so
+   * delete/reorder operations keep the right DOM nodes attached to the right
+   * data and don't shuffle focus between rows.
+   */
+  uiId?: string;
+}
+
+export type RegisteredNodeData = {
+  description: string;
+  adminKey: Key | null;
+  serviceEndpoints: ComponentRegisteredServiceEndpoint[];
 };
 
 export type SystemData = {
@@ -536,6 +572,163 @@ export function createNodeUpdateTransaction(
 
   if (data.nodeId) {
     transaction.setNodeId(Long.fromString(data.nodeId));
+  }
+
+  return transaction;
+}
+
+/* HIP-1137 — Registered Node */
+
+/**
+ * Set of `BlockNodeApi` numeric codes the *currently-installed* SDK knows about.
+ * Built once at module load from the SDK's enumerable static instances. Used
+ * by `buildRegisteredServiceEndpoint` to filter out any unknown codes before
+ * calling `setEndpointApis(...)` — without this guard, the SDK internally
+ * routes each numeric input through `BlockNodeApi._fromCode(n)` which THROWS
+ * `(BUG) BlockNodeApi._fromCode() does not handle code: N` for any code not
+ * baked into this SDK version. That crash is reachable from drafts saved on a
+ * future SDK release with a new enum entry.
+ */
+const KNOWN_BLOCK_NODE_API_CODES: ReadonlySet<number> = new Set(
+  Object.values(BlockNodeApi as unknown as Record<string, unknown>)
+    .filter((v): v is InstanceType<typeof BlockNodeApi> => v instanceof BlockNodeApi)
+    .map(api => Number(api)),
+);
+
+/**
+ * Strict IPv4 parser. Rejects octets that aren't pure decimal digits, so
+ * `"01"`, `"0xa"`, `"1e2"`, `"+1"`, `"  "`, `"5 "` all fail rather than
+ * being silently coerced by `Number()`. The proto contract says IPv4 = 4
+ * bytes big-endian; we never want the bytes on the wire to disagree with
+ * what the user typed.
+ */
+export const parseIpv4ToBytes = (ipAddressV4: string): Uint8Array | null => {
+  if (!ipAddressV4) return null;
+  const octets = ipAddressV4.trim().split('.');
+  if (octets.length !== 4) return null;
+  const parsed: number[] = [];
+  for (const octet of octets) {
+    if (!/^[0-9]{1,3}$/.test(octet)) return null;
+    const n = Number(octet);
+    if (n < 0 || n > 255) return null;
+    parsed.push(n);
+  }
+  return Uint8Array.from(parsed);
+};
+
+/** Strict port parser: requires pure-digit string, returns null on empty / non-digit / out-of-range. */
+export const parsePort = (port: string): number | null => {
+  const trimmed = port.trim();
+  if (!/^[0-9]+$/.test(trimmed)) return null;
+  const n = Number(trimmed);
+  if (n < 0 || n > 65535) return null;
+  return n;
+};
+
+const applyRegisteredEndpointBase = (
+  endpoint: RegisteredServiceEndpoint,
+  data: ComponentRegisteredServiceEndpoint,
+) => {
+  const ipBytes = parseIpv4ToBytes(data.ipAddressV4 ?? '');
+  if (ipBytes) {
+    endpoint.setIpAddress(ipBytes);
+  } else if (data.domainName?.trim()) {
+    endpoint.setDomainName(data.domainName.trim());
+  }
+
+  const port = parsePort(data.port ?? '');
+  if (port !== null) {
+    endpoint.setPort(port);
+  }
+
+  endpoint.setRequiresTls(Boolean(data.requiresTls));
+};
+
+export const buildRegisteredServiceEndpoint = (
+  data: ComponentRegisteredServiceEndpoint,
+): RegisteredServiceEndpoint | null => {
+  if (!data?.type) return null;
+
+  // proto `oneof address` requires exactly one of ip_address / domain_name.
+  // A non-empty `ipAddressV4` field that doesn't parse to 4 valid octets must
+  // NOT silently fall through to domain (which is empty) — otherwise we'd ship
+  // an endpoint with no address and the chain would return an opaque
+  // INVALID_REGISTERED_ENDPOINT_ADDRESS. `preCreateAssert` rejects this earlier,
+  // but this helper is also called from getData round-trip and external paths,
+  // so be defensive here too.
+  const hasIp = Boolean(data.ipAddressV4?.trim());
+  const hasDomain = Boolean(data.domainName?.trim());
+  if (!hasIp && !hasDomain) return null;
+  if (hasIp && parseIpv4ToBytes(data.ipAddressV4 ?? '') === null) return null;
+  // Symmetric port guard so non-form callers (drafts, external paths) can't
+  // produce an endpoint with the SDK's default port=0 just because the port
+  // string is empty/malformed.
+  if (parsePort(data.port ?? '') === null) return null;
+
+  switch (data.type) {
+    case 'blockNode': {
+      const endpoint = new BlockNodeServiceEndpoint();
+      applyRegisteredEndpointBase(endpoint, data);
+      // The SDK's `BlockNodeServiceEndpoint.setEndpointApis` routes each
+      // numeric input through `BlockNodeApi._fromCode(code)`, which throws on
+      // any code outside the SDK's known set. Filter unknown codes against
+      // `KNOWN_BLOCK_NODE_API_CODES` (derived from the running SDK) to avoid
+      // crashing the build for drafts saved on a future SDK release.
+      const apis = (data.endpointApis ?? []).filter(code =>
+        KNOWN_BLOCK_NODE_API_CODES.has(code),
+      );
+      if (apis.length > 0) {
+        endpoint.setEndpointApis(apis);
+      }
+      return endpoint;
+    }
+    case 'mirrorNode': {
+      const endpoint = new MirrorNodeServiceEndpoint();
+      applyRegisteredEndpointBase(endpoint, data);
+      return endpoint;
+    }
+    case 'rpcRelay': {
+      const endpoint = new RpcRelayServiceEndpoint();
+      applyRegisteredEndpointBase(endpoint, data);
+      return endpoint;
+    }
+    case 'generalService': {
+      const endpoint = new GeneralServiceEndpoint();
+      applyRegisteredEndpointBase(endpoint, data);
+      if (data.endpointDescription?.trim()) {
+        endpoint.setDescription(data.endpointDescription.trim());
+      }
+      return endpoint;
+    }
+    default:
+      return null;
+  }
+};
+
+export const getRegisteredServiceEndpoints = (
+  data: ComponentRegisteredServiceEndpoint[],
+): RegisteredServiceEndpoint[] =>
+  data
+    .map(buildRegisteredServiceEndpoint)
+    .filter((e): e is RegisteredServiceEndpoint => e !== null);
+
+export function createRegisteredNodeCreateTransaction(
+  data: TransactionCommonData & RegisteredNodeData,
+): RegisteredNodeCreateTransaction {
+  const transaction = new RegisteredNodeCreateTransaction();
+  setTransactionCommonData(transaction, data);
+
+  if (data.adminKey) {
+    transaction.setAdminKey(data.adminKey);
+  }
+
+  if (data.description && data.description.length > 0) {
+    transaction.setDescription(data.description);
+  }
+
+  const endpoints = getRegisteredServiceEndpoints(data.serviceEndpoints);
+  if (endpoints.length > 0) {
+    transaction.setServiceEndpoints(endpoints);
   }
 
   return transaction;

--- a/front-end/src/renderer/utils/sdk/getData.ts
+++ b/front-end/src/renderer/utils/sdk/getData.ts
@@ -11,15 +11,21 @@ import {
   AccountCreateTransaction,
   AccountDeleteTransaction,
   AccountUpdateTransaction,
+  BlockNodeServiceEndpoint,
   FileAppendTransaction,
   FileCreateTransaction,
   FileUpdateTransaction,
   FreezeTransaction,
+  GeneralServiceEndpoint,
   Hbar,
   KeyList,
+  MirrorNodeServiceEndpoint,
   NodeCreateTransaction,
   NodeDeleteTransaction,
   NodeUpdateTransaction,
+  RegisteredNodeCreateTransaction,
+  type RegisteredServiceEndpoint,
+  RpcRelayServiceEndpoint,
   TransferTransaction,
 } from '@hiero-ledger/sdk';
 
@@ -29,6 +35,7 @@ import type {
   AccountDeleteData,
   AccountUpdateData,
   ApproveHbarAllowanceData,
+  ComponentRegisteredServiceEndpoint,
   ComponentServiceEndpoint,
   FileAppendData,
   FileCreateData,
@@ -38,6 +45,8 @@ import type {
   NodeData,
   NodeDeleteData,
   NodeUpdateData,
+  RegisteredEndpointType,
+  RegisteredNodeData,
   SystemData,
   SystemDeleteData,
   SystemUndeleteData,
@@ -61,6 +70,7 @@ export type ExtendedTransactionData = TransactionCommonData &
     | NodeData
     | NodeUpdateData
     | NodeDeleteData
+    | RegisteredNodeData
     | SystemDeleteData
     | SystemUndeleteData
   );
@@ -288,6 +298,65 @@ export function getNodeDeleteData(transaction: Transaction): NodeDeleteData {
   };
 }
 
+/* HIP-1137 — Registered Node */
+const getRegisteredEndpointType = (
+  endpoint: RegisteredServiceEndpoint,
+): RegisteredEndpointType => {
+  if (endpoint instanceof BlockNodeServiceEndpoint) return 'blockNode';
+  if (endpoint instanceof MirrorNodeServiceEndpoint) return 'mirrorNode';
+  if (endpoint instanceof RpcRelayServiceEndpoint) return 'rpcRelay';
+  if (endpoint instanceof GeneralServiceEndpoint) return 'generalService';
+  // Fallback: trust the base-class `type` getter if subclass detection misses.
+  return endpoint.type;
+};
+
+/**
+ * Extract an endpoint from a decoded SDK transaction back into the FE-facing
+ * shape. Deliberately does NOT populate `uiId` — that field is a render-side
+ * concern owned by the form component (see `decorateEndpointsWithUiIds` in
+ * `RegisteredNodeCreate.vue`). Including `uiId` here would make every call to
+ * `transactionsDataMatch` produce mismatched JSON (uiIds are freshly generated
+ * per call), spuriously marking every loaded draft as "unsaved".
+ */
+const getComponentRegisteredEndpoint = (
+  endpoint: RegisteredServiceEndpoint,
+): ComponentRegisteredServiceEndpoint => {
+  const ipBytes = endpoint.ipAddress;
+  const ipAddressV4 =
+    ipBytes && ipBytes.length === 4 ? Array.from(ipBytes).join('.') : '';
+  const base: ComponentRegisteredServiceEndpoint = {
+    ipAddressV4,
+    port: endpoint.port != null ? endpoint.port.toString() : '',
+    domainName: endpoint.domainName ?? '',
+    type: getRegisteredEndpointType(endpoint),
+    requiresTls: Boolean(endpoint.requiresTls),
+  };
+
+  if (endpoint instanceof BlockNodeServiceEndpoint) {
+    // Use Number(api), which calls BlockNodeApi.valueOf() → numeric code.
+    // Avoids reaching into the SDK's underscore-prefixed `_code` field.
+    base.endpointApis = (endpoint.endpointApis ?? []).map(api => Number(api));
+  } else if (endpoint instanceof GeneralServiceEndpoint) {
+    base.endpointDescription = endpoint.description ?? '';
+  }
+
+  return base;
+};
+
+export function getRegisteredNodeData(transaction: Transaction): RegisteredNodeData {
+  assertTransactionType(transaction, RegisteredNodeCreateTransaction);
+
+  const endpoints = (transaction.serviceEndpoints ?? []).map(
+    getComponentRegisteredEndpoint,
+  );
+
+  return {
+    description: transaction.description ?? '',
+    adminKey: transaction.adminKey ?? null,
+    serviceEndpoints: endpoints,
+  };
+}
+
 export function getSystemData(
   transaction: SystemDeleteTransaction | SystemUndeleteTransaction,
 ): SystemData {
@@ -415,6 +484,14 @@ const transactionHandlers = new Map<
   ],
 
   [
+    RegisteredNodeCreateTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getRegisteredNodeData(tx),
+    }),
+  ],
+
+  [
     SystemDeleteTransaction,
     tx => ({
       ...getTransactionCommonData(tx),
@@ -468,5 +545,22 @@ export function transactionsDataMatch(t1: Transaction, t2: Transaction): boolean
   t2Data.validStart = undefined
   t1Data.startTimestamp = undefined;
   t2Data.startTimestamp = undefined;
+  // Defensive: `uiId` is a render-side stable key for endpoint rows and must
+  // never affect the "has the user edited anything?" comparison. The current
+  // `getRegisteredNodeData` does not emit it, but strip here too so that any
+  // future code path which accidentally carries it through is harmless.
+  stripUiIds(t1Data);
+  stripUiIds(t2Data);
   return JSON.stringify(t1Data) === JSON.stringify(t2Data);
 }
+
+const stripUiIds = (data: Record<string, unknown>) => {
+  const endpoints = data['serviceEndpoints'];
+  if (Array.isArray(endpoints)) {
+    for (const ep of endpoints) {
+      if (ep && typeof ep === 'object' && 'uiId' in ep) {
+        delete (ep as { uiId?: unknown }).uiId;
+      }
+    }
+  }
+};

--- a/front-end/src/renderer/utils/sdk/transactions.ts
+++ b/front-end/src/renderer/utils/sdk/transactions.ts
@@ -13,6 +13,7 @@ import {
   NodeCreateTransaction,
   NodeDeleteTransaction,
   NodeUpdateTransaction,
+  RegisteredNodeCreateTransaction,
   SystemDeleteTransaction,
   SystemUndeleteTransaction,
   Transaction,
@@ -102,6 +103,8 @@ export const getTransactionType = (
     transactionType = 'Node Update Transaction';
   } else if (transaction instanceof NodeDeleteTransaction) {
     transactionType = 'Node Delete Transaction';
+  } else if (transaction instanceof RegisteredNodeCreateTransaction) {
+    transactionType = 'Registered Node Create Transaction';
   } else if (transaction instanceof SystemDeleteTransaction) {
     transactionType = 'System Delete Transaction';
   } else if (transaction instanceof SystemUndeleteTransaction) {

--- a/front-end/src/renderer/utils/sdk/validation.ts
+++ b/front-end/src/renderer/utils/sdk/validation.ts
@@ -46,6 +46,32 @@ export function validate100CharInput(str: string, inputDescription: string) {
   }
 }
 
+/**
+ * UTF-8 byte length of a string. Use instead of `.length` (UTF-16 code units)
+ * whenever a proto contract specifies a byte limit — most Hedera string fields
+ * are byte-limited (memo, description, etc.).
+ */
+export function utf8ByteLength(str: string): number {
+  return new TextEncoder().encode(str).length;
+}
+
+/** Returns true if the string's UTF-8 byte length is strictly greater than the limit. */
+export function exceedsUtf8ByteLimit(str: string, byteLimit: number): boolean {
+  return utf8ByteLength(str) > byteLimit;
+}
+
+/**
+ * Byte-aware analogue of `validate100CharInput`. The HIP for registered nodes
+ * (and several other proto contracts) specifies `100 bytes UTF-8`, not 100
+ * characters — `.length` counts UTF-16 code units, which under-counts emoji
+ * and over-counts surrogate pairs.
+ */
+export function validate100ByteInput(str: string, inputDescription: string) {
+  if (exceedsUtf8ByteLimit(str, 100)) {
+    throw new Error(`${inputDescription} is limited to 100 bytes (UTF-8)`);
+  }
+}
+
 export const transactionIs = <T extends Transaction>(
   type: new (...args: any[]) => T,
   transaction: Transaction,

--- a/front-end/src/renderer/utils/transactionSignatureModels/index.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/index.ts
@@ -15,6 +15,7 @@ export * from './file-create-transaction.model';
 export * from './file-append-transaction.model';
 export * from './file-update-transaction.model';
 export * from './freeze-transaction.model';
+export * from './registered-node-create-transaction.model';
 export * from './system-delete-transaction.model';
 export * from './transaction-factory';
 export * from './transaction.model';

--- a/front-end/src/renderer/utils/transactionSignatureModels/registered-node-create-transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/registered-node-create-transaction.model.ts
@@ -1,0 +1,13 @@
+import { RegisteredNodeCreateTransaction } from '@hiero-ledger/sdk';
+
+import { TransactionBaseModel } from './transaction.model';
+
+export default class RegisteredNodeCreateTransactionModel extends TransactionBaseModel<RegisteredNodeCreateTransaction> {
+  override getNewKeys() {
+    if (this.transaction.adminKey != null) {
+      return [this.transaction.adminKey];
+    }
+
+    return [];
+  }
+}

--- a/front-end/src/renderer/utils/transactionSignatureModels/transaction-factory.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/transaction-factory.ts
@@ -14,6 +14,7 @@ import FileCreateTransactionModel from './file-create-transaction.model';
 import NodeCreateTransactionModel from './node-create-transaction.model';
 import NodeUpdateTransactionModel from './node-update-transaction.model';
 import NodeDeleteTransactionModel from './node-delete-transaction.model';
+import RegisteredNodeCreateTransactionModel from './registered-node-create-transaction.model';
 import { getTransactionType } from '../sdk/transactions';
 
 export default class TransactionFactory {
@@ -38,6 +39,7 @@ export default class TransactionFactory {
       NodeCreateTransaction: NodeCreateTransactionModel,
       NodeUpdateTransaction: NodeUpdateTransactionModel,
       NodeDeleteTransaction: NodeDeleteTransactionModel,
+      RegisteredNodeCreateTransaction: RegisteredNodeCreateTransactionModel,
     };
 
     const transactionType = getTransactionType(

--- a/front-end/src/shared/interfaces/organization/transactions/index.ts
+++ b/front-end/src/shared/interfaces/organization/transactions/index.ts
@@ -20,6 +20,7 @@ export enum BackEndTransactionType {
   NODE_CREATE = 'NODE CREATE',
   NODE_UPDATE = 'NODE UPDATE',
   NODE_DELETE = 'NODE DELETE',
+  REGISTERED_NODE_CREATE = 'REGISTERED NODE CREATE',
 }
 
 export const TransactionTypeName = {
@@ -38,6 +39,7 @@ export const TransactionTypeName = {
   [BackEndTransactionType.NODE_CREATE]: 'Node Create Transaction',
   [BackEndTransactionType.NODE_UPDATE]: 'Node Update Transaction',
   [BackEndTransactionType.NODE_DELETE]: 'Node Delete Transaction',
+  [BackEndTransactionType.REGISTERED_NODE_CREATE]: 'Registered Node Create Transaction',
 };
 
 export enum TransactionStatus {


### PR DESCRIPTION
Fixes: #2826

## Description
Adds HIP-1137 `RegisteredNodeCreate` support to the transaction tool.

## Why
HIP-1137 introduces a new on-chain registry for non-consensus nodes
(block nodes, mirror nodes, RPC relays, general services). The tool
now lets users create those entries.

## Front-end
- New menu entry **Registered Node Create** under the Node group,
  separated from existing items by a divider.
- New page `Transaction/Create/RegisteredNodeCreate/` mirrors the
  Node Create flow (form + per-endpoint row editor).
- Supports all 4 service-endpoint types per HIP-1137:
  Block Node, Mirror Node, RPC Relay, General Service.
- Enforces ≥1 endpoint, ≤50 endpoints, description ≤100 UTF-8 bytes,
  IPv4 octet validity, port range [0, 65535].
- New `RegisteredNodeDetails.vue` for the history / details view.

## Back-end
- New `RegisteredNodeCreateTransactionModel`. Tells the BE that the
  admin key is the required signer for this transaction type.
- Registered in `TransactionFactory`.
- `REGISTERED_NODE_CREATE` added to `TransactionType` enum (and the
  shared `BackEndTransactionType` so BE and FE stay in sync).
- Added type-detection branches in `utils/sdk/transaction.ts` so the
  BE recognizes the new transaction class.
- Refactored admin-key extraction in `transactions.service.ts` to
  dispatch through `TransactionFactory.getNewKeys()`. Adding future
  transaction types with admin keys is now just a model + factory
  entry — no service edit needed.


## Manual verification
- Personal mode → testnet → returns `UNAUTHORIZED 157`. Expected:
  the payer is not a governance account, so testnet rejects the
  create. End-to-end pipeline confirmed working.


## Screenshots
1. Menu for the `Registered Node Create`

<img width="822" height="335" alt="Screenshot 2026-05-15 at 11 39 14" src="https://github.com/user-attachments/assets/e07e7e5c-1644-414d-a7ae-6fe18c1cb514" />

2. `Registered Node Create` page

<img width="1107" height="1074" alt="Screenshot 2026-05-15 at 11 36 46" src="https://github.com/user-attachments/assets/b79ab2f8-a79f-42cb-9adc-162e35f20869" />
<img width="1100" height="1076" alt="Screenshot 2026-05-15 at 11 37 13" src="https://github.com/user-attachments/assets/83b16a8f-bc72-4a18-9c2c-c8327d69ba82" />

3. History tab

<img width="1098" height="1078" alt="Screenshot 2026-05-15 at 11 38 45" src="https://github.com/user-attachments/assets/d6c07a04-82c8-40b5-bdc5-ef097311abbc" />
<img width="1095" height="1074" alt="Screenshot 2026-05-15 at 11 38 57" src="https://github.com/user-attachments/assets/7b8fc6f9-b390-4ca7-83fb-29005b956462" />


