### PR TITLE
fix: update keysRequiredToSign to filter only when needed

### DIFF
--- a/back-end/apps/api/src/transactions/transactions.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.controller.spec.ts
@@ -301,7 +301,7 @@ describe('TransactionsController', () => {
     it('should return an array of key ids', async () => {
       const result = [1];
 
-      transactionService.userKeysToSign.mockResolvedValue(result);
+      transactionService.getUserKeysToSign.mockResolvedValue(result);
 
       expect(await controller.shouldSignTransaction(user, 1)).toBe(result);
     });

--- a/back-end/apps/api/src/transactions/transactions.controller.ts
+++ b/back-end/apps/api/src/transactions/transactions.controller.ts
@@ -192,7 +192,7 @@ export class TransactionsController {
     @Param('transactionId', ParseIntPipe) transactionId: number,
   ): Promise<number[]> {
     const transaction = await this.transactionsService.getTransactionById(transactionId);
-    return this.transactionsService.userKeysToSign(transaction, user);
+    return this.transactionsService.getUserKeysToSign(transaction, user);
   }
 
   /* Get all transactions to be approved by the user */

--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -409,7 +409,7 @@ describe('TransactionsService', () => {
       entityManager.find.mockReturnValue(Promise.resolve([{ id: 1 }]));
       transactionsRepo.find.mockResolvedValue([{ id: 1, name: 'Transaction 1' }] as Transaction[]);
 
-      jest.spyOn(service, 'userKeysToSign').mockImplementation(() => Promise.resolve([1]));
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([1]);
 
       const result = await service.getTransactionsToSign(userWithKeys, {
         page: 1,
@@ -429,8 +429,7 @@ describe('TransactionsService', () => {
         { id: 2, name: 'Transaction 2' },
       ] as Transaction[]);
 
-      jest
-        .spyOn(service, 'userKeysToSign')
+      (userKeysRequiredToSign as jest.Mock)
         .mockResolvedValueOnce([1])
         .mockRejectedValueOnce(new Error('Error'));
 
@@ -1986,7 +1985,7 @@ describe('TransactionsService', () => {
 
     it('should return true if user has keys to sign', async () => {
       const tx = { status: TransactionStatus.WAITING_FOR_SIGNATURES } as Transaction;
-      jest.spyOn(service, 'userKeysToSign').mockResolvedValueOnce([1]);
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([1]);
       await expect(service.verifyAccess(tx, user as User)).resolves.toBe(true);
     });
 
@@ -1995,7 +1994,7 @@ describe('TransactionsService', () => {
         status: TransactionStatus.WAITING_FOR_SIGNATURES,
         creatorKey: { userId: user.id },
       } as Transaction;
-      jest.spyOn(service, 'userKeysToSign').mockResolvedValueOnce([]);
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
       await expect(service.verifyAccess(tx, user as User)).resolves.toBe(true);
     });
 
@@ -2004,16 +2003,15 @@ describe('TransactionsService', () => {
         status: TransactionStatus.WAITING_FOR_SIGNATURES,
         observers: [{ userId: user.id }],
       } as Transaction;
-      jest.spyOn(service, 'userKeysToSign').mockResolvedValueOnce([]);
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
       await expect(service.verifyAccess(tx, user as User)).resolves.toBe(true);
     });
 
-    it('should return true if user is signer', async () => {
+    it('should return true if user has required keys', async () => {
       const tx = {
         status: TransactionStatus.WAITING_FOR_SIGNATURES,
-        signers: [{ userKey: { userId: user.id } }],
-      } as unknown as Transaction;
-      jest.spyOn(service, 'userKeysToSign').mockResolvedValueOnce([]);
+      } as Transaction;
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([1]);
       await expect(service.verifyAccess(tx, user as User)).resolves.toBe(true);
     });
 
@@ -2022,13 +2020,13 @@ describe('TransactionsService', () => {
         status: TransactionStatus.WAITING_FOR_SIGNATURES,
         approvers: [{ userId: user.id }],
       } as Transaction;
-      jest.spyOn(service, 'userKeysToSign').mockResolvedValueOnce([]);
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
       await expect(service.verifyAccess(tx, user as User)).resolves.toBe(true);
     });
 
     it('should return false if user has no access', async () => {
       const tx = { status: TransactionStatus.WAITING_FOR_SIGNATURES } as Transaction;
-      jest.spyOn(service, 'userKeysToSign').mockResolvedValueOnce([]);
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
       await expect(service.verifyAccess(tx, user as User)).resolves.toBe(false);
     });
   });
@@ -2515,7 +2513,7 @@ describe('TransactionsService', () => {
     it('should throw if transaction is not found', async () => {
       transactionsRepo.find.mockResolvedValue([]);
 
-      jest.spyOn(service, 'userKeysToSign').mockResolvedValueOnce([]);
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
       await expect(service.getTransactionWithVerifiedAccess(123, user as User)).rejects.toThrow(
         ErrorCodes.TNF,
       );
@@ -2535,7 +2533,7 @@ describe('TransactionsService', () => {
         observers: []
       };
 
-      jest.spyOn(service, 'userKeysToSign').mockResolvedValueOnce([]);
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
       jest.spyOn(approversService, 'getApproversByTransactionId').mockResolvedValueOnce([]);
       transactionsRepo.find.mockResolvedValue([transaction as Transaction]);
 
@@ -2544,7 +2542,7 @@ describe('TransactionsService', () => {
       );
     });
 
-    it('should return the transaction if the user is a signer', async () => {
+    it('should return the transaction if the user has required keys', async () => {
       const transaction = {
         id: 123,
         creatorKey: {
@@ -2558,15 +2556,7 @@ describe('TransactionsService', () => {
         observers: [],
       };
 
-      entityManager.find.mockResolvedValueOnce([
-        {
-          userKey: {
-            userId: user.id,
-          },
-        },
-      ]);
-
-      jest.spyOn(service, 'userKeysToSign').mockResolvedValueOnce([]);
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([1]);
       jest.spyOn(approversService, 'getApproversByTransactionId').mockResolvedValueOnce([]);
       transactionsRepo.find.mockResolvedValue([transaction as Transaction]);
 
@@ -2589,8 +2579,7 @@ describe('TransactionsService', () => {
         observers: [{ userId: user.id }],
       };
 
-      entityManager.find.mockResolvedValueOnce([]);
-      jest.spyOn(service, 'userKeysToSign').mockResolvedValueOnce([]);
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
       jest.spyOn(approversService, 'getApproversByTransactionId').mockResolvedValueOnce([]);
       transactionsRepo.find.mockResolvedValue([transaction as Transaction]);
 
@@ -2615,8 +2604,7 @@ describe('TransactionsService', () => {
 
       const approvers: TransactionApprover[] = [{ userId: user.id }] as TransactionApprover[];
 
-      entityManager.find.mockResolvedValueOnce([]);
-      jest.spyOn(service, 'userKeysToSign').mockResolvedValueOnce([]);
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
       jest.spyOn(approversService, 'getApproversByTransactionId').mockResolvedValueOnce(approvers);
       jest.spyOn(approversService, 'getTreeStructure').mockReturnValue(approvers);
       transactionsRepo.find.mockResolvedValue([transaction as Transaction]);
@@ -2640,8 +2628,7 @@ describe('TransactionsService', () => {
         observers: [],
       };
 
-      entityManager.find.mockResolvedValueOnce([]);
-      jest.spyOn(service, 'userKeysToSign').mockResolvedValueOnce([]);
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
       jest.spyOn(approversService, 'getApproversByTransactionId').mockResolvedValueOnce([]);
       jest.spyOn(approversService, 'getTreeStructure').mockReturnValue([]);
       transactionsRepo.find.mockResolvedValue([transaction as Transaction]);
@@ -2665,8 +2652,7 @@ describe('TransactionsService', () => {
         status: TransactionStatus.EXECUTED,
       };
 
-      entityManager.find.mockResolvedValueOnce([]);
-      jest.spyOn(service, 'userKeysToSign').mockResolvedValueOnce([]);
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
       jest.spyOn(approversService, 'getApproversByTransactionId').mockResolvedValueOnce([]);
       jest.spyOn(approversService, 'getTreeStructure').mockReturnValue([]);
       transactionsRepo.find.mockResolvedValue([transaction as Transaction]);
@@ -2704,26 +2690,6 @@ describe('TransactionsService', () => {
 
     it('should throw if not transaction is passed to attachTransactionSigners', async () => {
       await expect(service.attachTransactionSigners(null)).rejects.toThrow(ErrorCodes.TNF);
-    });
-  });
-
-  describe('userKeysToSign', () => {
-    beforeEach(() => {
-      jest.resetAllMocks();
-    });
-
-    it('should call user keys required with correct arguments', async () => {
-      const transaction = { id: 123 };
-
-      await service.userKeysToSign(transaction as Transaction, user as User);
-
-      expect(jest.mocked(userKeysRequiredToSign)).toHaveBeenCalledWith(
-        transaction,
-        user,
-        transactionSignatureService,
-        entityManager,
-        false,
-      );
     });
   });
 

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -257,6 +257,7 @@ export class TransactionsService {
   }
 
   /* Get the transactions that a user needs to sign */
+  /** @deprecated use transaction-nodes' getTransactionNodes instead */
   async getTransactionsToSign(
     user: User,
     { page, limit, size, offset }: Pagination,
@@ -309,7 +310,7 @@ export class TransactionsService {
     for (const transaction of transactions) {
       /* Check if the user should sign the transaction */
       try {
-        const keysToSign = await this.userKeysToSign(transaction, user);
+        const keysToSign = await this.getUserKeysToSign(transaction, user);
         if (keysToSign.length > 0) result.push({ transaction, keysToSign });
       } catch (error) {
         console.log(error);
@@ -620,7 +621,7 @@ export class TransactionsService {
     }
 
     for (const [id, { transaction, publicKeys, newBytes, isSameBytes }] of intermediate) {
-      // Without these signer rows, the signing user fails verifyAccess post-import (issue #2552).
+      // Create TransactionSigner rows for any keys found in the imported signatures (issue #2552).
       const newSignersForDto: { userId: number; transactionId: number; userKeyId: number }[] = [];
       if (publicKeys.length > 0) {
         let txExistingSigners = signersByTransaction.get(id);
@@ -672,7 +673,7 @@ export class TransactionsService {
     let dismissedRows: Array<{ id: number; userId: number }> = [];
     let committed = false;
 
-    // Bytes + signer rows + dismissals must commit together; partial state recreates issue #2552.
+    // Bytes + signer rows + dismissals must commit together atomically.
     if (updateArray.length > 0 || newSignerRows.length > 0) {
       try {
         await this.dataSource.transaction(async manager => {
@@ -974,13 +975,12 @@ export class TransactionsService {
     )
       return true;
 
-    const userKeysToSign = await this.userKeysToSign(transaction, user, true);
+    const requiredKeyIds = await this.getUserKeysToSign(transaction, user, true);
 
     return (
-      userKeysToSign.length !== 0 ||
+      requiredKeyIds.length !== 0 ||
       transaction.creatorKey?.userId === user.id ||
       !!transaction.observers?.some(o => o.userId === user.id) ||
-      !!transaction.signers?.some(s => s.userKey?.userId === user.id) ||
       !!transaction.approvers?.some(a => a.userId === user.id)
     );
   }
@@ -1049,7 +1049,7 @@ export class TransactionsService {
   }
 
   /* Get the user keys that are required for a given transaction */
-  async userKeysToSign(transaction: Transaction, user: User, showAll: boolean = false) {
+  async getUserKeysToSign(transaction: Transaction, user: User, showAll: boolean = false): Promise<number[]> {
     return userKeysRequiredToSign(transaction, user, this.transactionSignatureService, this.entityManager, showAll);
   }
 

--- a/back-end/apps/notifications/src/receiver/receiver.service.spec.ts
+++ b/back-end/apps/notifications/src/receiver/receiver.service.spec.ts
@@ -1381,10 +1381,7 @@ describe('ReceiverService', () => {
         expect.anything(),
         expect.anything(),
         expect.anything(),
-        false,
-        null,
-        expect.any(Map),
-        true,
+        { cache: expect.any(Map), excludeAlreadySigned: true },
       );
     });
 
@@ -1443,10 +1440,7 @@ describe('ReceiverService', () => {
         expect.anything(),
         expect.anything(),
         expect.anything(),
-        false,
-        null,
-        expect.any(Map),
-        true,
+        { cache: expect.any(Map), excludeAlreadySigned: true },
       );
 
       collectSpy.mockRestore();
@@ -1478,10 +1472,7 @@ describe('ReceiverService', () => {
         expect.anything(),
         expect.anything(),
         expect.anything(),
-        false,
-        null,
-        expect.any(Map),
-        true,
+        { cache: expect.any(Map), excludeAlreadySigned: true },
       );
       expect(reminderSpy).not.toHaveBeenCalled();
       expect(notifyTypeSpy).not.toHaveBeenCalled();

--- a/back-end/apps/notifications/src/receiver/receiver.service.spec.ts
+++ b/back-end/apps/notifications/src/receiver/receiver.service.spec.ts
@@ -1377,6 +1377,15 @@ describe('ReceiverService', () => {
 
       expect((service as any).processReminderEmail).toHaveBeenCalled();
       expect((service as any).processNotificationType).toHaveBeenCalled();
+      expect(keysRequiredToSign).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        false,
+        null,
+        expect.any(Map),
+        true,
+      );
     });
 
     it('processSignerReminders manual path processes updated receivers from processNotificationType', async () => {
@@ -1430,6 +1439,15 @@ describe('ReceiverService', () => {
         expect.any(Object), // inAppNotifications
         expect.any(Array), // inAppReceiverIds
       );
+      expect(keysRequiredToSign).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        false,
+        null,
+        expect.any(Map),
+        true,
+      );
 
       collectSpy.mockRestore();
     });
@@ -1456,7 +1474,15 @@ describe('ReceiverService', () => {
       await (service as any).processSignerReminders([{ entityId: 8 } as any], false);
 
       expect(prepSpy).toHaveBeenCalled();
-      expect(keysRequiredToSign).toHaveBeenCalled();
+      expect(keysRequiredToSign).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        false,
+        null,
+        expect.any(Map),
+        true,
+      );
       expect(reminderSpy).not.toHaveBeenCalled();
       expect(notifyTypeSpy).not.toHaveBeenCalled();
 

--- a/back-end/apps/notifications/src/receiver/receiver.service.ts
+++ b/back-end/apps/notifications/src/receiver/receiver.service.ts
@@ -1140,6 +1140,7 @@ export class ReceiverService {
         false,
         null,
         keyCache,
+        true,
       );
 
       // Filter out keys/users that have been soft-deleted to prevent notification failures

--- a/back-end/apps/notifications/src/receiver/receiver.service.ts
+++ b/back-end/apps/notifications/src/receiver/receiver.service.ts
@@ -187,9 +187,7 @@ export class ReceiverService {
       transaction,
       this.transactionSignatureService,
       entityManager,
-      false,
-      null,
-      keyCache,
+      { cache: keyCache },
     );
 
     // Filter out keys/users that have been soft-deleted to prevent notification failures
@@ -1137,10 +1135,7 @@ export class ReceiverService {
         transaction,
         this.transactionSignatureService,
         this.entityManager,
-        false,
-        null,
-        keyCache,
-        true,
+        { cache: keyCache, excludeAlreadySigned: true },
       );
 
       // Filter out keys/users that have been soft-deleted to prevent notification failures

--- a/back-end/libs/common/src/utils/transaction/index.integration.spec.ts
+++ b/back-end/libs/common/src/utils/transaction/index.integration.spec.ts
@@ -16,7 +16,7 @@ import { keysRequiredToSign, userKeysRequiredToSign } from '.';
  * Integration tests for keysRequiredToSign and userKeysRequiredToSign.
  *
  * These tests use a real Postgres container to verify the DB lookup path and
- * soft-delete filtering. TransactionSignatureService.computeSignatureKey is
+ * signed-bytes filtering. TransactionSignatureService.computeSignatureKey is
  * stubbed to return a controlled KeyList so we are not dependent on mirror-node
  * cache infrastructure.
  *
@@ -24,8 +24,10 @@ import { keysRequiredToSign, userKeysRequiredToSign } from '.';
  *  - All required key owners are returned regardless of signing state (default)
  *  - excludeAlreadySigned=true filters out keys whose signatures are present in
  *    the transaction bytes
- *  - Soft-deleted UserKeys are not returned
- *  - Soft-deleted Users are not returned
+ *  - Soft-deleted UserKeys are excluded by TypeORM's default soft-delete behaviour
+ *  - Soft-deleted Users: keysRequiredToSign does NOT filter these — the user
+ *    relation is loaded but active-user filtering is the caller's responsibility
+ *    (e.g. getUsersIdsRequiredToSign via filterActiveUserKeys)
  *  - Cache path correctly resolves keys and avoids extra DB hits
  */
 describe('keysRequiredToSign - Integration', () => {
@@ -133,7 +135,7 @@ describe('keysRequiredToSign - Integration', () => {
     const signedTx = await makeFrozenTx().sign(alicePk);
     const tx = makeTransaction(signedTx.toBytes());
 
-    const result = await keysRequiredToSign(tx, svc, em, false, null, undefined, true);
+    const result = await keysRequiredToSign(tx, svc, em, { excludeAlreadySigned: true });
 
     const userIds = result.map(k => k.userId);
     expect(userIds).not.toContain(alice.id);
@@ -148,7 +150,7 @@ describe('keysRequiredToSign - Integration', () => {
     const signedTx = await (await baseTx.sign(alicePk)).sign(bobPk);
     const tx = makeTransaction(signedTx.toBytes());
 
-    const result = await keysRequiredToSign(tx, svc, em, false, null, undefined, true);
+    const result = await keysRequiredToSign(tx, svc, em, { excludeAlreadySigned: true });
 
     expect(result).toEqual([]);
   });
@@ -195,12 +197,12 @@ describe('keysRequiredToSign - Integration', () => {
     const findSpy = jest.spyOn(em, 'find');
 
     // First call populates cache
-    await keysRequiredToSign(tx, svc, em, false, null, cache);
+    await keysRequiredToSign(tx, svc, em, { cache });
     const callsAfterFirst = findSpy.mock.calls.length;
 
     // Second call should hit cache entirely
     svc.computeSignatureKey = jest.fn().mockResolvedValue(keyList);
-    await keysRequiredToSign(tx, svc, em, false, null, cache);
+    await keysRequiredToSign(tx, svc, em, { cache });
 
     expect(findSpy.mock.calls.length).toBe(callsAfterFirst); // no new DB calls
 

--- a/back-end/libs/common/src/utils/transaction/index.integration.spec.ts
+++ b/back-end/libs/common/src/utils/transaction/index.integration.spec.ts
@@ -1,0 +1,326 @@
+import { DataSource, EntityManager } from 'typeorm';
+import {
+  AccountCreateTransaction,
+  AccountId,
+  KeyList,
+  PrivateKey,
+  TransactionId,
+} from '@hiero-ledger/sdk';
+
+import { User, UserKey, UserStatus } from '@entities';
+import { createTestPostgresDataSource } from '../../../../../test-utils/postgres-test-db';
+import { TransactionSignatureService } from '@app/common';
+import { keysRequiredToSign, userKeysRequiredToSign } from '.';
+
+/**
+ * Integration tests for keysRequiredToSign and userKeysRequiredToSign.
+ *
+ * These tests use a real Postgres container to verify the DB lookup path and
+ * soft-delete filtering. TransactionSignatureService.computeSignatureKey is
+ * stubbed to return a controlled KeyList so we are not dependent on mirror-node
+ * cache infrastructure.
+ *
+ * Key scenarios under test:
+ *  - All required key owners are returned regardless of signing state (default)
+ *  - excludeAlreadySigned=true filters out keys whose signatures are present in
+ *    the transaction bytes
+ *  - Soft-deleted UserKeys are not returned
+ *  - Soft-deleted Users are not returned
+ *  - Cache path correctly resolves keys and avoids extra DB hits
+ */
+describe('keysRequiredToSign - Integration', () => {
+  let dataSource: DataSource;
+  let cleanup: () => Promise<void>;
+  let em: EntityManager;
+
+  let alice: User;
+  let bob: User;
+  let aliceKey: UserKey;
+  let bobKey: UserKey;
+  let alicePk: PrivateKey;
+  let bobPk: PrivateKey;
+
+  const stubSignatureService = (keyList: KeyList) =>
+    ({ computeSignatureKey: jest.fn().mockResolvedValue(keyList) } as unknown as TransactionSignatureService);
+
+  const makeTransaction = (bytes: Uint8Array) => ({
+    id: 1,
+    transactionBytes: bytes,
+    mirrorNetwork: 'testnet',
+  } as any);
+
+  const makeFrozenTx = () =>
+    new AccountCreateTransaction()
+      .setTransactionId(TransactionId.generate('0.0.2'))
+      .setNodeAccountIds([AccountId.fromString('0.0.3')])
+      .freeze();
+
+  beforeAll(async () => {
+    const testDb = await createTestPostgresDataSource();
+    dataSource = testDb.dataSource;
+    cleanup = testDb.cleanup;
+    em = dataSource.manager;
+  }, 120_000);
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    // Clean up in FK-safe order
+    await em.getRepository(UserKey).createQueryBuilder().delete().execute();
+    await em.getRepository(User).createQueryBuilder().delete().execute();
+
+    // Generate key pairs
+    alicePk = PrivateKey.generateED25519();
+    bobPk = PrivateKey.generateED25519();
+
+    // Seed users
+    alice = await em.getRepository(User).save({
+      email: 'alice@test.com',
+      password: 'hashed',
+      status: UserStatus.NONE,
+      admin: false,
+    });
+    bob = await em.getRepository(User).save({
+      email: 'bob@test.com',
+      password: 'hashed',
+      status: UserStatus.NONE,
+      admin: false,
+    });
+
+    // Seed keys
+    aliceKey = await em.getRepository(UserKey).save({
+      userId: alice.id,
+      publicKey: alicePk.publicKey.toStringRaw(),
+    });
+    bobKey = await em.getRepository(UserKey).save({
+      userId: bob.id,
+      publicKey: bobPk.publicKey.toStringRaw(),
+    });
+  });
+
+  it('returns all required key owners when neither has signed (default)', async () => {
+    const keyList = new KeyList([alicePk.publicKey, bobPk.publicKey]);
+    const svc = stubSignatureService(keyList);
+    const tx = makeTransaction(makeFrozenTx().toBytes());
+
+    const result = await keysRequiredToSign(tx, svc, em);
+
+    const userIds = result.map(k => k.userId).sort();
+    expect(userIds).toEqual([alice.id, bob.id].sort());
+  });
+
+  it('returns all required key owners even when one has already signed (default, excludeAlreadySigned=false)', async () => {
+    const keyList = new KeyList([alicePk.publicKey, bobPk.publicKey]);
+    const svc = stubSignatureService(keyList);
+
+    // Alice signs the transaction
+    const signedTx = await makeFrozenTx().sign(alicePk);
+    const tx = makeTransaction(signedTx.toBytes());
+
+    const result = await keysRequiredToSign(tx, svc, em);
+
+    const userIds = result.map(k => k.userId).sort();
+    expect(userIds).toEqual([alice.id, bob.id].sort());
+  });
+
+  it('excludes already-signed keys when excludeAlreadySigned=true', async () => {
+    const keyList = new KeyList([alicePk.publicKey, bobPk.publicKey]);
+    const svc = stubSignatureService(keyList);
+
+    // Alice signs the transaction
+    const signedTx = await makeFrozenTx().sign(alicePk);
+    const tx = makeTransaction(signedTx.toBytes());
+
+    const result = await keysRequiredToSign(tx, svc, em, false, null, undefined, true);
+
+    const userIds = result.map(k => k.userId);
+    expect(userIds).not.toContain(alice.id);
+    expect(userIds).toContain(bob.id);
+  });
+
+  it('returns empty array when all required keys have signed and excludeAlreadySigned=true', async () => {
+    const keyList = new KeyList([alicePk.publicKey, bobPk.publicKey]);
+    const svc = stubSignatureService(keyList);
+
+    const baseTx = makeFrozenTx();
+    const signedTx = await (await baseTx.sign(alicePk)).sign(bobPk);
+    const tx = makeTransaction(signedTx.toBytes());
+
+    const result = await keysRequiredToSign(tx, svc, em, false, null, undefined, true);
+
+    expect(result).toEqual([]);
+  });
+
+  it('does not return soft-deleted UserKeys', async () => {
+    // Soft-delete alice's key
+    await em.getRepository(UserKey).softDelete(aliceKey.id);
+
+    const keyList = new KeyList([alicePk.publicKey, bobPk.publicKey]);
+    const svc = stubSignatureService(keyList);
+    const tx = makeTransaction(makeFrozenTx().toBytes());
+
+    const result = await keysRequiredToSign(tx, svc, em);
+
+    const userIds = result.map(k => k.userId);
+    expect(userIds).not.toContain(alice.id);
+    expect(userIds).toContain(bob.id);
+  });
+
+  it('returns key with user relation loaded, including for soft-deleted users (caller filters)', async () => {
+    await em.getRepository(User).softDelete(bob.id);
+
+    const keyList = new KeyList([alicePk.publicKey, bobPk.publicKey]);
+    const svc = stubSignatureService(keyList);
+    const tx = makeTransaction(makeFrozenTx().toBytes());
+
+    const result = await keysRequiredToSign(tx, svc, em);
+
+    // keysRequiredToSign does not filter by user.deletedAt — that is the
+    // responsibility of callers (e.g. getUsersIdsRequiredToSign via filterActiveUserKeys).
+    // Both keys are returned; the soft-deleted user's deletedAt is visible on the relation.
+    const returnedKeyIds = result.map(k => k.id).sort();
+    expect(returnedKeyIds).toEqual([aliceKey.id, bobKey.id].sort());
+    const bobResult = result.find(k => k.id === bobKey.id);
+    expect(bobResult?.user?.deletedAt).not.toBeNull();
+  });
+
+  it('resolves keys via cache on second call without extra DB hits', async () => {
+    const keyList = new KeyList([alicePk.publicKey, bobPk.publicKey]);
+    const svc = stubSignatureService(keyList);
+    const tx = makeTransaction(makeFrozenTx().toBytes());
+    const cache = new Map<string, UserKey>();
+
+    const findSpy = jest.spyOn(em, 'find');
+
+    // First call populates cache
+    await keysRequiredToSign(tx, svc, em, false, null, cache);
+    const callsAfterFirst = findSpy.mock.calls.length;
+
+    // Second call should hit cache entirely
+    svc.computeSignatureKey = jest.fn().mockResolvedValue(keyList);
+    await keysRequiredToSign(tx, svc, em, false, null, cache);
+
+    expect(findSpy.mock.calls.length).toBe(callsAfterFirst); // no new DB calls
+
+    findSpy.mockRestore();
+  });
+});
+
+describe('userKeysRequiredToSign - Integration', () => {
+  let dataSource: DataSource;
+  let cleanup: () => Promise<void>;
+  let em: EntityManager;
+
+  let alice: User;
+  let alicePk: PrivateKey;
+  let aliceKey: UserKey;
+  let aliceKey2: UserKey;
+  let alicePk2: PrivateKey;
+
+  const stubSignatureService = (keyList: KeyList) =>
+    ({ computeSignatureKey: jest.fn().mockResolvedValue(keyList) } as unknown as TransactionSignatureService);
+
+  const makeFrozenTx = () =>
+    new AccountCreateTransaction()
+      .setTransactionId(TransactionId.generate('0.0.2'))
+      .setNodeAccountIds([AccountId.fromString('0.0.3')])
+      .freeze();
+
+  beforeAll(async () => {
+    const testDb = await createTestPostgresDataSource();
+    dataSource = testDb.dataSource;
+    cleanup = testDb.cleanup;
+    em = dataSource.manager;
+  }, 120_000);
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  beforeEach(async () => {
+    await em.getRepository(UserKey).createQueryBuilder().delete().execute();
+    await em.getRepository(User).createQueryBuilder().delete().execute();
+
+    alicePk = PrivateKey.generateED25519();
+    alicePk2 = PrivateKey.generateED25519();
+
+    alice = await em.getRepository(User).save({
+      email: 'alice@test.com',
+      password: 'hashed',
+      status: UserStatus.NONE,
+      admin: false,
+    });
+
+    aliceKey = await em.getRepository(UserKey).save({
+      userId: alice.id,
+      publicKey: alicePk.publicKey.toStringRaw(),
+    });
+    aliceKey2 = await em.getRepository(UserKey).save({
+      userId: alice.id,
+      publicKey: alicePk2.publicKey.toStringRaw(),
+    });
+  });
+
+  it('returns IDs of all required user keys regardless of signing state', async () => {
+    const keyList = new KeyList([alicePk.publicKey, alicePk2.publicKey]);
+    const svc = stubSignatureService(keyList);
+
+    // alice has already signed with key1
+    const signedTx = await makeFrozenTx().sign(alicePk);
+    const user = { ...alice, keys: [aliceKey, aliceKey2] };
+
+    const result = await userKeysRequiredToSign(
+      { id: 1, transactionBytes: signedTx.toBytes(), mirrorNetwork: 'testnet' } as any,
+      user as any,
+      svc,
+      em,
+    );
+
+    // Both keys returned — signed state does not filter by default
+    expect(result).toContain(aliceKey.id);
+    expect(result).toContain(aliceKey2.id);
+  });
+
+  it('returns empty array when user has no keys matching required set', async () => {
+    const otherPk = PrivateKey.generateED25519();
+    const keyList = new KeyList([otherPk.publicKey]); // neither of alice's keys
+    const svc = stubSignatureService(keyList);
+
+    const user = { ...alice, keys: [aliceKey, aliceKey2] };
+
+    const result = await userKeysRequiredToSign(
+      { id: 1, transactionBytes: makeFrozenTx().toBytes(), mirrorNetwork: 'testnet' } as any,
+      user as any,
+      svc,
+      em,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('excludes soft-deleted keys from user.keys match', async () => {
+    await em.getRepository(UserKey).softDelete(aliceKey.id);
+    const deletedKey = await em.getRepository(UserKey).findOne({
+      where: { id: aliceKey.id },
+      withDeleted: true,
+    });
+
+    const keyList = new KeyList([alicePk.publicKey, alicePk2.publicKey]);
+    const svc = stubSignatureService(keyList);
+
+    // Simulate what attachKeys would populate — active keys only
+    const user = { ...alice, keys: [aliceKey2] };
+
+    const result = await userKeysRequiredToSign(
+      { id: 1, transactionBytes: makeFrozenTx().toBytes(), mirrorNetwork: 'testnet' } as any,
+      user as any,
+      svc,
+      em,
+    );
+
+    expect(result).not.toContain(deletedKey.id);
+    expect(result).toContain(aliceKey2.id);
+  });
+});

--- a/back-end/libs/common/src/utils/transaction/index.spec.ts
+++ b/back-end/libs/common/src/utils/transaction/index.spec.ts
@@ -59,7 +59,7 @@ describe('keysRequiredToSign', () => {
     transactionSignatureService.computeSignatureKey.mockResolvedValueOnce(keyList);
     jest.mocked(flattenKeyList).mockReturnValueOnce([pk.publicKey]);
 
-    const result = await keysRequiredToSign(transaction, transactionSignatureService, entityManager, false, null, undefined, true);
+    const result = await keysRequiredToSign(transaction, transactionSignatureService, entityManager, { excludeAlreadySigned: true });
     expect(result).toEqual([]);
   });
 });

--- a/back-end/libs/common/src/utils/transaction/index.spec.ts
+++ b/back-end/libs/common/src/utils/transaction/index.spec.ts
@@ -59,7 +59,7 @@ describe('keysRequiredToSign', () => {
     transactionSignatureService.computeSignatureKey.mockResolvedValueOnce(keyList);
     jest.mocked(flattenKeyList).mockReturnValueOnce([pk.publicKey]);
 
-    const result = await keysRequiredToSign(transaction, transactionSignatureService, entityManager);
+    const result = await keysRequiredToSign(transaction, transactionSignatureService, entityManager, false, null, undefined, true);
     expect(result).toEqual([]);
   });
 });

--- a/back-end/libs/common/src/utils/transaction/index.ts
+++ b/back-end/libs/common/src/utils/transaction/index.ts
@@ -17,6 +17,9 @@ import {
   TransactionStatus,
 } from '@entities';
 
+/* Returns all UserKeys structurally required to sign the transaction, regardless of whether
+   they have already signed. Pass excludeAlreadySigned=true only when you need the remaining
+   unsigned keys (e.g. signer reminders). */
 export const keysRequiredToSign = async (
   transaction: Transaction,
   transactionSignatureService: TransactionSignatureService,
@@ -24,25 +27,23 @@ export const keysRequiredToSign = async (
   showAll: boolean = false,
   userKeys?: UserKey[],
   cache?: Map<string, UserKey>,
+  excludeAlreadySigned: boolean = false,
 ): Promise<UserKey[]> => {
   if (!transaction) return [];
 
-  /* Deserialize the transaction */
-  const sdkTransaction = SDKTransaction.fromBytes(transaction.transactionBytes);
-
-  // list of just public keys that have already signed the transaction
-  const signerKeys = sdkTransaction._signerPublicKeys;
-
   const signature = await transactionSignatureService.computeSignatureKey(transaction, showAll);
-  // flatten the key list to an array of public keys
-  // and filter out any keys that have already signed the transaction
-  const flatPublicKeys = flattenKeyList(signature)
-    .map(pk => pk.toStringRaw())
-    .filter(pk => !signerKeys.has(pk));
+  let flatPublicKeys = flattenKeyList(signature).map(pk => pk.toStringRaw());
+
+  if (excludeAlreadySigned) {
+    /* Deserialize the transaction */
+    const sdkTransaction = SDKTransaction.fromBytes(transaction.transactionBytes);
+    const signerKeys = sdkTransaction._signerPublicKeys;
+    flatPublicKeys = flatPublicKeys.filter(pk => !signerKeys.has(pk));
+  }
 
   if (flatPublicKeys.length === 0) return [];
 
-  let results: UserKey[] = [];
+  let results: UserKey[];
   // Now if userKeys is provided, filter out any keys that are not in the flatPublicKeys array
   // this way a user requesting required keys will only see their own keys that are required
   // Otherwise, fetch all UserKeys that are in flatPublicKeys
@@ -93,6 +94,8 @@ export const keysRequiredToSign = async (
   return results;
 };
 
+/* Returns the IDs of the given user's keys that are structurally required to sign the
+   transaction, regardless of whether they have already signed. */
 export const userKeysRequiredToSign = async (
   transaction: Transaction,
   user: User,

--- a/back-end/libs/common/src/utils/transaction/index.ts
+++ b/back-end/libs/common/src/utils/transaction/index.ts
@@ -17,18 +17,25 @@ import {
   TransactionStatus,
 } from '@entities';
 
+type KeysRequiredToSignOptions = {
+  showAll?: boolean;
+  userKeys?: UserKey[];
+  cache?: Map<string, UserKey>;
+  /** When true, keys whose signatures are already present in the transaction bytes are excluded.
+   *  Defaults to false — all structurally required keys are returned regardless of signing state. */
+  excludeAlreadySigned?: boolean;
+};
+
 /* Returns all UserKeys structurally required to sign the transaction, regardless of whether
-   they have already signed. Pass excludeAlreadySigned=true only when you need the remaining
+   they have already signed. Pass excludeAlreadySigned: true only when you need the remaining
    unsigned keys (e.g. signer reminders). */
 export const keysRequiredToSign = async (
   transaction: Transaction,
   transactionSignatureService: TransactionSignatureService,
   entityManager: EntityManager,
-  showAll: boolean = false,
-  userKeys?: UserKey[],
-  cache?: Map<string, UserKey>,
-  excludeAlreadySigned: boolean = false,
+  options: KeysRequiredToSignOptions = {},
 ): Promise<UserKey[]> => {
+  const { showAll = false, userKeys, cache, excludeAlreadySigned = false } = options;
   if (!transaction) return [];
 
   const signature = await transactionSignatureService.computeSignatureKey(transaction, showAll);
@@ -110,8 +117,7 @@ export const userKeysRequiredToSign = async (
     transaction,
     transactionSignatureService,
     entityManager,
-    showAll,
-    user.keys
+    { showAll, userKeys: user.keys },
   );
 
   return userKeysRequiredToSign.map(k => k.id);


### PR DESCRIPTION
**Description**:
Determining the required keys was always filtering out keys that had already signed the transaction. This calculation should only filter out these keys in certain situations, not all. Now, filtering is optional.

**Related issue(s)**:

Fixes #2863
