### PR TITLE
feat: details page for Token Transfer now displays all transfer types

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -83,6 +83,7 @@
     "@vue/eslint-config-typescript": "14.1.3",
     "@vue/test-utils": "2.4.10",
     "@vue/tsconfig": "0.7.0",
+    "axios-mock-adapter": "2.1.0",
     "electron": "41.5.1",
     "electron-builder": "26.8.1",
     "eslint": "9.39.3",

--- a/front-end/src/renderer/caches/AppCache.ts
+++ b/front-end/src/renderer/caches/AppCache.ts
@@ -10,6 +10,7 @@ import { BackendTransactionCache } from './backend/BackendTransactionCache.ts';
 import { AccountByPublicKeyCache } from './mirrorNode/AccountByPublicKeyCache';
 import TransactionFactory from '@renderer/utils/transactionSignatureModels/transaction-factory.ts';
 import { createLogger } from '@renderer/utils';
+import { TokenByIdCache } from '@renderer/caches/mirrorNode/TokenByIdCache';
 
 export class AppCache {
   private static readonly injectKey = Symbol();
@@ -20,6 +21,7 @@ export class AppCache {
   public readonly mirrorAccountByPublicKey = new AccountByPublicKeyCache();
   public readonly mirrorNodeById = new NodeByIdCache();
   public readonly mirrorTransactionById = new TransactionByIdCache();
+  public readonly mirrorTokenById = new TokenByIdCache();
 
   // Backend
   public readonly backendTransaction = new BackendTransactionCache();

--- a/front-end/src/renderer/caches/mirrorNode/TokenByIdCache.ts
+++ b/front-end/src/renderer/caches/mirrorNode/TokenByIdCache.ts
@@ -1,0 +1,53 @@
+import axios from 'axios';
+import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
+import type { ITokenInfo } from '@shared/interfaces/ITokenInfo';
+
+export class TokenByIdCache extends EntityCache<string, ITokenInfo | null> {
+  //
+  // EntityCache
+  //
+
+  protected override async load(
+    tokenId: string,
+    mirrorNodeURL: string,
+  ): Promise<ITokenInfo | null> {
+    let result: ITokenInfo | null;
+    try {
+      const url = mirrorNodeURL + '/api/v1/tokens/' + tokenId;
+      const response = await axios.get<ITokenInfo>(url);
+      result = response.data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status == 404) {
+        result = null;
+      } else {
+        throw error;
+      }
+    }
+    return result;
+  }
+}
+
+export const MAX_TOKEN_SUPPLY = 9223372036854775807n;
+
+export function formatTokenAmount(rawAmount: bigint, tokenInfo: ITokenInfo): string {
+  let result: string;
+  if (rawAmount > MAX_TOKEN_SUPPLY) {
+    rawAmount = MAX_TOKEN_SUPPLY;
+  }
+  const decimalCount = decimalCountFromTokenInfo(tokenInfo);
+  const amountFormatter = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: decimalCount,
+    maximumFractionDigits: decimalCount,
+  });
+  if (decimalCount) {
+    result = amountFormatter.format(Number(rawAmount) / Math.pow(10, decimalCount));
+  } else {
+    result = amountFormatter.format(rawAmount);
+  }
+  return result;
+}
+
+export function decimalCountFromTokenInfo(tokenInfo: ITokenInfo): number {
+  const result = Number(tokenInfo.decimals);
+  return isNaN(result) ? 0 : result;
+}

--- a/front-end/src/renderer/components/Transaction/Details/TransferDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/TransferDetails.vue
@@ -12,6 +12,7 @@ import { getAll } from '@renderer/services/accountsService';
 
 import { isUserLoggedIn } from '@renderer/utils';
 import HBarTransferDetails from './TransferDetails/HBarTransferDetails.vue';
+import TokenTransferDetails from '@renderer/components/Transaction/Details/TransferDetails/TokenTransferDetails.vue';
 
 /* Props */
 const props = defineProps<{
@@ -44,6 +45,13 @@ onBeforeMount(async () => {
         :hbar-transfers="props.transaction.hbarTransfersList"
         :linkedAccounts="linkedAccounts"
       />
+      <template v-for="tokenId in props.transaction.tokenTransfers.keys()" :key="tokenId">
+        <TokenTransferDetails
+          :token-id="tokenId"
+          :transaction="props.transaction"
+          :linkedAccounts="linkedAccounts"
+        />
+      </template>
     </div>
   </div>
 </template>

--- a/front-end/src/renderer/components/Transaction/Details/TransferDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/TransferDetails.vue
@@ -1,17 +1,17 @@
 <script setup lang="ts">
 import type { HederaAccount } from '@prisma/client';
 
-import { computed, onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref } from 'vue';
 
-import { Transaction, Transfer, TransferTransaction } from '@hiero-ledger/sdk';
+import { Transaction, TransferTransaction } from '@hiero-ledger/sdk';
 
 import useUserStore from '@renderer/stores/storeUser';
 import useNetworkStore from '@renderer/stores/storeNetwork';
 
 import { getAll } from '@renderer/services/accountsService';
 
-import { getAccountIdWithChecksum, isUserLoggedIn, stringifyHbar } from '@renderer/utils';
-import { AppCache } from '@renderer/caches/AppCache';
+import { isUserLoggedIn } from '@renderer/utils';
+import HBarTransferDetails from './TransferDetails/HBarTransferDetails.vue';
 
 /* Props */
 const props = defineProps<{
@@ -22,47 +22,12 @@ const props = defineProps<{
 const user = useUserStore();
 const network = useNetworkStore();
 
-/* Injected */
-const accountByIdCache = AppCache.inject().mirrorAccountById;
-
 /* State */
 const linkedAccounts = ref<HederaAccount[]>([]);
-const transfersExceedingBalance = ref<Transfer[]>([]);
-const transferParsingComplete = ref(false);
-
-/* Computed */
-const errorMessage = computed(() => {
-  let result: string | null;
-  if (transfersExceedingBalance.value.length > 0) {
-    result = `Insufficient balance for transfer`;
-  } else {
-    result = null;
-  }
-  return result;
-});
 
 /* Hooks */
 onBeforeMount(async () => {
   if (!isUserLoggedIn(user.personal)) throw new Error('User is not logged in');
-  if (!(props.transaction instanceof TransferTransaction)) {
-    throw new Error('Transaction is not Transfer Transaction');
-  }
-
-  for (const transfer of props.transaction.hbarTransfersList) {
-    if (transfer.amount.isNegative()) {
-      const accountInfo = await accountByIdCache.lookup(
-        transfer.accountId.toString(),
-        network.mirrorNodeBaseURL,
-      );
-      if (
-        accountInfo &&
-        transfer.amount.negated().toBigNumber().isGreaterThan(accountInfo.balance.toBigNumber())
-      ) {
-        transfersExceedingBalance.value.push(transfer);
-      }
-    }
-  }
-  transferParsingComplete.value = true;
 
   linkedAccounts.value = await getAll({
     where: {
@@ -71,143 +36,14 @@ onBeforeMount(async () => {
     },
   });
 });
-
-/* Functions */
-const balanceExceeded = (transfer: Transfer): boolean => {
-  return transfersExceedingBalance.value.some(t => t.accountId === transfer.accountId);
-};
 </script>
 <template>
-  <div v-if="transaction instanceof TransferTransaction && true" class="mt-5">
-    <!-- Hbar transfers -->
-    <div v-if="transferParsingComplete" class="row">
-      <div class="col-6">
-        <div class="mt-3">
-          <template v-for="debit in transaction.hbarTransfersList" :key="debit.accountId">
-            <div v-if="debit.amount.isNegative()" class="mt-3">
-              <div class="row align-items-center px-3">
-                <div
-                  class="col-6 col-lg-5 flex-centered justify-content-start flex-wrap overflow-hidden"
-                >
-                  <template
-                    v-if="
-                      (
-                        linkedAccounts.find(la => la.account_id === debit.accountId.toString())
-                          ?.nickname || ''
-                      ).length > 0
-                    "
-                  >
-                    <p v-if="debit.isApproved" class="text-small text-semi-bold me-2">Approved</p>
-
-                    <div class="d-flex align-items-baseline justify-content-start flex-wrap">
-                      <p class="text-small text-semi-bold me-2">
-                        {{
-                          linkedAccounts.find(la => la.account_id === debit.accountId.toString())
-                            ?.nickname
-                        }}
-                      </p>
-                      <p class="text-secondary text-micro overflow-hidden">
-                        ({{ getAccountIdWithChecksum(debit.accountId.toString()) }})
-                      </p>
-                    </div>
-                  </template>
-                  <template v-else>
-                    <p v-if="debit.isApproved" class="text-small text-semi-bold me-2">Approved</p>
-                    <p
-                      class="text-secondary text-small overflow-hidden"
-                      data-testid="p-transfer-from-account-details"
-                    >
-                      {{ getAccountIdWithChecksum(debit.accountId.toString()) }}
-                    </p>
-                  </template>
-                </div>
-                <div class="col-6 col-lg-7 text-end text-nowrap overflow-hidden">
-                  <template v-if="balanceExceeded(debit)">
-                    <p
-                      class="text-danger text-small text-bold overflow-hidden"
-                      data-testid="p-transfer-from-amount-details"
-                    >
-                      {{ stringifyHbar(debit.amount)
-                      }}<span
-                        v-if="transfersExceedingBalance.length > 0"
-                        class="bi bi-exclamation-triangle-fill ms-2"
-                      ></span>
-                    </p>
-                  </template>
-                  <template v-else>
-                    <p
-                      class="text-secondary text-small text-bold overflow-hidden"
-                      data-testid="p-transfer-from-amount-details"
-                    >
-                      {{ stringifyHbar(debit.amount)
-                      }}<span
-                        v-if="transfersExceedingBalance.length > 0"
-                        class="invisible bi bi-exclamation-triangle-fill ms-2"
-                      ></span>
-                    </p>
-                  </template>
-                </div>
-              </div>
-              <hr class="separator" />
-            </div>
-          </template>
-        </div>
-        <p v-if="errorMessage" class="text-danger text-small text-end mt-3">{{ errorMessage }}</p>
-      </div>
-      <div class="col-6">
-        <div class="mt-3">
-          <template v-for="credit in transaction.hbarTransfersList" :key="credit.accountId">
-            <div v-if="!credit.amount.isNegative()" class="mt-3">
-              <div class="row align-items-center px-3">
-                <div
-                  class="col-6 col-lg-5 flex-centered justify-content-start flex-wrap overflow-hidden"
-                >
-                  <template
-                    v-if="
-                      (
-                        linkedAccounts.find(la => la.account_id === credit.accountId.toString())
-                          ?.nickname || ''
-                      ).length > 0
-                    "
-                  >
-                    <div class="d-flex align-items-baseline justify-content-start flex-wrap">
-                      <p class="text-small text-semi-bold me-2">
-                        {{
-                          linkedAccounts.find(la => la.account_id === credit.accountId.toString())
-                            ?.nickname
-                        }}
-                      </p>
-                      <p
-                        class="text-secondary text-micro overflow-hidden"
-                        data-testid="p-transfer-to-account-details"
-                      >
-                        ({{ getAccountIdWithChecksum(credit.accountId.toString()) }})
-                      </p>
-                    </div>
-                  </template>
-                  <template v-else>
-                    <p
-                      class="text-secondary text-small overflow-hidden"
-                      data-testid="p-transfer-to-account-details"
-                    >
-                      {{ getAccountIdWithChecksum(credit.accountId.toString()) }}
-                    </p>
-                  </template>
-                </div>
-                <div class="col-6 col-lg-7 text-end text-nowrap overflow-hidden">
-                  <p
-                    class="text-secondary text-small text-bold overflow-hidden"
-                    data-testid="p-transfer-to-amount-details"
-                  >
-                    {{ stringifyHbar(credit.amount) }}
-                  </p>
-                </div>
-              </div>
-              <hr class="separator" />
-            </div>
-          </template>
-        </div>
-      </div>
+  <div v-if="props.transaction instanceof TransferTransaction && true" class="mt-5">
+    <div class="row">
+      <HBarTransferDetails
+        :hbar-transfers="props.transaction.hbarTransfersList"
+        :linkedAccounts="linkedAccounts"
+      />
     </div>
   </div>
 </template>

--- a/front-end/src/renderer/components/Transaction/Details/TransferDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/TransferDetails.vue
@@ -13,6 +13,7 @@ import { getAll } from '@renderer/services/accountsService';
 import { isUserLoggedIn } from '@renderer/utils';
 import HBarTransferDetails from './TransferDetails/HBarTransferDetails.vue';
 import TokenTransferDetails from '@renderer/components/Transaction/Details/TransferDetails/TokenTransferDetails.vue';
+import NftTransferDetails from '@renderer/components/Transaction/Details/TransferDetails/NftTransferDetails.vue';
 
 /* Props */
 const props = defineProps<{
@@ -47,6 +48,13 @@ onBeforeMount(async () => {
       />
       <template v-for="tokenId in props.transaction.tokenTransfers.keys()" :key="tokenId">
         <TokenTransferDetails
+          :token-id="tokenId"
+          :transaction="props.transaction"
+          :linkedAccounts="linkedAccounts"
+        />
+      </template>
+      <template v-for="tokenId in props.transaction.nftTransfers.keys()" :key="tokenId">
+        <NftTransferDetails
           :token-id="tokenId"
           :transaction="props.transaction"
           :linkedAccounts="linkedAccounts"

--- a/front-end/src/renderer/components/Transaction/Details/TransferDetails/HBarTransferDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/TransferDetails/HBarTransferDetails.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import { computed, onBeforeMount, ref } from 'vue';
+import { Transfer } from '@hiero-ledger/sdk';
+import { getAccountIdWithChecksum, stringifyHbar } from '@renderer/utils';
+import type { HederaAccount } from '@prisma/client';
+import useNetworkStore from '@renderer/stores/storeNetwork.ts';
+import { AppCache } from '@renderer/caches/AppCache.ts';
+
+/* Props */
+const props = defineProps<{
+  hbarTransfers: Transfer[];
+  linkedAccounts: HederaAccount[];
+}>();
+
+/* Stores */
+const network = useNetworkStore();
+
+/* Injected */
+const accountByIdCache = AppCache.inject().mirrorAccountById;
+
+/* State */
+const transfersExceedingBalance = ref<Transfer[]>([]);
+const transferParsingComplete = ref(false);
+
+/* Computed */
+const errorMessage = computed(() => {
+  let result: string | null;
+  if (transfersExceedingBalance.value.length > 0) {
+    result = `Insufficient balance for transfer`;
+  } else {
+    result = null;
+  }
+  return result;
+});
+
+/* Hooks */
+onBeforeMount(async () => {
+  for (const transfer of props.hbarTransfers) {
+    if (transfer.amount.isNegative()) {
+      const accountInfo = await accountByIdCache.lookup(
+        transfer.accountId.toString(),
+        network.mirrorNodeBaseURL,
+      );
+      if (
+        accountInfo &&
+        transfer.amount.negated().toBigNumber().isGreaterThan(accountInfo.balance.toBigNumber())
+      ) {
+        transfersExceedingBalance.value.push(transfer);
+      }
+    }
+  }
+  transferParsingComplete.value = true;
+});
+
+/* Functions */
+const balanceExceeded = (transfer: Transfer): boolean => {
+  return transfersExceedingBalance.value.some(t => t.accountId === transfer.accountId);
+};
+</script>
+
+<template>
+  <template v-if="transferParsingComplete">
+    <div class="col-6">
+      <div class="mt-3">
+        <template v-for="debit in props.hbarTransfers" :key="debit.accountId">
+          <div v-if="debit.amount.isNegative()" class="mt-3">
+            <div class="row align-items-center px-3">
+              <div
+                class="col-6 col-lg-5 flex-centered justify-content-start flex-wrap overflow-hidden"
+              >
+                <template
+                  v-if="
+                    (
+                      props.linkedAccounts.find(la => la.account_id === debit.accountId.toString())
+                        ?.nickname || ''
+                    ).length > 0
+                  "
+                >
+                  <p v-if="debit.isApproved" class="text-small text-semi-bold me-2">Approved</p>
+
+                  <div class="d-flex align-items-baseline justify-content-start flex-wrap">
+                    <p class="text-small text-semi-bold me-2">
+                      {{
+                        props.linkedAccounts.find(
+                          la => la.account_id === debit.accountId.toString(),
+                        )?.nickname
+                      }}
+                    </p>
+                    <p class="text-secondary text-micro overflow-hidden">
+                      ({{ getAccountIdWithChecksum(debit.accountId.toString()) }})
+                    </p>
+                  </div>
+                </template>
+                <template v-else>
+                  <p v-if="debit.isApproved" class="text-small text-semi-bold me-2">Approved</p>
+                  <p
+                    class="text-secondary text-small overflow-hidden"
+                    data-testid="p-transfer-from-account-details"
+                  >
+                    {{ getAccountIdWithChecksum(debit.accountId.toString()) }}
+                  </p>
+                </template>
+              </div>
+              <div class="col-6 col-lg-7 text-end text-nowrap overflow-hidden">
+                <template v-if="balanceExceeded(debit)">
+                  <p
+                    class="text-danger text-small text-bold overflow-hidden"
+                    data-testid="p-transfer-from-amount-details"
+                  >
+                    {{ stringifyHbar(debit.amount)
+                    }}<span
+                      v-if="transfersExceedingBalance.length > 0"
+                      class="bi bi-exclamation-triangle-fill ms-2"
+                    ></span>
+                  </p>
+                </template>
+                <template v-else>
+                  <p
+                    class="text-secondary text-small text-bold overflow-hidden"
+                    data-testid="p-transfer-from-amount-details"
+                  >
+                    {{ stringifyHbar(debit.amount)
+                    }}<span
+                      v-if="transfersExceedingBalance.length > 0"
+                      class="invisible bi bi-exclamation-triangle-fill ms-2"
+                    ></span>
+                  </p>
+                </template>
+              </div>
+            </div>
+            <hr class="separator" />
+          </div>
+        </template>
+      </div>
+      <p v-if="errorMessage" class="text-danger text-small text-end mt-3">{{ errorMessage }}</p>
+    </div>
+    <div class="col-6">
+      <div class="mt-3">
+        <template v-for="credit in props.hbarTransfers" :key="credit.accountId">
+          <div v-if="!credit.amount.isNegative()" class="mt-3">
+            <div class="row align-items-center px-3">
+              <div
+                class="col-6 col-lg-5 flex-centered justify-content-start flex-wrap overflow-hidden"
+              >
+                <template
+                  v-if="
+                    (
+                      props.linkedAccounts.find(la => la.account_id === credit.accountId.toString())
+                        ?.nickname || ''
+                    ).length > 0
+                  "
+                >
+                  <div class="d-flex align-items-baseline justify-content-start flex-wrap">
+                    <p class="text-small text-semi-bold me-2">
+                      {{
+                        props.linkedAccounts.find(
+                          la => la.account_id === credit.accountId.toString(),
+                        )?.nickname
+                      }}
+                    </p>
+                    <p
+                      class="text-secondary text-micro overflow-hidden"
+                      data-testid="p-transfer-to-account-details"
+                    >
+                      ({{ getAccountIdWithChecksum(credit.accountId.toString()) }})
+                    </p>
+                  </div>
+                </template>
+                <template v-else>
+                  <p
+                    class="text-secondary text-small overflow-hidden"
+                    data-testid="p-transfer-to-account-details"
+                  >
+                    {{ getAccountIdWithChecksum(credit.accountId.toString()) }}
+                  </p>
+                </template>
+              </div>
+              <div class="col-6 col-lg-7 text-end text-nowrap overflow-hidden">
+                <p
+                  class="text-secondary text-small text-bold overflow-hidden"
+                  data-testid="p-transfer-to-amount-details"
+                >
+                  {{ stringifyHbar(credit.amount) }}
+                </p>
+              </div>
+            </div>
+            <hr class="separator" />
+          </div>
+        </template>
+      </div>
+    </div>
+  </template>
+</template>
+
+<style scoped></style>

--- a/front-end/src/renderer/components/Transaction/Details/TransferDetails/NftSerial.vue
+++ b/front-end/src/renderer/components/Transaction/Details/TransferDetails/NftSerial.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import type { TokenId } from '@hiero-ledger/sdk';
+import { AppCache } from '@renderer/caches/AppCache';
+import useNetwork from '@renderer/stores/storeNetwork.ts';
+
+/* Props */
+const props = defineProps<{
+  serial: Long;
+  tokenId: TokenId;
+}>();
+
+/* Injected */
+const appCache = AppCache.inject();
+
+/* Stores */
+const network = useNetwork();
+
+/* State */
+const tokenSymbol = ref<string | null>(null);
+
+/* Hook */
+watch(
+  [() => props.serial, () => props.tokenId],
+  async () => {
+    try {
+      const tokenInfo = await appCache.mirrorTokenById.lookup(
+        props.tokenId.toString(),
+        network.mirrorNodeBaseURL,
+      );
+      if (tokenInfo !== null) {
+        tokenSymbol.value = tokenInfo.symbol;
+      } else {
+        tokenSymbol.value = props.tokenId.toString();
+      }
+    } catch {
+      tokenSymbol.value = props.tokenId.toString();
+    }
+  },
+  { immediate: true },
+);
+</script>
+
+<template>
+  <span
+    v-if="tokenSymbol !== null"
+    class="text-secondary text-small text-bold overflow-hidden"
+    data-testid="p-transfer-from-amount-details"
+  >
+    {{ tokenSymbol }} #{{ props.serial }}
+  </span>
+</template>
+
+<style scoped></style>

--- a/front-end/src/renderer/components/Transaction/Details/TransferDetails/NftTransferDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/TransferDetails/NftTransferDetails.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { AccountId, TokenId, TransferTransaction } from '@hiero-ledger/sdk';
+import type { HederaAccount } from '@prisma/client';
+import NftSerial from '@renderer/components/Transaction/Details/TransferDetails/NftSerial.vue';
+import { getAccountIdWithChecksum } from '@renderer/utils';
+
+/* Props */
+const props = defineProps<{
+  tokenId: TokenId;
+  transaction: TransferTransaction;
+  linkedAccounts: HederaAccount[];
+}>();
+
+/* Computed */
+const nftTransfers = computed(() => {
+  const result: {
+    sender: AccountId;
+    recipient: AccountId;
+    serial: Long;
+    key: string;
+  }[] = [];
+  const nftTransfers = props.transaction.nftTransfers.get(props.tokenId);
+  if (nftTransfers !== null) {
+    for (const t of nftTransfers) {
+      result.push({
+        sender: t.sender,
+        recipient: t.recipient,
+        serial: t.serial,
+        key: t.sender.toString() + '/' + t.recipient.toString() + '/' + t.serial,
+      });
+    }
+  }
+  return result;
+});
+
+/* Functions */
+const findNickname = (accountId: AccountId) => {
+  return props.linkedAccounts.find(la => la.account_id === accountId.toString())?.nickname ?? null;
+};
+</script>
+
+<template>
+  <div class="col-6">
+    <div class="mt-3">
+      <template v-for="t in nftTransfers" :key="t.key">
+        <div class="mt-3">
+          <div class="row align-items-center px-3">
+            <div
+              class="col-6 col-lg-5 flex-centered justify-content-start flex-wrap overflow-hidden"
+            >
+              <template v-if="findNickname(t.sender) !== null">
+                <div class="d-flex align-items-baseline justify-content-start flex-wrap">
+                  <p class="text-small text-semi-bold me-2">
+                    {{ findNickname(t.sender) }}
+                  </p>
+                  <p class="text-secondary text-micro overflow-hidden">
+                    ({{ getAccountIdWithChecksum(t.sender.toString()) }})
+                  </p>
+                </div>
+              </template>
+              <template v-else>
+                <p
+                  class="text-secondary text-small overflow-hidden"
+                  data-testid="p-transfer-from-account-details"
+                >
+                  {{ getAccountIdWithChecksum(t.sender.toString()) }}
+                </p>
+              </template>
+            </div>
+            <div class="col-6 col-lg-7 text-end text-nowrap overflow-hidden">
+              <NftSerial :serial="t.serial" :token-id="tokenId" />
+            </div>
+          </div>
+          <hr class="separator" />
+        </div>
+      </template>
+    </div>
+  </div>
+  <div class="col-6">
+    <div class="mt-3">
+      <template v-for="t in nftTransfers" :key="t.key">
+        <div class="mt-3">
+          <div class="row align-items-center px-3">
+            <div
+              class="col-6 col-lg-5 flex-centered justify-content-start flex-wrap overflow-hidden"
+            >
+              <template v-if="findNickname(t.recipient) !== null">
+                <div class="d-flex align-items-baseline justify-content-start flex-wrap">
+                  <p class="text-small text-semi-bold me-2">
+                    {{ findNickname(t.recipient) }}
+                  </p>
+                  <p
+                    class="text-secondary text-micro overflow-hidden"
+                    data-testid="p-transfer-to-account-details"
+                  >
+                    ({{ getAccountIdWithChecksum(t.recipient.toString()) }})
+                  </p>
+                </div>
+              </template>
+              <template v-else>
+                <p
+                  class="text-secondary text-small overflow-hidden"
+                  data-testid="p-transfer-to-account-details"
+                >
+                  {{ getAccountIdWithChecksum(t.recipient.toString()) }}
+                </p>
+              </template>
+            </div>
+            <div class="col-6 col-lg-7 text-end text-nowrap overflow-hidden">
+              <NftSerial :serial="t.serial" :token-id="tokenId" />
+            </div>
+          </div>
+          <hr class="separator" />
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/front-end/src/renderer/components/Transaction/Details/TransferDetails/TokenAmount.vue
+++ b/front-end/src/renderer/components/Transaction/Details/TransferDetails/TokenAmount.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import type { TokenId } from '@hiero-ledger/sdk';
+import { AppCache } from '@renderer/caches/AppCache';
+import useNetwork from '@renderer/stores/storeNetwork.ts';
+import { formatTokenAmount } from '@renderer/caches/mirrorNode/TokenByIdCache';
+
+/* Props */
+const props = defineProps<{
+  amount: Long;
+  tokenId: TokenId;
+}>();
+
+/* Injected */
+const appCache = AppCache.inject();
+
+/* Stores */
+const network = useNetwork();
+
+/* State */
+const formattedAmount = ref<string | null>(null);
+const tokenSymbol = ref<string | null>(null);
+
+/* Hook */
+watch(
+  [() => props.amount, () => props.tokenId],
+  async () => {
+    try {
+      const tokenInfo = await appCache.mirrorTokenById.lookup(
+        props.tokenId.toString(),
+        network.mirrorNodeBaseURL,
+      );
+      if (tokenInfo !== null) {
+        formattedAmount.value = formatTokenAmount(props.amount.toBigInt(), tokenInfo);
+        tokenSymbol.value = tokenInfo.symbol;
+      } else {
+        formattedAmount.value = props.amount.toString();
+        tokenSymbol.value = props.tokenId.toString();
+      }
+    } catch {
+      formattedAmount.value = props.amount.toString();
+      tokenSymbol.value = props.tokenId.toString();
+    }
+  },
+  { immediate: true },
+);
+</script>
+
+<template>
+  <span
+    v-if="formattedAmount !== null"
+    class="text-secondary text-small text-bold overflow-hidden"
+    data-testid="p-transfer-from-amount-details"
+  >
+    {{ formattedAmount }} <span v-if="tokenSymbol !== null"> {{ tokenSymbol }} </span>
+  </span>
+</template>
+
+<style scoped></style>

--- a/front-end/src/renderer/components/Transaction/Details/TransferDetails/TokenTransferDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/TransferDetails/TokenTransferDetails.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { AccountId, TokenId, TransferTransaction } from '@hiero-ledger/sdk';
+import type { HederaAccount } from '@prisma/client';
+import { getAccountIdWithChecksum } from '@renderer/utils';
+import TokenAmount from '@renderer/components/Transaction/Details/TransferDetails/TokenAmount.vue';
+
+/* Props */
+const props = defineProps<{
+  tokenId: TokenId;
+  transaction: TransferTransaction;
+  linkedAccounts: HederaAccount[];
+}>();
+
+/* Computed */
+const tokenTransfers = computed(() => {
+  const result: { accountId: AccountId; amount: Long }[] = [];
+  const map = props.transaction.tokenTransfers.get(props.tokenId);
+  if (map !== null) {
+    for (const accountId of map.keys()) {
+      result.push({ accountId: accountId, amount: map.get(accountId)! });
+    }
+  }
+  return result;
+});
+
+/* Functions */
+const findNickname = (accountId: AccountId) => {
+  return props.linkedAccounts.find(la => la.account_id === accountId.toString())?.nickname ?? null;
+};
+</script>
+
+<template>
+  <div class="col-6">
+    <div class="mt-3">
+      <template v-for="debit in tokenTransfers" :key="debit.accountId">
+        <div v-if="debit.amount.isNegative()" class="mt-3">
+          <div class="row align-items-center px-3">
+            <div
+              class="col-6 col-lg-5 flex-centered justify-content-start flex-wrap overflow-hidden"
+            >
+              <template v-if="findNickname(debit.accountId) !== null">
+                <div class="d-flex align-items-baseline justify-content-start flex-wrap">
+                  <p class="text-small text-semi-bold me-2">
+                    {{ findNickname(debit.accountId) }}
+                  </p>
+                  <p class="text-secondary text-micro overflow-hidden">
+                    ({{ getAccountIdWithChecksum(debit.accountId.toString()) }})
+                  </p>
+                </div>
+              </template>
+              <template v-else>
+                <p
+                  class="text-secondary text-small overflow-hidden"
+                  data-testid="p-transfer-from-account-details"
+                >
+                  {{ getAccountIdWithChecksum(debit.accountId.toString()) }}
+                </p>
+              </template>
+            </div>
+            <div class="col-6 col-lg-7 text-end text-nowrap overflow-hidden">
+              <TokenAmount :amount="debit.amount" :token-id="props.tokenId" />
+            </div>
+          </div>
+          <hr class="separator" />
+        </div>
+      </template>
+    </div>
+  </div>
+  <div class="col-6">
+    <div class="mt-3">
+      <template v-for="credit in tokenTransfers" :key="credit.accountId">
+        <div v-if="credit.amount.isPositive()" class="mt-3">
+          <div class="row align-items-center px-3">
+            <div
+              class="col-6 col-lg-5 flex-centered justify-content-start flex-wrap overflow-hidden"
+            >
+              <template v-if="findNickname(credit.accountId) !== null">
+                <div class="d-flex align-items-baseline justify-content-start flex-wrap">
+                  <p class="text-small text-semi-bold me-2">
+                    {{ findNickname(credit.accountId) }}
+                  </p>
+                  <p
+                    class="text-secondary text-micro overflow-hidden"
+                    data-testid="p-transfer-to-account-details"
+                  >
+                    ({{ getAccountIdWithChecksum(credit.accountId.toString()) }})
+                  </p>
+                </div>
+              </template>
+              <template v-else>
+                <p
+                  class="text-secondary text-small overflow-hidden"
+                  data-testid="p-transfer-to-account-details"
+                >
+                  {{ getAccountIdWithChecksum(credit.accountId.toString()) }}
+                </p>
+              </template>
+            </div>
+            <div class="col-6 col-lg-7 text-end text-nowrap overflow-hidden">
+              <TokenAmount :amount="credit.amount" :token-id="props.tokenId" />
+            </div>
+          </div>
+          <hr class="separator" />
+        </div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/front-end/src/shared/interfaces/ITokenInfo.ts
+++ b/front-end/src/shared/interfaces/ITokenInfo.ts
@@ -1,0 +1,83 @@
+export interface ITokenInfo {
+  admin_key: Key | null;
+  auto_renew_account: string | null; // Network entity ID in the format of shard.realm.num
+  auto_renew_period: number | null;
+  created_timestamp: string;
+  decimals: string;
+  deleted: boolean | null;
+  expiry_timestamp: string | null;
+  fee_schedule_key: Key | null;
+  freeze_default: boolean;
+  freeze_key: Key | null;
+  initial_supply: string;
+  kyc_key: Key | null;
+  max_supply: string;
+  metadata: string;
+  metadata_key: Key | null;
+  modified_timestamp: string;
+  name: string;
+  memo: string;
+  pause_key: Key | null;
+  pause_status: string; // NOT_APPLICABLE, PAUSED, UNPAUSED
+  supply_key: Key | null;
+  supply_type: string; // FINITE, INFINITE
+  symbol: string;
+  token_id: string | null; // Network entity ID in the format of shard.realm.num
+  total_supply: string;
+  treasury_account_id: string | null; // Network entity ID in the format of shard.realm.num
+  type: string; // FUNGIBLE_COMMON, NON_FUNGIBLE_UNIQUE
+  wipe_key: Key | null;
+  custom_fees: CustomFees;
+}
+
+export interface CustomFees {
+  created_timestamp: string;
+  fixed_fees: FixedFee[]; // Always present
+  fractional_fees: FractionalFee[] | undefined; // Present when FUNGIBLE
+  royalty_fees: RoyaltyFee[] | undefined; // Present when NON_FUNGIBLE
+}
+
+export interface FixedFee {
+  all_collectors_are_exempt: boolean;
+  amount: number;
+  collector_account_id: string | null; // Network entity ID in the format of shard.realm.num
+  denominating_token_id: string | null; // Network entity ID in the format of shard.realm.num
+}
+
+export interface FractionalFee {
+  all_collectors_are_exempt: boolean;
+  amount: FractionAmount;
+  collector_account_id: string | null; // Network entity ID in the format of shard.realm.num
+  denominating_token_id: string | null; // Network entity ID in the format of shard.realm.num
+  maximum: number | null;
+  minimum: number;
+  net_of_transfers: boolean;
+}
+
+export interface RoyaltyFee {
+  all_collectors_are_exempt: boolean;
+  amount: FractionAmount;
+  collector_account_id: string | null; // Network entity ID in the format of shard.realm.num
+  fallback_fee: FallbackFee; // Network entity ID in the format of shard.realm.num
+}
+
+export interface FallbackFee {
+  amount: number;
+  denominating_token_id: string | null; // Network entity ID in the format of shard.realm.num
+}
+
+export interface FractionAmount {
+  numerator: number;
+  denominator: number;
+}
+
+export interface Key {
+  _type: KeyType;
+  key: string;
+}
+
+export enum KeyType {
+  ECDSA_SECP256K1 = 'ECDSA_SECP256K1',
+  ED25519 = 'ED25519',
+  ProtobufEncoded = 'ProtobufEncoded',
+}

--- a/front-end/src/shared/interfaces/ITokenInfo.ts
+++ b/front-end/src/shared/interfaces/ITokenInfo.ts
@@ -33,8 +33,8 @@ export interface ITokenInfo {
 export interface CustomFees {
   created_timestamp: string;
   fixed_fees: FixedFee[]; // Always present
-  fractional_fees: FractionalFee[] | undefined; // Present when FUNGIBLE
-  royalty_fees: RoyaltyFee[] | undefined; // Present when NON_FUNGIBLE
+  fractional_fees?: FractionalFee[]; // Present when FUNGIBLE
+  royalty_fees?: RoyaltyFee[]; // Present when NON_FUNGIBLE
 }
 
 export interface FixedFee {

--- a/front-end/src/tests/renderer/caches/mirrorNode/TokenByIdCache.spec.ts
+++ b/front-end/src/tests/renderer/caches/mirrorNode/TokenByIdCache.spec.ts
@@ -1,0 +1,77 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import {
+  formatTokenAmount,
+  MAX_TOKEN_SUPPLY,
+  TokenByIdCache,
+} from '@renderer/caches/mirrorNode/TokenByIdCache.ts';
+import { KeyType } from '@shared/interfaces/ITokenInfo.ts';
+
+describe('TokenByIdCache', () => {
+  test('TokenByIdCache.lookup()', async () => {
+    const cache = new TokenByIdCache();
+    const mirrorNodeUrl = 'https://localhost:3001';
+
+    const mock = new MockAdapter(axios);
+
+    const tokenId = SAMPLE_TOKEN_INFO.token_id;
+    const matcher1 = mirrorNodeUrl + '/api/v1/tokens/' + tokenId;
+    mock.onGet(matcher1).reply(200, SAMPLE_TOKEN_INFO);
+
+    const tokenInfo = await cache.lookup(tokenId, mirrorNodeUrl);
+    expect(tokenInfo).toStrictEqual(SAMPLE_TOKEN_INFO);
+    expect(mock.history.length).toEqual(1);
+    expect(mock.history[0].url).toStrictEqual(matcher1);
+  });
+
+  test('formatTokenAmount', () => {
+    const rawAmount = 1550n;
+    const formattedAmount = formatTokenAmount(rawAmount, SAMPLE_TOKEN_INFO);
+    expect(formattedAmount).toEqual('15.50');
+  });
+
+  test('formatTokenAmount + overflow', () => {
+    const rawAmount = MAX_TOKEN_SUPPLY + 1n;
+    const formattedAmount = formatTokenAmount(rawAmount, SAMPLE_TOKEN_INFO);
+    expect(formattedAmount).toEqual('92,233,720,368,547,760.00');
+  });
+});
+
+const SAMPLE_TOKEN_INFO = {
+  admin_key: null,
+  auto_renew_account: '0.0.1584',
+  auto_renew_period: 7776000,
+  created_timestamp: '1708535268.723610618',
+  custom_fees: {
+    created_timestamp: '1708535268.723610618',
+    fixed_fees: [],
+    fractional_fees: [],
+  },
+  decimals: '2',
+  deleted: false,
+  expiry_timestamp: null,
+  fee_schedule_key: null,
+  freeze_default: false,
+  freeze_key: null,
+  initial_supply: '10000',
+  kyc_key: null,
+  max_supply: '0',
+  memo: 'Created by hedera-contract-album',
+  metadata: '',
+  metadata_key: null,
+  modified_timestamp: '1708535268.723610618',
+  name: 'Grenoble Le Versoud',
+  pause_key: null,
+  pause_status: 'NOT_APPLICABLE',
+  supply_key: {
+    _type: KeyType.ECDSA_SECP256K1,
+    key: '03d236ba45caea9dd8053b6b0db1953564a4d06c9fb7dbf93bec499e6362b5b45f',
+  },
+  supply_type: 'INFINITE',
+  symbol: 'LFLG',
+  token_id: '0.0.3580228',
+  total_supply: '10000',
+  treasury_account_id: '0.0.1584',
+  type: 'FUNGIBLE_COMMON',
+  wipe_key: null,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,7 +154,7 @@ importers:
     dependencies:
       '@hiero-ledger/proto':
         specifier: 'catalog:'
-        version: 2.30.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.2.0)(strip-ansi@7.1.2)
+        version: 2.30.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.3)(protobufjs@8.2.0)(strip-ansi@7.2.0)
       '@hiero-ledger/sdk':
         specifier: 'catalog:'
         version: 2.84.0(bn.js@5.2.3)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))
@@ -169,7 +169,7 @@ importers:
         version: 1.3.3
       axios:
         specifier: 'catalog:'
-        version: 1.16.0(debug@4.4.1)
+        version: 1.16.0(debug@4.4.3)
       bcrypt:
         specifier: 'catalog:'
         version: 6.0.0
@@ -471,7 +471,7 @@ importers:
         version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
       ts-loader:
         specifier: 'catalog:'
-        version: 9.5.7(typescript@5.9.3)(webpack@5.106.0)
+        version: 9.5.7(typescript@5.9.3)(webpack@5.106.2)
       ts-node:
         specifier: 'catalog:'
         version: 10.9.2(@types/node@25.5.0)(typescript@5.9.3)
@@ -688,6 +688,9 @@ importers:
       '@vue/tsconfig':
         specifier: 0.7.0
         version: 0.7.0(typescript@5.7.3)(vue@3.5.34(typescript@5.7.3))
+      axios-mock-adapter:
+        specifier: 2.1.0
+        version: 2.1.0(axios@1.16.0(debug@4.4.3))
       electron:
         specifier: 41.5.1
         version: 41.5.1
@@ -3944,6 +3947,11 @@ packages:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
+  axios-mock-adapter@2.1.0:
+    resolution: {integrity: sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==}
+    peerDependencies:
+      axios: '>= 0.17.0'
+
   axios@1.16.0:
     resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
@@ -5762,6 +5770,10 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -12784,13 +12796,11 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
-  axios@1.16.0(debug@4.4.1):
+  axios-mock-adapter@2.1.0(axios@1.16.0(debug@4.4.3)):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.1)
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
+      axios: 1.16.0(debug@4.4.3)
+      fast-deep-equal: 3.1.3
+      is-buffer: 2.0.5
 
   axios@1.16.0(debug@4.4.3):
     dependencies:
@@ -14456,10 +14466,6 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.16.0(debug@4.4.1):
-    optionalDependencies:
-      debug: 4.4.1
-
   follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -14957,6 +14963,8 @@ snapshots:
   ipaddr.js@1.9.1: {}
 
   is-arrayish@0.2.1: {}
+
+  is-buffer@2.0.5: {}
 
   is-callable@1.2.7: {}
 
@@ -17979,16 +17987,6 @@ snapshots:
       '@jest/types': 30.4.1
       babel-jest: 30.4.1(@babel/core@7.29.0)
       jest-util: 30.4.1
-
-  ts-loader@9.5.7(typescript@5.9.3)(webpack@5.106.0):
-    dependencies:
-      chalk: 4.1.2
-      enhanced-resolve: 5.21.0
-      micromatch: 4.0.8
-      semver: 7.7.4
-      source-map: 0.7.6
-      typescript: 5.9.3
-      webpack: 5.106.0
 
   ts-loader@9.5.7(typescript@5.9.3)(webpack@5.106.2):
     dependencies:


### PR DESCRIPTION
**Description**:

Changes below extend `Transfer Info` section in `Transaction Details` to  display token and NFT transfers (in addition to Hbar transfers).

For instance, screenshot below shows a `Token Transfer` transaction which includes:
- Hbar transfers from `0.0.1584` to `0.0.1299`, `0.0.1306` and `0.0.1437`
- LFLG token transfers from `0.0.1584` to `0.0.1299`, `0.0.1306` and `0.0.1437`
- transfers of `AIR #1`, `#2` and `#3` from `0.0.1584` to `0.0.1299`, `0.0.1306` and `0.0.1437`

<img width="970" height="625" alt="image" src="https://github.com/user-attachments/assets/9da29729-cfd2-4904-ac89-145793ee1667" />

Note: transactions with fungible and NFT token transfers cannot be created with transaction tool.
Transaction above has been created by patching source code for testing purpose.

**Related issue(s)**:

Fixes #2785

**Notes for reviewer**:
```
M   front-end/src/renderer/components/Transaction/Details/TransferDetails.vue
A   front-end/src/renderer/components/Transaction/Details/TransferDetails/HBarTransferDetails.vue
    # TransferDetails is now split in several subviews: hbar transfer display logic
    # moves to HbarTransferDetails view
    
A   front-end/src/renderer/components/Transaction/Details/TransferDetails/TokenTransferDetails.vue
A   front-end/src/renderer/components/Transaction/Details/TransferDetails/TokenAmount.vue
    # TokenTransferDetails view is the subview of TransferDetails in charge of displaying
    # fungible token transfers

A   front-end/src/renderer/components/Transaction/Details/TransferDetails/NftTransferDetails.vue
A   front-end/src/renderer/components/Transaction/Details/TransferDetails/NftSerial.vue
    # NftTransferDetails view is the subview of TransferDetails in charge of displaying
    # NFT transfers


M   front-end/src/renderer/caches/AppCache.ts
A   front-end/src/renderer/caches/mirrorNode/TokenByIdCache.ts
A   front-end/src/shared/interfaces/ITokenInfo.ts
    # New mirror node cache in charge of data from api/v1/tokens/{tokenId}


A   front-end/src/tests/renderer/caches/mirrorNode/TokenByIdCache.spec.ts
M   front-end/package.json
M   pnpm-lock.yaml
    # Unit tests for TokenByIdCache.
    # They use a new devDependency : axios-mock-adapter.
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
