### PR TITLE
feat: allow keys in Public Keys to be used in Account transactions

### DIFF
--- a/front-end/src/renderer/components/ComplexKey/ComplexKeyAddPublicKeyModal.vue
+++ b/front-end/src/renderer/components/ComplexKey/ComplexKeyAddPublicKeyModal.vue
@@ -20,6 +20,7 @@ const logger = createLogger('renderer.component.complexKeyAddPublicKeyModal');
 /* Enums */
 enum KeyTab {
   MY = 'My keys',
+  PUBLIC_KEY = 'My public keys',
   CONTACTS = 'My contacts',
 }
 
@@ -58,6 +59,12 @@ const myKeys = computed(() => {
     nickname: kp.nickname,
   }));
 });
+const myPublicKeys = computed(() => {
+  return user.publicKeyMappings.map(m => ({
+    publicKey: m.public_key,
+    nickname: m.nickname,
+  }));
+});
 
 const myContactListKeys = computed(() => {
   if (!isLoggedInOrganization(user.selectedOrganization)) return [];
@@ -71,6 +78,9 @@ const listedKeyList = computed(() => {
   switch (currentTab.value) {
     case KeyTab.MY:
       result = myKeys.value;
+      break;
+    case KeyTab.PUBLIC_KEY:
+      result = myPublicKeys.value;
       break;
     case KeyTab.CONTACTS:
       result = myContactListKeys.value;

--- a/front-end/src/renderer/stores/storeUser.ts
+++ b/front-end/src/renderer/stores/storeUser.ts
@@ -247,8 +247,9 @@ const useUserStore = defineStore('user', () => {
   /* Watchers */
   watch(
     () => network.network,
-    () => {
-      refetchAccounts();
+    async () => {
+      await refetchAccounts();
+      await refetchPublicKeys();
     },
   );
 


### PR DESCRIPTION
**Description**:
Changes below add an extra tab in `Key Chooser` modal which enables to select a key defined in `Settings` > `Public Keys`.

Before:
<img width="397" height="374" alt="image" src="https://github.com/user-attachments/assets/86145b77-a0e6-41ef-b303-a91ba143a591" />

After:
<img width="397" height="374" alt="image" src="https://github.com/user-attachments/assets/b77cf885-384d-4627-abf5-711be9a8e7ac" />


**Related issue(s)**:

Fixes #1578

**Notes for reviewer**:

```
M   front-end/src/renderer/components/ComplexKey/ComplexKeyAddPublicKeyModal.vue
    # Added tab 'My public keys'.
    # Keys are fetched from storeUser.publicKeyMappings.
    
M   front-end/src/renderer/stores/storeUser.ts
    # Added a call to to refetchPublicKeys() to make sure that key mappings are loaded.
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
