### PR TITLE
feat: HIP 1137 support associated registered nodes

### DIFF
--- a/front-end/src/renderer/components/Transaction/Create/Node/RegisteredNodeIdInput.vue
+++ b/front-end/src/renderer/components/Transaction/Create/Node/RegisteredNodeIdInput.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import ChipMultiInput from '@renderer/components/ui/ChipMultiInput.vue';
+import { registeredNodeIdStrategy } from '@renderer/components/Transaction/Create/Node/registeredNodeIdStrategy';
+
+defineProps<{
+  modelValue: string[];
+}>();
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', ids: string[]): void;
+}>();
+</script>
+
+<template>
+  <ChipMultiInput
+    :model-value="modelValue"
+    :strategy="registeredNodeIdStrategy"
+    :max-ids="20"
+    label="Associated Registered Nodes"
+    placeholder="Comma-separated values or ranges (e.g. 1, 5, 10-15). Max 20."
+    @update:model-value="emit('update:modelValue', $event)"
+  />
+</template>

--- a/front-end/src/renderer/components/Transaction/Create/Node/registeredNodeIdStrategy.ts
+++ b/front-end/src/renderer/components/Transaction/Create/Node/registeredNodeIdStrategy.ts
@@ -1,0 +1,162 @@
+import type { ChipMultiInputStrategy } from '@renderer/components/ui/ChipMultiInput.vue';
+
+// HIP-1137 caps `associated_registered_node` at 20 entries, which is also the
+// `maxIds` we pass to ChipMultiInput. A single range can therefore never
+// usefully contribute more than 20 entries — anything larger would fail the
+// downstream cap anyway. Bound it here too, so a typo like `0-9999999999`
+// errors immediately instead of trying to expand into a giant Set first.
+const MAX_RANGE_LENGTH = 20n;
+
+// Total unique IDs we'll let `parse` accumulate before short-circuiting.
+// Matches HIP-1137's 20-entry list cap (and the `maxIds` ChipMultiInput uses
+// downstream) — anything past 20 will be rejected anyway, so we short-circuit
+// here to bound the work of a paste like "1, 2, 3, ..." with thousands of
+// tokens instead of churning through them all first.
+const MAX_TOTAL_IDS = 20;
+
+// Registered node IDs are non-negative integers (uint64). The input accepts
+// a CSV of values and `start-end` ranges, e.g. `1, 5, 10-15`. The sanitize /
+// parse / format hooks below all assume this grammar.
+export const registeredNodeIdStrategy: ChipMultiInputStrategy<string> = {
+  // Live filter as the user types or pastes. Only digits, commas, hyphens,
+  // and whitespace are valid tokens in the CSV grammar; anything else (letters,
+  // dots, slashes, etc.) can't lead to a legal parse, so we drop it on input
+  // instead of waiting for commit to reject it. Runs of `,,` or `--` are
+  // collapsed (whitespace-tolerant) since they're never meaningful and would
+  // otherwise produce empty parts / malformed ranges at commit time.
+  // Whitespace is also normalized: runs of tabs/spaces collapse to a single
+  // space, and a leading space is stripped — the user can't start the input
+  // with whitespace, and can't accidentally type multiple spaces in a row.
+  sanitize(raw) {
+    let cleaned = raw.replace(/[^0-9,\- \t]/g, '');
+    cleaned = cleaned.replace(/,(\s*,)+/g, ',');
+    cleaned = cleaned.replace(/-(\s*-)+/g, '-');
+    cleaned = cleaned.replace(/[\t ]+/g, ' ').replace(/^ /, '');
+    return cleaned;
+  },
+
+  // Split on `,`, then for each token expand `a-b` into the inclusive integer
+  // range (rejecting `a > b` and negatives). Duplicates across tokens / ranges
+  // are deduped via the Set. Returns sorted ascending so the chips render in a
+  // predictable order regardless of the order the user typed.
+  //
+  // Internals use BigInt rather than Number so values above
+  // `Number.MAX_SAFE_INTEGER` (2^53−1) don't silently lose precision — proto
+  // `uint64` legally goes up to 2^64−1. `BigInt(...)` throws on non-integer or
+  // non-numeric strings, which gives us validation for free (no separate
+  // `isInteger`/`isNaN` checks needed). The public `ids` output is still
+  // `string[]` so callers don't have to deal with BigInt themselves.
+  parse(raw) {
+    const parts = raw
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean);
+
+    const seen = new Set<bigint>();
+    for (const part of parts) {
+      if (part.includes('-')) {
+        // A valid range is exactly two non-empty bounds separated by one
+        // hyphen. Without this check, `"1-2-3"` would silently destructure
+        // to `[a="1", b="2"]` and drop the `3`, and `"-5"` / `"5-"` would
+        // silently coerce the empty bound to `0n` (since `BigInt("") === 0n`).
+        const segments = part.split('-').map(s => s.trim());
+        if (segments.length !== 2 || segments[0] === '' || segments[1] === '') {
+          return { error: `Invalid range: "${part}"` };
+        }
+        const [a, b] = segments;
+        let start: bigint;
+        let end: bigint;
+        try {
+          start = BigInt(a);
+          end = BigInt(b);
+        } catch {
+          return { error: `Invalid range: "${part}"` };
+        }
+        if (start < 0n || end < 0n || start > end) {
+          return { error: `Invalid range: "${part}"` };
+        }
+        // Inclusive length: `end - start + 1` is the entry count.
+        if (end - start + 1n > MAX_RANGE_LENGTH) {
+          return { error: `Range too large: "${part}" (max ${MAX_RANGE_LENGTH} per range)` };
+        }
+        for (let i = start; i <= end; i++) {
+          seen.add(i);
+          if (seen.size > MAX_TOTAL_IDS) {
+            return { error: `Too many IDs (max ${MAX_TOTAL_IDS})` };
+          }
+        }
+      } else {
+        let n: bigint;
+        try {
+          n = BigInt(part);
+        } catch {
+          return { error: `Invalid value: "${part}"` };
+        }
+        if (n < 0n) {
+          return { error: `Invalid value: "${part}"` };
+        }
+        seen.add(n);
+        if (seen.size > MAX_TOTAL_IDS) {
+          return { error: `Too many IDs (max ${MAX_TOTAL_IDS})` };
+        }
+      }
+    }
+
+    return {
+      ids: [...seen].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)).map(String),
+    };
+  },
+
+  // Render the current id set back into the text-input grammar, collapsing
+  // runs of consecutive integers into `a-b`. This is what gets written back
+  // into the input on commit and after a chip is removed, so the displayed
+  // text always round-trips with `parse` and stays compact (e.g. removing 7
+  // from "5-10" yields "5-6, 8-10" instead of six separate numbers). Uses
+  // BigInt internally for the same precision reasons as `parse`.
+  //
+  // `format` is also called from the parent-update watcher with whatever the
+  // parent passes in `modelValue` (draft load, API response, etc.), so it
+  // can't assume every entry is well-formed or unique. Invalid entries
+  // (non-integer strings or negatives) are silently skipped — better to
+  // render the valid subset than crash the renderer on a single bad value.
+  // Duplicates are dedup'd via the Set (BigInt has value semantics, so
+  // `5n === 5n` and the Set collapses them) — without this, `['1','1','2']`
+  // would render as `"1, 1-2"` because the run-collapsing loop would emit
+  // the lone `1` and then start a fresh `1-2` run.
+  format(ids) {
+    if (!ids.length) return '';
+    const seen = new Set<bigint>();
+    for (const id of ids) {
+      try {
+        const n = BigInt(id);
+        if (n >= 0n) seen.add(n);
+      } catch {
+        // skip invalid entry
+      }
+    }
+    if (!seen.size) return '';
+    const sorted = [...seen].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    const ranges: string[] = [];
+    let start = sorted[0];
+    let end = sorted[0];
+    // Walk the sorted list extending the current run; when the next value
+    // breaks the run, flush the pending [start..end] to `ranges` and reset.
+    // After the loop, one final range is always pending (the run that was
+    // still being extended when we ran out of input) — push it explicitly
+    // rather than relying on an off-by-one iteration to flush it.
+    for (let i = 1; i < sorted.length; i++) {
+      if (sorted[i] === end + 1n) {
+        end = sorted[i];
+      } else {
+        ranges.push(start === end ? `${start}` : `${start}-${end}`);
+        start = end = sorted[i];
+      }
+    }
+    ranges.push(start === end ? `${start}` : `${start}-${end}`);
+    return ranges.join(', ');
+  },
+
+  display(id) {
+    return id;
+  },
+};

--- a/front-end/src/renderer/components/Transaction/Create/Node/registeredNodeIdStrategy.ts
+++ b/front-end/src/renderer/components/Transaction/Create/Node/registeredNodeIdStrategy.ts
@@ -1,17 +1,11 @@
 import type { ChipMultiInputStrategy } from '@renderer/components/ui/ChipMultiInput.vue';
 
 // HIP-1137 caps `associated_registered_node` at 20 entries, which is also the
-// `maxIds` we pass to ChipMultiInput. A single range can therefore never
-// usefully contribute more than 20 entries — anything larger would fail the
-// downstream cap anyway. Bound it here too, so a typo like `0-9999999999`
-// errors immediately instead of trying to expand into a giant Set first.
-const MAX_RANGE_LENGTH = 20n;
-
-// Total unique IDs we'll let `parse` accumulate before short-circuiting.
-// Matches HIP-1137's 20-entry list cap (and the `maxIds` ChipMultiInput uses
-// downstream) — anything past 20 will be rejected anyway, so we short-circuit
-// here to bound the work of a paste like "1, 2, 3, ..." with thousands of
-// tokens instead of churning through them all first.
+// `maxIds` we pass to ChipMultiInput downstream. We short-circuit here once
+// the parse exceeds that — both per-range (so a typo like `0-9999999999`
+// errors immediately instead of trying to expand into a giant Set first) and
+// across the whole input (so a paste like "1, 2, 3, ..." with thousands of
+// tokens bails out instead of churning through them all).
 const MAX_TOTAL_IDS = 20;
 
 // Registered node IDs are non-negative integers (uint64). The input accepts
@@ -75,16 +69,13 @@ export const registeredNodeIdStrategy: ChipMultiInputStrategy<string> = {
         if (start < 0n || end < 0n || start > end) {
           return { error: `Invalid range: "${part}"` };
         }
-        // Inclusive length: `end - start + 1` is the entry count.
-        if (end - start + 1n > MAX_RANGE_LENGTH) {
-          return { error: `Range too large: "${part}" (max ${MAX_RANGE_LENGTH} per range)` };
+        // Inclusive length: `end - start + 1` is the entry count. Bounds the
+        // inner loop so a giant range can't expand into the Set before the
+        // post-loop total check fires.
+        if (end - start + 1n > BigInt(MAX_TOTAL_IDS)) {
+          return { error: `Range too large: "${part}" (max ${MAX_TOTAL_IDS} per range)` };
         }
-        for (let i = start; i <= end; i++) {
-          seen.add(i);
-          if (seen.size > MAX_TOTAL_IDS) {
-            return { error: `Too many IDs (max ${MAX_TOTAL_IDS})` };
-          }
-        }
+        for (let i = start; i <= end; i++) seen.add(i);
       } else {
         let n: bigint;
         try {
@@ -96,9 +87,9 @@ export const registeredNodeIdStrategy: ChipMultiInputStrategy<string> = {
           return { error: `Invalid value: "${part}"` };
         }
         seen.add(n);
-        if (seen.size > MAX_TOTAL_IDS) {
-          return { error: `Too many IDs (max ${MAX_TOTAL_IDS})` };
-        }
+      }
+      if (seen.size > MAX_TOTAL_IDS) {
+        return { error: `Too many IDs (max ${MAX_TOTAL_IDS})` };
       }
     }
 

--- a/front-end/src/renderer/components/Transaction/Create/NodeCreate/NodeCreate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/NodeCreate/NodeCreate.vue
@@ -35,6 +35,7 @@ const data = reactive<NodeData>({
   certificateHash: Uint8Array.from([]),
   adminKey: null,
   declineReward: false,
+  associatedRegisteredNodes: [],
 });
 
 /* Computed */

--- a/front-end/src/renderer/components/Transaction/Create/NodeCreate/NodeFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/NodeCreate/NodeFormData.vue
@@ -27,6 +27,7 @@ import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppTextArea from '@renderer/components/ui/AppTextArea.vue';
 import KeyField from '@renderer/components/KeyField.vue';
 import AppSwitch from '@renderer/components/ui/AppSwitch.vue';
+import RegisteredNodeIdInput from '@renderer/components/Transaction/Create/Node/RegisteredNodeIdInput.vue';
 
 /* Props */
 const props = defineProps<{
@@ -495,6 +496,20 @@ watch(
         />
       </div>
     </div>
+  </div>
+
+  <hr class="separator my-5" />
+
+  <div class="mt-6 col-8 col-xxxl-6">
+    <RegisteredNodeIdInput
+      :model-value="data.associatedRegisteredNodes"
+      @update:model-value="
+        emit('update:data', {
+          ...data,
+          associatedRegisteredNodes: $event,
+        })
+      "
+    />
   </div>
 
   <hr class="separator my-5" />

--- a/front-end/src/renderer/components/Transaction/Create/NodeUpdate/NodeUpdate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/NodeUpdate/NodeUpdate.vue
@@ -38,6 +38,7 @@ const data = reactive<NodeUpdateData>({
   certificateHash: Uint8Array.from([]),
   adminKey: null,
   declineReward: false,
+  associatedRegisteredNodes: [],
 });
 
 /* Computed */
@@ -92,6 +93,7 @@ watch(nodeData.nodeInfo, nodeInfo => {
     data.certificateHash = Uint8Array.from([]);
     data.adminKey = null;
     data.declineReward = false;
+    data.associatedRegisteredNodes = [];
   } else if (!route.query.draftId) {
     data.nodeAccountId = nodeInfo.node_account_id?.toString() || '';
     newNodeAccountData.accountId.value = data.nodeAccountId;
@@ -103,6 +105,7 @@ watch(nodeData.nodeInfo, nodeInfo => {
     data.certificateHash = Uint8Array.from([]);
     data.adminKey = nodeInfo.admin_key;
     data.declineReward = nodeInfo.decline_reward;
+    data.associatedRegisteredNodes = nodeInfo.associated_registered_node.map(String);
   }
 });
 watch(

--- a/front-end/src/renderer/components/Transaction/Details/NodeDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/NodeDetails.vue
@@ -18,6 +18,7 @@ import {
   uint8ToHex,
 } from '@renderer/utils';
 
+import { registeredNodeIdStrategy } from '@renderer/components/Transaction/Create/Node/registeredNodeIdStrategy';
 import KeyStructureModal from '@renderer/components/KeyStructureModal.vue';
 
 /* Props */
@@ -38,6 +39,43 @@ const grpcWebProxyEndpoint = computed(() => {
     return getComponentServiceEndpoint(props.transaction.grpcWebProxyEndpoint);
   }
   return null;
+});
+
+// HIP-1137 `associated_registered_node`. NodeCreate uses a plain repeated field
+// (the SDK getter always returns `Long[]`, possibly empty). NodeUpdate uses the
+// `AssociatedRegisteredNodeList` wrapper, so the SDK distinguishes three states:
+//   - `null`  → wrapper absent → "unchanged" → omit the row
+//   - `[]`    → wrapper present, empty → "Cleared"
+//   - `Long[]`→ wrapper present with values → render formatted list
+// We reuse `registeredNodeIdStrategy.format` to collapse consecutive ids into
+// ranges (e.g. "1, 5, 10-15") — same compact rendering the input uses.
+type AssociatedRegisteredNodesDisplay =
+  | { kind: 'omit' }
+  | { kind: 'empty' }
+  | { kind: 'list'; text: string };
+
+const associatedRegisteredNodesDisplay = computed<AssociatedRegisteredNodesDisplay>(() => {
+  if (
+    !(
+      props.transaction instanceof NodeCreateTransaction ||
+      props.transaction instanceof NodeUpdateTransaction
+    )
+  ) {
+    return { kind: 'omit' };
+  }
+  const ids = props.transaction.associatedRegisteredNodes;
+  if (ids == null) {
+    return props.transaction instanceof NodeUpdateTransaction
+      ? { kind: 'omit' }
+      : { kind: 'empty' };
+  }
+  if (ids.length === 0) {
+    return { kind: 'empty' };
+  }
+  return {
+    kind: 'list',
+    text: registeredNodeIdStrategy.format(ids.map(id => id.toString())),
+  };
 });
 
 /* Hooks */
@@ -193,6 +231,22 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
       <div v-if="grpcWebProxyEndpoint" class="col-12 my-3">
         <h4 :class="detailItemLabelClass">gRPC Web Proxy Endpoint</h4>
         <p>{{ grpcWebProxyEndpoint.domainName }}:{{ grpcWebProxyEndpoint.port }}</p>
+      </div>
+
+      <!-- Associated Registered Nodes -->
+      <div v-if="associatedRegisteredNodesDisplay.kind !== 'omit'" class="col-12 my-3">
+        <h4 :class="detailItemLabelClass">Associated Registered Nodes</h4>
+        <p
+          :class="detailItemValueClass"
+          class="text-break"
+          data-testid="p-node-details-associated-registered-nodes"
+        >
+          <template v-if="associatedRegisteredNodesDisplay.kind === 'empty'">
+            <template v-if="transaction instanceof NodeUpdateTransaction">Cleared</template>
+            <template v-else>None</template>
+          </template>
+          <template v-else>{{ associatedRegisteredNodesDisplay.text }}</template>
+        </p>
       </div>
 
       <!-- Gossip CA Certificate -->

--- a/front-end/src/renderer/components/ui/ChipMultiInput.vue
+++ b/front-end/src/renderer/components/ui/ChipMultiInput.vue
@@ -43,7 +43,7 @@ watch(
     if (isFocused.value) return;
     rawInput.value = props.strategy.format(ids);
   },
-  { immediate: true },
+  { immediate: true, deep: true },
 );
 
 function onInput(e: Event) {

--- a/front-end/src/renderer/components/ui/ChipMultiInput.vue
+++ b/front-end/src/renderer/components/ui/ChipMultiInput.vue
@@ -1,0 +1,162 @@
+<script setup lang="ts" generic="T extends string | number">
+import { ref, useId, watch } from 'vue';
+
+// `T` is constrained to a primitive so it can be used directly as Vue's
+// `:key` on the chip `v-for` (and so reference equality in `removeId` works
+// as value equality). All current and planned strategies use a canonical
+// string id (e.g. `"5"` for registered nodes, `"0.0.4-asdfn"` for accounts).
+export interface ChipMultiInputStrategy<T extends string | number> {
+  sanitize: (raw: string) => string;
+  parse: (raw: string) => { ids: T[] } | { error: string };
+  format: (ids: T[]) => string;
+  display: (id: T) => string;
+}
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: T[];
+    strategy: ChipMultiInputStrategy<T>;
+    maxIds?: number;
+    label?: string;
+    placeholder?: string;
+  }>(),
+  {
+    maxIds: 20,
+  },
+);
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', ids: T[]): void;
+}>();
+
+const inputId = useId();
+const rawInput = ref('');
+const errorMsg = ref('');
+const isFocused = ref(false);
+
+watch(
+  () => props.modelValue,
+  ids => {
+    // Skip sync while the user is mid-edit. Otherwise an async parent update
+    // (e.g. a draft load landing after the user has already started typing)
+    // would overwrite their in-progress input. On blur we re-sync via commit().
+    if (isFocused.value) return;
+    rawInput.value = props.strategy.format(ids);
+  },
+  { immediate: true },
+);
+
+function onInput(e: Event) {
+  const target = e.target as HTMLInputElement;
+  const sanitized = props.strategy.sanitize(target.value);
+  if (sanitized !== target.value) {
+    target.value = sanitized;
+  }
+  rawInput.value = sanitized;
+  errorMsg.value = '';
+}
+
+function commit() {
+  const raw = rawInput.value.trim();
+  errorMsg.value = '';
+
+  if (!raw) {
+    // Normalize the displayed text back to empty too — without this, a
+    // whitespace-only input would leave the visible field showing those
+    // spaces even though the component treated it as empty (the
+    // modelValue watcher only fires when modelValue actually changed,
+    // so empty→empty wouldn't re-sync the text).
+    rawInput.value = '';
+    if (props.modelValue.length > 0) emit('update:modelValue', []);
+    return;
+  }
+
+  const result = props.strategy.parse(raw);
+  if ('error' in result) {
+    errorMsg.value = result.error;
+    return;
+  }
+
+  if (result.ids.length > props.maxIds) {
+    errorMsg.value = `Too many IDs (${result.ids.length} — max ${props.maxIds})`;
+    return;
+  }
+
+  rawInput.value = props.strategy.format(result.ids);
+  emit('update:modelValue', result.ids);
+}
+
+function removeId(id: T) {
+  // `id` is taken directly from `v-for="id of modelValue"`, so it's a
+  // reference (or value, for primitive T) into the current `modelValue`.
+  // Plain `!==` is enough — no need to round-trip through `keyFor`.
+  const next = props.modelValue.filter(v => v !== id);
+  rawInput.value = props.strategy.format(next);
+  errorMsg.value = '';
+  emit('update:modelValue', next);
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    commit();
+  }
+}
+
+function onFocus() {
+  isFocused.value = true;
+}
+
+function onBlur() {
+  isFocused.value = false;
+  commit();
+}
+</script>
+
+<template>
+  <div class="form-group">
+    <label v-if="label" :for="inputId" class="form-label">{{ label }}</label>
+    <input
+      :id="inputId"
+      :value="rawInput"
+      class="form-control is-fill"
+      :placeholder="placeholder"
+      @focus="onFocus"
+      @input="onInput"
+      @keydown="onKeydown"
+      @blur="onBlur"
+    />
+
+    <div class="d-flex align-items-start mt-3">
+      <div
+        v-if="modelValue.length > 0"
+        class="chip-container d-flex flex-wrap flex-grow-1 me-3"
+      >
+        <div
+          v-for="id of modelValue"
+          :key="id"
+          class="chip d-inline-flex align-items-center px-2 border rounded lh-1"
+        >
+          <span class="chip-label text-center">{{ strategy.display(id) }}</span>
+          <button
+            type="button"
+            class="chip-remove ms-1 lh-1"
+            :aria-label="`Remove ${strategy.display(id)}`"
+            @click="removeId(id)"
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      </div>
+
+      <p
+        class="text-micro mb-0 ms-auto text-nowrap"
+        :class="modelValue.length >= maxIds ? 'text-danger' : 'text-muted'"
+      >
+        {{ modelValue.length }} / {{ maxIds }}
+      </p>
+    </div>
+
+    <p v-if="errorMsg" class="text-micro text-danger mt-1 mb-0">{{ errorMsg }}</p>
+  </div>
+</template>

--- a/front-end/src/renderer/services/mirrorNodeDataService.ts
+++ b/front-end/src/renderer/services/mirrorNodeDataService.ts
@@ -267,6 +267,7 @@ export const getNodeInfo = async (
               domainName: node.grpc_proxy_endpoint.domain_name || '',
             })
           : null,
+        associated_registered_node: node.associated_registered_node ?? [],
       };
       return nodeInfo;
     }

--- a/front-end/src/renderer/styles/_ui-elements.scss
+++ b/front-end/src/renderer/styles/_ui-elements.scss
@@ -302,11 +302,6 @@ td .btn {
 .chip {
   height: 28px;
   font-size: 13px;
-  // Tag-style colored background using the project's light-blue / dark-blue
-  // tokens (mirrors the convention used by `.transaction-group-row` etc.).
-  // Avoids the `body-secondary` gray (reads as disabled) and avoids the
-  // primary purple (reads as an active button).
-  background-color: $light-blue-600;
   border-color: $light-blue-800 !important;
 
   @media (prefers-color-scheme: dark) {

--- a/front-end/src/renderer/styles/_ui-elements.scss
+++ b/front-end/src/renderer/styles/_ui-elements.scss
@@ -293,6 +293,59 @@ td .btn {
   cursor: pointer;
 }
 
+/* Chip Multi Input */
+.chip-container {
+  gap: 6px;
+  min-height: 28px;
+}
+
+.chip {
+  height: 28px;
+  font-size: 13px;
+  // Tag-style colored background using the project's light-blue / dark-blue
+  // tokens (mirrors the convention used by `.transaction-group-row` etc.).
+  // Avoids the `body-secondary` gray (reads as disabled) and avoids the
+  // primary purple (reads as an active button).
+  background-color: $light-blue-600;
+  border-color: $light-blue-800 !important;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: $dark-blue-700;
+    border-color: $dark-blue-500 !important;
+  }
+}
+
+.chip-label {
+  min-width: 32px;
+  padding: 0 2px;
+}
+
+.chip-remove {
+  // Applied to a <button>, so reset the user-agent button styling so it
+  // visually looks the same as a bare glyph inside the chip.
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: inherit;
+
+  cursor: pointer;
+  font-size: 16px;
+  opacity: 0.6;
+
+  &:hover,
+  &:focus-visible {
+    opacity: 1;
+  }
+
+  // Show a clear focus ring for keyboard users (`:focus-visible` excludes
+  // mouse-click focus, so this doesn't add visual noise on click).
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+}
+
 .container-multiple-select {
   border-radius: $border-radius;
   cursor: pointer;

--- a/front-end/src/renderer/utils/sdk/createTransactions.ts
+++ b/front-end/src/renderer/utils/sdk/createTransactions.ts
@@ -553,19 +553,11 @@ const setNodeData = (
     transaction.setDeclineReward(data.declineReward);
   }
 
-  const oldAssociated = oldData?.associated_registered_node ?? [];
-  const newAssociated = data.associatedRegisteredNodes;
-  const canonicalOldAssociated = oldAssociated
-    .map(id => String(id))
-    .slice()
-    .sort();
-  const canonicalNewAssociated = newAssociated.slice().sort();
-  const sameAssociated =
-    canonicalOldAssociated.length === canonicalNewAssociated.length &&
-    canonicalOldAssociated.every((id, i) => id === canonicalNewAssociated[i]);
-  if (!sameAssociated) {
+  const oldAssociated = (oldData?.associated_registered_node ?? []).map(String).sort().join(',');
+  const newAssociated = data.associatedRegisteredNodes.slice().sort().join(',');
+  if (oldAssociated !== newAssociated) {
     transaction.setAssociatedRegisteredNodes(
-      newAssociated.map(id => Long.fromString(id)),
+      data.associatedRegisteredNodes.map(id => Long.fromString(id)),
     );
   }
 };

--- a/front-end/src/renderer/utils/sdk/createTransactions.ts
+++ b/front-end/src/renderer/utils/sdk/createTransactions.ts
@@ -555,9 +555,14 @@ const setNodeData = (
 
   const oldAssociated = oldData?.associated_registered_node ?? [];
   const newAssociated = data.associatedRegisteredNodes;
+  const canonicalOldAssociated = oldAssociated
+    .map(id => String(id))
+    .slice()
+    .sort();
+  const canonicalNewAssociated = newAssociated.slice().sort();
   const sameAssociated =
-    oldAssociated.length === newAssociated.length &&
-    oldAssociated.every((id, i) => String(id) === newAssociated[i]);
+    canonicalOldAssociated.length === canonicalNewAssociated.length &&
+    canonicalOldAssociated.every((id, i) => id === canonicalNewAssociated[i]);
   if (!sameAssociated) {
     transaction.setAssociatedRegisteredNodes(
       newAssociated.map(id => Long.fromString(id)),

--- a/front-end/src/renderer/utils/sdk/createTransactions.ts
+++ b/front-end/src/renderer/utils/sdk/createTransactions.ts
@@ -131,6 +131,7 @@ export type NodeData = {
   certificateHash: Uint8Array;
   adminKey: Key | null;
   declineReward: boolean;
+  associatedRegisteredNodes: string[];
 };
 
 export type NodeUpdateData = NodeData & {
@@ -550,6 +551,17 @@ const setNodeData = (
 
   if (oldData?.decline_reward !== data.declineReward) {
     transaction.setDeclineReward(data.declineReward);
+  }
+
+  const oldAssociated = oldData?.associated_registered_node ?? [];
+  const newAssociated = data.associatedRegisteredNodes;
+  const sameAssociated =
+    oldAssociated.length === newAssociated.length &&
+    oldAssociated.every((id, i) => String(id) === newAssociated[i]);
+  if (!sameAssociated) {
+    transaction.setAssociatedRegisteredNodes(
+      newAssociated.map(id => Long.fromString(id)),
+    );
   }
 };
 

--- a/front-end/src/renderer/utils/sdk/getData.ts
+++ b/front-end/src/renderer/utils/sdk/getData.ts
@@ -280,6 +280,8 @@ export function getNodeData(transaction: Transaction): NodeData {
     certificateHash: transaction.certificateHash || Uint8Array.from([]),
     adminKey: transaction.adminKey,
     declineReward: transaction.declineReward || false,
+    associatedRegisteredNodes:
+      transaction.associatedRegisteredNodes?.map(id => id.toString()) ?? [],
   };
 }
 

--- a/front-end/src/renderer/utils/sdk/getData.ts
+++ b/front-end/src/renderer/utils/sdk/getData.ts
@@ -280,8 +280,9 @@ export function getNodeData(transaction: Transaction): NodeData {
     certificateHash: transaction.certificateHash || Uint8Array.from([]),
     adminKey: transaction.adminKey,
     declineReward: transaction.declineReward || false,
-    associatedRegisteredNodes:
-      transaction.associatedRegisteredNodes?.map(id => id.toString()) ?? [],
+    associatedRegisteredNodes: [
+      ...new Set(transaction.associatedRegisteredNodes?.map(id => id.toString()) ?? []),
+    ],
   };
 }
 

--- a/front-end/src/shared/interfaces/HederaSchema.ts
+++ b/front-end/src/shared/interfaces/HederaSchema.ts
@@ -663,6 +663,7 @@ export interface NetworkNode {
   reward_rate_start: number | null;
   decline_reward: boolean | null;
   grpc_proxy_endpoint: ServiceEndPoint | null;
+  associated_registered_node: number[] | null | undefined;
 }
 
 export interface ServiceEndPoint {

--- a/front-end/src/shared/interfaces/INodeInfoParsed.ts
+++ b/front-end/src/shared/interfaces/INodeInfoParsed.ts
@@ -21,4 +21,5 @@ export interface INodeInfoParsed {
   reward_rate_start: Hbar | null;
   decline_reward: boolean;
   grpc_web_proxy_endpoint: ServiceEndpoint | null;
+  associated_registered_node: number[];
 }

--- a/front-end/src/tests/renderer/components/Transaction/Create/Node/RegisteredNodeIdInput.spec.ts
+++ b/front-end/src/tests/renderer/components/Transaction/Create/Node/RegisteredNodeIdInput.spec.ts
@@ -1,0 +1,41 @@
+// @vitest-environment happy-dom
+import { describe, test, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import RegisteredNodeIdInput from '@renderer/components/Transaction/Create/Node/RegisteredNodeIdInput.vue';
+import { registeredNodeIdStrategy } from '@renderer/components/Transaction/Create/Node/registeredNodeIdStrategy';
+
+// This is a thin wrapper around the generic ChipMultiInput. Its job is to
+// pin the strategy, the per-input cap, and the user-facing copy. The wrapper
+// doesn't have its own logic to test — these checks just guard against an
+// accidental copy/cap regression.
+describe('RegisteredNodeIdInput (wrapper)', () => {
+  test('mounts ChipMultiInput with the registered-node strategy and maxIds=20', () => {
+    const wrapper = mount(RegisteredNodeIdInput, {
+      props: { modelValue: [] },
+    });
+    const chip = wrapper.findComponent({ name: 'ChipMultiInput' });
+    expect(chip.exists()).toBe(true);
+    expect(chip.props('strategy')).toBe(registeredNodeIdStrategy);
+    expect(chip.props('maxIds')).toBe(20);
+    expect(chip.props('label')).toMatch(/associated registered nodes/i);
+    expect(typeof chip.props('placeholder')).toBe('string');
+  });
+
+  test('forwards modelValue down', () => {
+    const wrapper = mount(RegisteredNodeIdInput, {
+      props: { modelValue: ['1', '5'] },
+    });
+    const chip = wrapper.findComponent({ name: 'ChipMultiInput' });
+    expect(chip.props('modelValue')).toEqual(['1', '5']);
+  });
+
+  test('forwards ChipMultiInput\'s update:modelValue back up', async () => {
+    const wrapper = mount(RegisteredNodeIdInput, {
+      props: { modelValue: [] },
+    });
+    const chip = wrapper.findComponent({ name: 'ChipMultiInput' });
+    chip.vm.$emit('update:modelValue', ['7', '8']);
+    expect(wrapper.emitted('update:modelValue')).toEqual([[['7', '8']]]);
+  });
+});

--- a/front-end/src/tests/renderer/components/Transaction/Create/Node/registeredNodeIdStrategy.spec.ts
+++ b/front-end/src/tests/renderer/components/Transaction/Create/Node/registeredNodeIdStrategy.spec.ts
@@ -1,0 +1,242 @@
+// @vitest-environment node
+import { describe, test, expect } from 'vitest';
+
+import { registeredNodeIdStrategy } from '@renderer/components/Transaction/Create/Node/registeredNodeIdStrategy';
+
+const { sanitize, parse, format, display } = registeredNodeIdStrategy;
+
+describe('registeredNodeIdStrategy.sanitize', () => {
+  test('preserves digits, commas, hyphens, and whitespace', () => {
+    expect(sanitize('1, 2-5, 7')).toBe('1, 2-5, 7');
+  });
+
+  test('strips letters and other punctuation', () => {
+    expect(sanitize('1a,b2-c3.x/y!')).toBe('1,2-3');
+  });
+
+  test('collapses runs of commas', () => {
+    expect(sanitize('1,,2,,,3')).toBe('1,2,3');
+  });
+
+  test('collapses runs of hyphens', () => {
+    expect(sanitize('1--3')).toBe('1-3');
+  });
+
+  test('collapses comma / hyphen runs with whitespace between', () => {
+    expect(sanitize('1 , , 2 - - 5')).toBe('1 , 2 - 5');
+  });
+
+  test('leaves single comma and hyphen alone', () => {
+    expect(sanitize('1,2-3')).toBe('1,2-3');
+  });
+
+  test('strips a leading space', () => {
+    expect(sanitize(' 1, 2')).toBe('1, 2');
+  });
+
+  test('strips a leading tab', () => {
+    expect(sanitize('\t1, 2')).toBe('1, 2');
+  });
+
+  test('collapses runs of whitespace into a single space', () => {
+    expect(sanitize('1,  2,   3')).toBe('1, 2, 3');
+  });
+
+  test('collapses mixed tabs and spaces', () => {
+    expect(sanitize('1, \t 2')).toBe('1, 2');
+  });
+});
+
+describe('registeredNodeIdStrategy.parse', () => {
+  test('parses a CSV of single integers', () => {
+    expect(parse('1, 2, 3')).toEqual({ ids: ['1', '2', '3'] });
+  });
+
+  test('expands ranges inclusively', () => {
+    expect(parse('2-5')).toEqual({ ids: ['2', '3', '4', '5'] });
+  });
+
+  test('mixes singletons and ranges', () => {
+    expect(parse('1, 5, 10-12')).toEqual({ ids: ['1', '5', '10', '11', '12'] });
+  });
+
+  test('dedupes overlapping ranges and singletons', () => {
+    expect(parse('1-3, 2, 3-5')).toEqual({ ids: ['1', '2', '3', '4', '5'] });
+  });
+
+  test('sorts ascending regardless of input order', () => {
+    expect(parse('10, 3, 5-7, 1')).toEqual({ ids: ['1', '3', '5', '6', '7', '10'] });
+  });
+
+  test('accepts zero', () => {
+    expect(parse('0')).toEqual({ ids: ['0'] });
+  });
+
+  test('rejects descending range', () => {
+    const result = parse('5-3');
+    expect(result).toHaveProperty('error');
+    if ('error' in result) {
+      expect(result.error).toContain('5-3');
+    }
+  });
+
+  test('rejects non-numeric range bounds', () => {
+    const result = parse('a-5');
+    expect(result).toHaveProperty('error');
+  });
+
+  test('rejects non-integer single value', () => {
+    const result = parse('1.5');
+    expect(result).toHaveProperty('error');
+  });
+
+  test('ignores empty tokens from trailing or repeated commas in pre-sanitized input', () => {
+    // After sanitize this shouldn't happen, but parse should still be tolerant.
+    expect(parse('1, ,2')).toEqual({ ids: ['1', '2'] });
+  });
+
+  test('empty input parses as empty list', () => {
+    expect(parse('')).toEqual({ ids: [] });
+  });
+
+  test('preserves values above Number.MAX_SAFE_INTEGER (uint64 precision)', () => {
+    // 2^60 — well above MAX_SAFE_INTEGER (2^53−1) but a valid uint64 value.
+    // Using `Number(...)` would round this; BigInt must preserve it.
+    const big = (2n ** 60n).toString();
+    expect(parse(big)).toEqual({ ids: [big] });
+  });
+
+  test('rejects a range with more than two bounds (no silent truncation)', () => {
+    // Without explicit shape validation, destructuring would take `1` and
+    // `2` and silently drop the `3`. Must error instead.
+    const result = parse('1-2-3');
+    expect(result).toHaveProperty('error');
+    if ('error' in result) {
+      expect(result.error).toContain('1-2-3');
+    }
+  });
+
+  test('rejects a range with a missing lower bound', () => {
+    // `BigInt("")` is `0n`, so without a shape check `-5` would silently
+    // parse as the range `0-5`.
+    const result = parse('-5');
+    expect(result).toHaveProperty('error');
+  });
+
+  test('rejects a range with a missing upper bound', () => {
+    const result = parse('5-');
+    expect(result).toHaveProperty('error');
+  });
+
+  test('rejects a bare hyphen', () => {
+    const result = parse('-');
+    expect(result).toHaveProperty('error');
+  });
+
+  test('rejects an oversized range without materializing it', () => {
+    // Would expand to ~10^12 entries unguarded — must reject before allocation.
+    const result = parse('0-1000000000000');
+    expect(result).toHaveProperty('error');
+    if ('error' in result) {
+      expect(result.error.toLowerCase()).toContain('range too large');
+    }
+  });
+
+  test('accepts a range exactly at the per-range cap (20 entries)', () => {
+    // `0-19` = 20 inclusive entries = the maxIds limit. Must be allowed.
+    const result = parse('0-19');
+    expect(result).toEqual({
+      ids: Array.from({ length: 20 }, (_, i) => String(i)),
+    });
+  });
+
+  test('rejects a range one beyond the per-range cap (21 entries)', () => {
+    // `0-20` = 21 inclusive entries = one past the cap.
+    const result = parse('0-20');
+    expect(result).toHaveProperty('error');
+    if ('error' in result) {
+      expect(result.error.toLowerCase()).toContain('range too large');
+    }
+  });
+
+  test('short-circuits when total unique IDs blow past the defensive cap', () => {
+    // Many small ranges/tokens can accumulate past `maxIds` before the
+    // downstream check sees the result — parse must short-circuit instead
+    // of churning through a giant pasted blob.
+    const tokens = Array.from({ length: 500 }, (_, i) => String(i)).join(',');
+    const result = parse(tokens);
+    expect(result).toHaveProperty('error');
+    if ('error' in result) {
+      expect(result.error.toLowerCase()).toContain('too many ids');
+    }
+  });
+});
+
+describe('registeredNodeIdStrategy.format', () => {
+  test('empty list renders as empty string', () => {
+    expect(format([])).toBe('');
+  });
+
+  test('singletons rendered as comma-separated list', () => {
+    expect(format(['1', '3', '5'])).toBe('1, 3, 5');
+  });
+
+  test('consecutive integers collapse into a range', () => {
+    expect(format(['1', '2', '3', '4', '5'])).toBe('1-5');
+  });
+
+  test('non-consecutive runs collapse independently', () => {
+    expect(format(['1', '2', '3', '7', '8', '10'])).toBe('1-3, 7-8, 10');
+  });
+
+  test('numeric (not lexical) sort', () => {
+    expect(format(['10', '2', '1'])).toBe('1-2, 10');
+  });
+
+  test('preserves values above Number.MAX_SAFE_INTEGER (uint64 precision)', () => {
+    const big = (2n ** 60n).toString();
+    expect(format([big])).toBe(big);
+  });
+
+  test('does not throw on invalid entries — renders the valid subset', () => {
+    // `format` is called with whatever the parent passes in modelValue, so a
+    // single bad value (from a stale draft, API blob, etc.) must not crash.
+    expect(format(['1', 'abc', '3'])).toBe('1, 3');
+  });
+
+  test('skips negative entries (invalid uint64) without crashing', () => {
+    // BigInt('-5') doesn't throw but is an illegal uint64; format must drop it.
+    expect(format(['-5', '1', '2'])).toBe('1-2');
+  });
+
+  test('returns empty string when every entry is invalid', () => {
+    expect(format(['abc', '1.5', '-1'])).toBe('');
+  });
+
+  test('dedupes duplicate entries before collapsing into ranges', () => {
+    // Without dedup, the run-collapsing loop would see [1, 1, 2] and emit
+    // a lone `1` and then a fresh `1-2` run, producing "1, 1-2".
+    expect(format(['1', '1', '2'])).toBe('1-2');
+  });
+});
+
+describe('registeredNodeIdStrategy.display', () => {
+  test('display returns the id as-is', () => {
+    expect(display('42')).toBe('42');
+  });
+});
+
+describe('registeredNodeIdStrategy round-trip', () => {
+  test('format -> parse yields the same set', () => {
+    const ids = ['1', '2', '3', '7', '8', '10'];
+    const text = format(ids);
+    const reparsed = parse(text);
+    expect(reparsed).toEqual({ ids });
+  });
+
+  test('remove-then-format produces compact output (example from comment)', () => {
+    // Starting from 5-10, drop 7 → expect "5-6, 8-10".
+    const after = ['5', '6', '8', '9', '10'];
+    expect(format(after)).toBe('5-6, 8-10');
+  });
+});

--- a/front-end/src/tests/renderer/components/Transaction/Create/NodeUpdate/NodeUpdate.spec.ts
+++ b/front-end/src/tests/renderer/components/Transaction/Create/NodeUpdate/NodeUpdate.spec.ts
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { AccountId } from '@hiero-ledger/sdk';
+
+import type { INodeInfoParsed } from '@shared/interfaces';
+
+// Module-level mock state. `vi.mock` factories below close over these and
+// only deref them when the consuming code (NodeUpdate's setup) actually
+// invokes the mocked function — by which point these are initialized.
+const refs = {
+  nodeInfo: ref<INodeInfoParsed | null>(null),
+  nodeId: ref<number | null>(null),
+  newAccountId: ref<string>(''),
+};
+const mockToast = { success: vi.fn(), error: vi.fn() };
+let mockRouteQuery: Record<string, string | undefined> = {};
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: mockRouteQuery }),
+}));
+
+vi.mock('@renderer/utils/ToastManager', () => ({
+  ToastManager: { inject: () => mockToast },
+}));
+
+vi.mock('@renderer/composables/useNodeId', () => ({
+  default: () => ({
+    nodeInfo: refs.nodeInfo,
+    nodeId: refs.nodeId,
+    accountData: { accountId: refs.newAccountId },
+  }),
+}));
+
+vi.mock('@renderer/composables/useAccountId', () => ({
+  default: () => ({ accountId: refs.newAccountId }),
+}));
+
+// Keep `@renderer/utils` mostly real (we need `getNodeUpdateData` from it for
+// draft-load handlers we don't exercise), but stub `getComponentServiceEndpoint`
+// so the watcher's grpc-proxy line doesn't try to reach into endpoint utils.
+vi.mock('@renderer/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/utils')>();
+  return {
+    ...actual,
+    getComponentServiceEndpoint: () => null,
+  };
+});
+
+// Stub the heavy children inline. We read NodeUpdateFormData's :data prop
+// later via `findComponent({ name: 'NodeUpdateFormData' })` to see what
+// NodeUpdate.vue's watcher seeded after a nodeInfo change. The stubs must
+// be inlined inside the mock factories because `vi.mock` is hoisted above
+// any module-level `const` declarations.
+vi.mock('@renderer/components/Transaction/Create/BaseTransaction', () => ({
+  default: {
+    name: 'BaseTransaction',
+    props: ['createTransaction', 'createDisabled'],
+    emits: ['executed:success', 'draft-loaded'],
+    // NodeUpdate.vue has a second watcher that calls
+    // `baseTransactionRef.value?.updateTransactionKey()`. Exposing a no-op
+    // here prevents that watcher from throwing into the unhandled-rejection
+    // channel and (in some test orderings) tripping up the assertion.
+    methods: { updateTransactionKey() {} },
+    template: '<div><slot /></div>',
+  },
+}));
+
+vi.mock(
+  '@renderer/components/Transaction/Create/NodeUpdate/NodeUpdateFormData.vue',
+  () => ({
+    default: {
+      name: 'NodeUpdateFormData',
+      props: ['data'],
+      emits: ['update:data'],
+      template: '<div data-testid="form-stub"></div>',
+    },
+  }),
+);
+
+import NodeUpdate from '@renderer/components/Transaction/Create/NodeUpdate/NodeUpdate.vue';
+
+function makeNodeInfo(overrides: Partial<INodeInfoParsed> = {}): INodeInfoParsed {
+  return {
+    admin_key: null,
+    description: 'node-3',
+    file_id: null,
+    memo: null,
+    node_id: 3,
+    node_account_id: AccountId.fromString('0.0.3'),
+    node_cert_hash: null,
+    public_key: null,
+    service_endpoints: [],
+    timestamp: null,
+    max_stake: null,
+    min_stake: null,
+    stake: null,
+    stake_not_rewarded: null,
+    stake_rewarded: null,
+    staking_period: null,
+    reward_rate_start: null,
+    decline_reward: false,
+    grpc_web_proxy_endpoint: null,
+    associated_registered_node: [],
+    ...overrides,
+  };
+}
+
+async function mountAndSettle() {
+  const wrapper = mount(NodeUpdate);
+  await flushPromises();
+  return wrapper;
+}
+
+function readSeededData(wrapper: ReturnType<typeof mount>) {
+  return wrapper.findComponent({ name: 'NodeUpdateFormData' }).props('data') as {
+    associatedRegisteredNodes: string[];
+    nodeAccountId: string;
+    description: string;
+  };
+}
+
+describe('NodeUpdate.vue — associatedRegisteredNodes seeding watcher', () => {
+  beforeEach(() => {
+    mockRouteQuery = {};
+    refs.nodeInfo.value = null;
+    refs.nodeId.value = null;
+    refs.newAccountId.value = '';
+    vi.clearAllMocks();
+  });
+
+  test('seeds data.associatedRegisteredNodes from nodeInfo when it loads', async () => {
+    const wrapper = await mountAndSettle();
+
+    refs.nodeInfo.value = makeNodeInfo({ associated_registered_node: [1, 7, 12] });
+    await flushPromises();
+
+    expect(readSeededData(wrapper).associatedRegisteredNodes).toEqual(['1', '7', '12']);
+  });
+
+  test('seeds data.associatedRegisteredNodes to [] when nodeInfo carries an empty list', async () => {
+    const wrapper = await mountAndSettle();
+
+    refs.nodeInfo.value = makeNodeInfo({ associated_registered_node: [] });
+    await flushPromises();
+
+    expect(readSeededData(wrapper).associatedRegisteredNodes).toEqual([]);
+  });
+
+  test('resets data.associatedRegisteredNodes to [] when nodeInfo clears', async () => {
+    const wrapper = await mountAndSettle();
+
+    refs.nodeInfo.value = makeNodeInfo({ associated_registered_node: [1, 2] });
+    await flushPromises();
+    expect(readSeededData(wrapper).associatedRegisteredNodes).toEqual(['1', '2']);
+
+    refs.nodeInfo.value = null;
+    await flushPromises();
+    expect(readSeededData(wrapper).associatedRegisteredNodes).toEqual([]);
+  });
+
+  test('skips seeding when a draftId is present in the route (draft load owns the data)', async () => {
+    // When loading a draft, NodeUpdate's watcher skips the "seed from nodeInfo"
+    // branch so the draft's data isn't clobbered. The associatedRegisteredNodes
+    // field must honor this too.
+    mockRouteQuery = { draftId: 'abc' };
+    const wrapper = await mountAndSettle();
+
+    refs.nodeInfo.value = makeNodeInfo({ associated_registered_node: [9, 10] });
+    await flushPromises();
+
+    // Untouched — stays at the initial empty state from the reactive declaration.
+    expect(readSeededData(wrapper).associatedRegisteredNodes).toEqual([]);
+  });
+});

--- a/front-end/src/tests/renderer/components/Transaction/Details/NodeDetails.spec.ts
+++ b/front-end/src/tests/renderer/components/Transaction/Details/NodeDetails.spec.ts
@@ -1,0 +1,165 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import {
+  AccountId,
+  NodeCreateTransaction,
+  NodeUpdateTransaction,
+  Timestamp,
+  Transaction,
+  TransactionId,
+} from '@hiero-ledger/sdk';
+import Long from 'long';
+
+import NodeDetails from '@renderer/components/Transaction/Details/NodeDetails.vue';
+
+/**
+ * HIP-1137 added an `associated_registered_node` field with two distinct
+ * encodings:
+ *
+ *   - NodeCreate: a plain `repeated uint64`. The SDK getter always returns a
+ *     `Long[]` (possibly empty) — there is no "unset" state on the wire.
+ *
+ *   - NodeUpdate: an `AssociatedRegisteredNodeList` wrapper. The wrapper's
+ *     presence is what carries the intent:
+ *       null   → wrapper absent       → "unchanged"
+ *       []     → wrapper present, []  → "clear"
+ *       [ids]  → wrapper present, ids → "replace"
+ *
+ * The details view has to render all three cases meaningfully — particularly
+ * "unchanged" must NOT show up as `Cleared` or as an empty list, since users
+ * need to be able to tell at a glance that the field wasn't touched.
+ *
+ * Each test round-trips the transaction through `Transaction.fromBytes` so the
+ * object we render matches what the details view actually receives in
+ * production (we display transactions parsed from server bytes, not the
+ * in-memory builders).
+ */
+
+const nodeAccount = new AccountId(0, 0, 3);
+const payerAccount = new AccountId(0, 0, 2);
+const validStart = Timestamp.fromDate(new Date('2026-01-01T00:00:00Z'));
+
+const baseFields = <T extends NodeCreateTransaction | NodeUpdateTransaction>(tx: T): T => {
+  tx.setNodeAccountIds([nodeAccount]);
+  tx.setTransactionId(TransactionId.withValidStart(payerAccount, validStart));
+  return tx;
+};
+
+const roundTripCreate = (
+  configure: (tx: NodeCreateTransaction) => NodeCreateTransaction,
+): NodeCreateTransaction => {
+  const frozen = configure(baseFields(new NodeCreateTransaction())).freeze();
+  const parsed = Transaction.fromBytes(frozen.toBytes());
+  if (!(parsed instanceof NodeCreateTransaction)) {
+    throw new Error('round-trip did not produce a NodeCreateTransaction');
+  }
+  return parsed;
+};
+
+const roundTripUpdate = (
+  configure: (tx: NodeUpdateTransaction) => NodeUpdateTransaction,
+): NodeUpdateTransaction => {
+  const built = configure(baseFields(new NodeUpdateTransaction().setNodeId(Long.fromNumber(3))));
+  const frozen = built.freeze();
+  const parsed = Transaction.fromBytes(frozen.toBytes());
+  if (!(parsed instanceof NodeUpdateTransaction)) {
+    throw new Error('round-trip did not produce a NodeUpdateTransaction');
+  }
+  return parsed;
+};
+
+const mountDetails = (transaction: Transaction) =>
+  mount(NodeDetails, {
+    props: { transaction, organizationTransaction: null },
+    global: {
+      stubs: { KeyStructureModal: true },
+    },
+  });
+
+const findRow = (wrapper: ReturnType<typeof mountDetails>, label: string) =>
+  wrapper
+    .findAll('h4')
+    .find(h => h.text() === label)
+    ?.element.parentElement ?? null;
+
+const findAssociatedRow = (wrapper: ReturnType<typeof mountDetails>) =>
+  findRow(wrapper, 'Associated Registered Nodes');
+
+describe('NodeDetails.vue — associatedRegisteredNodes', () => {
+  describe('NodeCreate', () => {
+    it('renders "None" when the list is empty (the wire default for NodeCreate)', () => {
+      // No setAssociatedRegisteredNodes() call → SDK exposes `[]`. We still
+      // surface the row, with the explicit "None" so the absence is visible
+      // rather than hidden.
+      const tx = roundTripCreate(t => t);
+      expect(tx.associatedRegisteredNodes).toEqual([]);
+
+      const wrapper = mountDetails(tx);
+      const row = findAssociatedRow(wrapper);
+      expect(row).not.toBeNull();
+      expect(row?.textContent).toContain('None');
+      expect(
+        wrapper.find('[data-testid="p-node-details-associated-registered-nodes"]').text(),
+      ).toBe('None');
+    });
+
+    it('renders a formatted list with the strategy compacting consecutive ids into ranges', () => {
+      // 1, 5, 10, 11, 12, 13, 14, 15 → "1, 5, 10-15"
+      const tx = roundTripCreate(t =>
+        t.setAssociatedRegisteredNodes([1, 5, 10, 11, 12, 13, 14, 15]),
+      );
+
+      const wrapper = mountDetails(tx);
+      const cell = wrapper.find('[data-testid="p-node-details-associated-registered-nodes"]');
+      expect(cell.exists()).toBe(true);
+      expect(cell.text()).toBe('1, 5, 10-15');
+      expect(cell.text()).not.toContain('None');
+      expect(cell.text()).not.toContain('Cleared');
+    });
+  });
+
+  describe('NodeUpdate', () => {
+    it('OMITS the row entirely when the wrapper is absent ("unchanged")', () => {
+      // No setAssociatedRegisteredNodes() call on a NodeUpdate → SDK keeps the
+      // field as null → wrapper not serialized → after decode it stays null.
+      // This is the "do not touch" signal, and the details page must reflect
+      // that by not showing the row at all (otherwise a user can't distinguish
+      // unchanged from cleared).
+      const tx = roundTripUpdate(t => t);
+      expect(tx.associatedRegisteredNodes).toBeNull();
+
+      const wrapper = mountDetails(tx);
+      expect(findAssociatedRow(wrapper)).toBeNull();
+      expect(wrapper.text()).not.toContain('Associated Registered Nodes');
+      expect(
+        wrapper.find('[data-testid="p-node-details-associated-registered-nodes"]').exists(),
+      ).toBe(false);
+    });
+
+    it('renders "Cleared" when the wrapper is present with an empty array', () => {
+      // setAssociatedRegisteredNodes([]) → wrapper serialized with no entries
+      // → decoded as []. The semantic on the wire is "replace existing list
+      // with empty", which we surface as "Cleared".
+      const tx = roundTripUpdate(t => t.setAssociatedRegisteredNodes([]));
+      expect(tx.associatedRegisteredNodes).toEqual([]);
+
+      const wrapper = mountDetails(tx);
+      const cell = wrapper.find('[data-testid="p-node-details-associated-registered-nodes"]');
+      expect(cell.exists()).toBe(true);
+      expect(cell.text()).toBe('Cleared');
+      expect(cell.text()).not.toContain('None');
+    });
+
+    it('renders the formatted list when the wrapper carries values', () => {
+      const tx = roundTripUpdate(t => t.setAssociatedRegisteredNodes([3, 4, 5, 9]));
+
+      const wrapper = mountDetails(tx);
+      const cell = wrapper.find('[data-testid="p-node-details-associated-registered-nodes"]');
+      expect(cell.exists()).toBe(true);
+      // 3-5 is a consecutive run; 9 stands alone.
+      expect(cell.text()).toBe('3-5, 9');
+    });
+  });
+});

--- a/front-end/src/tests/renderer/components/ui/ChipMultiInput.spec.ts
+++ b/front-end/src/tests/renderer/components/ui/ChipMultiInput.spec.ts
@@ -1,0 +1,239 @@
+// @vitest-environment happy-dom
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import ChipMultiInput, {
+  type ChipMultiInputStrategy,
+} from '@renderer/components/ui/ChipMultiInput.vue';
+
+// A minimal strategy for testing: pass-through string IDs, no sanitize, parse
+// is comma-separated, format is comma-separated. We override individual hooks
+// per test when we want to assert behavior specific to one.
+function makeStrategy(
+  overrides: Partial<ChipMultiInputStrategy<string>> = {},
+): ChipMultiInputStrategy<string> {
+  return {
+    sanitize: vi.fn((raw: string) => raw),
+    parse: vi.fn((raw: string) => ({
+      ids: raw
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean),
+    })),
+    format: vi.fn((ids: string[]) => ids.join(', ')),
+    display: vi.fn((id: string) => id),
+    ...overrides,
+  };
+}
+
+function mountInput(props: Partial<{
+  modelValue: string[];
+  strategy: ChipMultiInputStrategy<string>;
+  maxIds: number;
+  label: string;
+  placeholder: string;
+}> = {}) {
+  // ChipMultiInput is a generic component (`<script setup generic="T">`); when
+  // mounted through `@vue/test-utils`, TS can't infer T through the runtime
+  // mount() API and falls back to `unknown`, which then mismatches our
+  // `ChipMultiInputStrategy<string>` (the interface is invariant in T). Cast
+  // the component reference to silence the inference; the runtime contract
+  // still holds and is exercised by every assertion below.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return mount(ChipMultiInput as any, {
+    props: {
+      modelValue: [] as string[],
+      strategy: makeStrategy(),
+      ...props,
+    },
+  });
+}
+
+describe('ChipMultiInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('renders label and placeholder when provided', () => {
+    const wrapper = mountInput({
+      label: 'My Label',
+      placeholder: 'type here',
+    });
+    expect(wrapper.text()).toContain('My Label');
+    expect(wrapper.find('input').attributes('placeholder')).toBe('type here');
+  });
+
+  test('label is programmatically associated with the input via matching for/id', () => {
+    const wrapper = mountInput({ label: 'My Label' });
+    const inputId = wrapper.find('input').attributes('id');
+    expect(inputId).toBeTruthy();
+    expect(wrapper.find('label').attributes('for')).toBe(inputId);
+  });
+
+  test('renders a chip per modelValue item using strategy.display', () => {
+    const strategy = makeStrategy({ display: vi.fn(id => `#${id}`) });
+    const wrapper = mountInput({ modelValue: ['1', '2', '3'], strategy });
+    const chips = wrapper.findAll('.chip');
+    expect(chips).toHaveLength(3);
+    expect(chips[0].text()).toContain('#1');
+    expect(chips[2].text()).toContain('#3');
+  });
+
+  test('seeds the input text from strategy.format on initial render', () => {
+    const wrapper = mountInput({ modelValue: ['1', '2'] });
+    const input = wrapper.find('input').element as HTMLInputElement;
+    expect(input.value).toBe('1, 2');
+  });
+
+  test('input event runs strategy.sanitize and writes the cleaned value back', async () => {
+    const strategy = makeStrategy({ sanitize: vi.fn(() => '1,2') });
+    const wrapper = mountInput({ strategy });
+    const input = wrapper.find('input');
+    await input.setValue('garbage');
+    expect(strategy.sanitize).toHaveBeenCalledWith('garbage');
+    expect((input.element as HTMLInputElement).value).toBe('1,2');
+  });
+
+  test('Enter commits: parses the raw text and emits update:modelValue', async () => {
+    const wrapper = mountInput();
+    const input = wrapper.find('input');
+    await input.setValue('1, 2, 3');
+    await input.trigger('keydown', { key: 'Enter' });
+    const emitted = wrapper.emitted('update:modelValue');
+    expect(emitted).toHaveLength(1);
+    expect(emitted![0][0]).toEqual(['1', '2', '3']);
+  });
+
+  test('blur commits the raw text', async () => {
+    const wrapper = mountInput();
+    const input = wrapper.find('input');
+    await input.setValue('4, 5');
+    await input.trigger('blur');
+    expect(wrapper.emitted('update:modelValue')![0][0]).toEqual(['4', '5']);
+  });
+
+  test('blur on empty input clears a previously non-empty modelValue', async () => {
+    const wrapper = mountInput({ modelValue: ['1', '2'] });
+    const input = wrapper.find('input');
+    await input.setValue('');
+    await input.trigger('blur');
+    const emitted = wrapper.emitted('update:modelValue');
+    expect(emitted).toBeTruthy();
+    expect(emitted![0][0]).toEqual([]);
+  });
+
+  test('blur on empty input with empty modelValue does not emit', async () => {
+    const wrapper = mountInput({ modelValue: [] });
+    const input = wrapper.find('input');
+    await input.trigger('blur');
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+
+  test('whitespace-only blur normalizes the displayed input back to empty', async () => {
+    // The strategy may legitimately allow whitespace in the input; on blur
+    // the trimmed value is empty so we treat it as cleared. The visible
+    // text must also be normalized to empty so the user doesn't see
+    // lingering spaces after blur. (Pre-fix this only worked when the
+    // watcher fired — i.e. when modelValue actually changed.)
+    const wrapper = mountInput({
+      modelValue: [],
+      // Override sanitize to allow spaces to reach the input as-is.
+      strategy: makeStrategy({ sanitize: vi.fn(raw => raw) }),
+    });
+    const input = wrapper.find('input');
+    await input.setValue('   ');
+    await input.trigger('blur');
+    expect((input.element as HTMLInputElement).value).toBe('');
+  });
+
+  test('parser error is displayed and update:modelValue is not emitted', async () => {
+    const strategy = makeStrategy({
+      parse: vi.fn(() => ({ error: 'bad input' })),
+    });
+    const wrapper = mountInput({ strategy });
+    const input = wrapper.find('input');
+    await input.setValue('whatever');
+    await input.trigger('blur');
+    expect(wrapper.text()).toContain('bad input');
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+
+  test('exceeding maxIds shows error and does not emit', async () => {
+    const wrapper = mountInput({ maxIds: 2 });
+    const input = wrapper.find('input');
+    await input.setValue('1, 2, 3');
+    await input.trigger('blur');
+    expect(wrapper.text()).toMatch(/Too many IDs/i);
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+
+  test('counter shows N / maxIds and turns red at the cap', async () => {
+    const wrapper = mountInput({ modelValue: ['1', '2'], maxIds: 2 });
+    expect(wrapper.text()).toContain('2 / 2');
+    const counter = wrapper.findAll('p').find(p => p.text().includes('2 / 2'));
+    expect(counter?.classes()).toContain('text-danger');
+  });
+
+  test('removing a chip emits the new list without that id', async () => {
+    const wrapper = mountInput({ modelValue: ['1', '2', '3'] });
+    const removes = wrapper.findAll('.chip-remove');
+    await removes[1].trigger('click');
+    expect(wrapper.emitted('update:modelValue')).toEqual([[['1', '3']]]);
+  });
+
+  test('removing a chip rewrites the input via strategy.format', async () => {
+    const strategy = makeStrategy({
+      format: vi.fn((ids: string[]) => ids.join('|')),
+    });
+    const wrapper = mountInput({ modelValue: ['1', '2'], strategy });
+    const input = wrapper.find('input').element as HTMLInputElement;
+    expect(input.value).toBe('1|2');
+    await wrapper.findAll('.chip-remove')[0].trigger('click');
+    expect(input.value).toBe('2');
+  });
+
+  test('chip-remove is a real <button> with an aria-label that names the id', () => {
+    const wrapper = mountInput({ modelValue: ['1', '2'] });
+    const remove = wrapper.findAll('.chip-remove')[0];
+    expect(remove.element.tagName.toLowerCase()).toBe('button');
+    expect(remove.attributes('type')).toBe('button');
+    expect(remove.attributes('aria-label')).toBe('Remove 1');
+    // The decorative × glyph must be hidden from AT so the announced name
+    // is just the aria-label ("Remove 1") and not "X Remove 1" or similar.
+    const glyph = remove.find('span');
+    expect(glyph.exists()).toBe(true);
+    expect(glyph.attributes('aria-hidden')).toBe('true');
+  });
+
+  test('async parent update does NOT overwrite the input while focused', async () => {
+    const wrapper = mountInput({ modelValue: [] });
+    const input = wrapper.find('input');
+    // Simulate the user focusing and typing partway through a value.
+    await input.trigger('focus');
+    await input.setValue('1, 2');
+    // Now the parent updates modelValue out from under us (e.g., a draft
+    // loaded asynchronously after the user already started editing).
+    await wrapper.setProps({ modelValue: ['5', '6', '7'] });
+    // The input must still show what the user typed, not the parent's value.
+    expect((input.element as HTMLInputElement).value).toBe('1, 2');
+  });
+
+  test('parent update is applied when the input is not focused', async () => {
+    const wrapper = mountInput({ modelValue: ['1'] });
+    const input = wrapper.find('input').element as HTMLInputElement;
+    expect(input.value).toBe('1');
+    await wrapper.setProps({ modelValue: ['5', '6', '7'] });
+    expect(input.value).toBe('5, 6, 7');
+  });
+
+  test('commit normalizes the input via strategy.format on successful parse', async () => {
+    const strategy = makeStrategy({
+      format: vi.fn((ids: string[]) => ids.join('-')),
+    });
+    const wrapper = mountInput({ strategy });
+    const input = wrapper.find('input');
+    await input.setValue('1, 2, 3');
+    await input.trigger('keydown', { key: 'Enter' });
+    expect((input.element as HTMLInputElement).value).toBe('1-2-3');
+  });
+});

--- a/front-end/src/tests/renderer/services/mirrorNodeDataService.spec.ts
+++ b/front-end/src/tests/renderer/services/mirrorNodeDataService.spec.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+const { axiosGet } = vi.hoisted(() => ({ axiosGet: vi.fn() }));
+
+vi.mock('axios', () => ({
+  default: {
+    get: axiosGet,
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('@renderer/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+import { getNodeInfo } from '@renderer/services/mirrorNodeDataService';
+
+// A minimal node payload from the mirror node — only the fields getNodeInfo
+// reads explicitly. Any field this test doesn't override is null so the parser
+// hits its fallback branches.
+function nodePayload(overrides: Record<string, unknown> = {}) {
+  return {
+    admin_key: null,
+    description: null,
+    file_id: null,
+    memo: null,
+    node_id: 3,
+    node_account_id: '0.0.3',
+    node_cert_hash: null,
+    public_key: null,
+    service_endpoints: [],
+    timestamp: null,
+    max_stake: null,
+    min_stake: null,
+    stake: null,
+    stake_not_rewarded: null,
+    stake_rewarded: null,
+    staking_period: null,
+    reward_rate_start: null,
+    decline_reward: false,
+    grpc_proxy_endpoint: null,
+    ...overrides,
+  };
+}
+
+function mockNodesResponse(node: Record<string, unknown>) {
+  axiosGet.mockResolvedValueOnce({ data: { nodes: [node] } });
+}
+
+describe('mirrorNodeDataService.getNodeInfo — associated_registered_node', () => {
+  beforeEach(() => {
+    axiosGet.mockReset();
+  });
+
+  test('defaults to [] when the mirror response omits the field', async () => {
+    mockNodesResponse(nodePayload()); // no associated_registered_node key
+    const info = await getNodeInfo(3, 'https://mirror.example');
+    expect(info?.associated_registered_node).toEqual([]);
+  });
+
+  test('passes a numeric array through unchanged', async () => {
+    mockNodesResponse(nodePayload({ associated_registered_node: [1, 7, 12] }));
+    const info = await getNodeInfo(3, 'https://mirror.example');
+    expect(info?.associated_registered_node).toEqual([1, 7, 12]);
+  });
+
+  test('treats explicit null as []', async () => {
+    mockNodesResponse(nodePayload({ associated_registered_node: null }));
+    const info = await getNodeInfo(3, 'https://mirror.example');
+    expect(info?.associated_registered_node).toEqual([]);
+  });
+
+  test('treats explicit empty array as []', async () => {
+    mockNodesResponse(nodePayload({ associated_registered_node: [] }));
+    const info = await getNodeInfo(3, 'https://mirror.example');
+    expect(info?.associated_registered_node).toEqual([]);
+  });
+});

--- a/front-end/src/tests/renderer/utils/sdk/getNodeData.spec.ts
+++ b/front-end/src/tests/renderer/utils/sdk/getNodeData.spec.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { describe, test, expect } from 'vitest';
+import { Hbar, NodeCreateTransaction, NodeUpdateTransaction } from '@hiero-ledger/sdk';
+import Long from 'long';
+
+import {
+  createNodeCreateTransaction,
+  createNodeUpdateTransaction,
+  type NodeData,
+  type NodeUpdateData,
+} from '@renderer/utils/sdk/createTransactions';
+import { getNodeData } from '@renderer/utils/sdk/getData';
+
+const common = {
+  payerId: '0.0.2',
+  validStart: new Date('2026-01-01T00:00:00Z'),
+  maxTransactionFee: new Hbar(2),
+  transactionMemo: '',
+};
+
+const baseData: NodeData = {
+  nodeAccountId: '0.0.3',
+  description: '',
+  gossipEndpoints: [],
+  serviceEndpoints: [],
+  grpcWebProxyEndpoint: null,
+  gossipCaCertificate: Uint8Array.from([]),
+  certificateHash: Uint8Array.from([]),
+  adminKey: null,
+  declineReward: false,
+  associatedRegisteredNodes: [],
+};
+
+describe('getNodeData — associatedRegisteredNodes', () => {
+  test('NodeCreate with no registered nodes returns an empty array', () => {
+    const tx = createNodeCreateTransaction({ ...common, ...baseData });
+    const parsed = getNodeData(tx);
+    expect(parsed.associatedRegisteredNodes).toEqual([]);
+  });
+
+  test('NodeCreate with values returns them as decimal strings', () => {
+    const tx = createNodeCreateTransaction({
+      ...common,
+      ...baseData,
+      associatedRegisteredNodes: ['1', '7', '12'],
+    });
+    const parsed = getNodeData(tx);
+    expect(parsed.associatedRegisteredNodes).toEqual(['1', '7', '12']);
+  });
+
+  test('NodeUpdate where the field was never set returns []', () => {
+    const updateData: NodeUpdateData = { ...baseData, nodeId: '3' };
+    const tx = createNodeUpdateTransaction({ ...common, ...updateData }, null);
+    // SDK leaves the field as null when never set on an update; getNodeData
+    // must normalize null to [] so callers always get an array.
+    expect(tx.associatedRegisteredNodes).toBeNull();
+    const parsed = getNodeData(tx);
+    expect(parsed.associatedRegisteredNodes).toEqual([]);
+  });
+
+  test('NodeUpdate where the field was explicitly cleared returns []', () => {
+    const tx = new NodeUpdateTransaction();
+    tx.setNodeId(Long.fromNumber(3));
+    tx.setAssociatedRegisteredNodes([]);
+    expect(getNodeData(tx).associatedRegisteredNodes).toEqual([]);
+  });
+
+  test('NodeUpdate with values returns them as decimal strings', () => {
+    const tx = new NodeUpdateTransaction();
+    tx.setNodeId(Long.fromNumber(3));
+    tx.setAssociatedRegisteredNodes([Long.fromNumber(5), Long.fromNumber(8)]);
+    expect(getNodeData(tx).associatedRegisteredNodes).toEqual(['5', '8']);
+  });
+
+  test('throws on non-Node transactions (sanity check on the assertion path)', () => {
+    const tx = new NodeCreateTransaction();
+    // Replace prototype so instanceof check fails — a quick way to stress the guard.
+    Object.setPrototypeOf(tx, Object.prototype);
+    expect(() => getNodeData(tx as unknown as NodeCreateTransaction)).toThrow();
+  });
+});

--- a/front-end/src/tests/renderer/utils/sdk/nodeTransactions.spec.ts
+++ b/front-end/src/tests/renderer/utils/sdk/nodeTransactions.spec.ts
@@ -1,0 +1,238 @@
+// @vitest-environment node
+import { describe, test, expect } from 'vitest';
+import {
+  AccountId,
+  Hbar,
+  NodeCreateTransaction,
+  NodeUpdateTransaction,
+  Transaction,
+} from '@hiero-ledger/sdk';
+import Long from 'long';
+
+import {
+  createNodeCreateTransaction,
+  createNodeUpdateTransaction,
+  type NodeData,
+  type NodeUpdateData,
+} from '@renderer/utils/sdk/createTransactions';
+import type { INodeInfoParsed } from '@shared/interfaces';
+
+const common = {
+  payerId: '0.0.2',
+  validStart: new Date('2026-01-01T00:00:00Z'),
+  maxTransactionFee: new Hbar(2),
+  transactionMemo: '',
+};
+
+function makeNodeData(overrides: Partial<NodeData> = {}): NodeData {
+  return {
+    nodeAccountId: '0.0.3',
+    description: '',
+    gossipEndpoints: [],
+    serviceEndpoints: [],
+    grpcWebProxyEndpoint: null,
+    gossipCaCertificate: Uint8Array.from([]),
+    certificateHash: Uint8Array.from([]),
+    adminKey: null,
+    declineReward: false,
+    associatedRegisteredNodes: [],
+    ...overrides,
+  };
+}
+
+function makeOldNodeInfo(
+  overrides: Partial<INodeInfoParsed> = {},
+): INodeInfoParsed {
+  return {
+    admin_key: null,
+    description: '',
+    file_id: null,
+    memo: null,
+    node_id: 3,
+    node_account_id: AccountId.fromString('0.0.3'),
+    node_cert_hash: null,
+    public_key: null,
+    service_endpoints: [],
+    timestamp: null,
+    max_stake: null,
+    min_stake: null,
+    stake: null,
+    stake_not_rewarded: null,
+    stake_rewarded: null,
+    staking_period: null,
+    reward_rate_start: null,
+    decline_reward: false,
+    grpc_web_proxy_endpoint: null,
+    associated_registered_node: [],
+    ...overrides,
+  };
+}
+
+function longs(values: number[]) {
+  return values.map(v => Long.fromNumber(v));
+}
+
+// Compare a Long[] field by decimal string. Proto-decoded Longs come back as
+// `unsigned: true` (since the proto field is uint64), while Long.fromNumber
+// gives signed Longs. We don't care about that flag — the numeric value is
+// what matters, so flatten to strings for the assertion.
+function longStrings(value: Long[] | null | undefined): string[] {
+  return (value ?? []).map(v => v.toString());
+}
+
+function makeUpdateData(overrides: Partial<NodeUpdateData> = {}): NodeUpdateData {
+  return {
+    ...makeNodeData(),
+    nodeId: '3',
+    ...overrides,
+  };
+}
+
+describe('createNodeCreateTransaction — associatedRegisteredNodes', () => {
+  test('empty list defaults the SDK field to [] and produces no entries', () => {
+    const tx = createNodeCreateTransaction({ ...common, ...makeNodeData() });
+    // SDK always exposes an array on NodeCreate (default []), even when never set.
+    expect(tx.associatedRegisteredNodes).toEqual([]);
+  });
+
+  test('non-empty list is set on the transaction as Longs', () => {
+    const tx = createNodeCreateTransaction({
+      ...common,
+      ...makeNodeData({ associatedRegisteredNodes: ['1', '7', '12'] }),
+    });
+    expect(tx.associatedRegisteredNodes).toEqual(longs([1, 7, 12]));
+  });
+});
+
+describe('createNodeUpdateTransaction — associatedRegisteredNodes', () => {
+  test('unchanged list does not set the SDK field (left as null = no change on the wire)', () => {
+    const tx = createNodeUpdateTransaction(
+      {
+        ...common,
+        ...makeUpdateData({ associatedRegisteredNodes: ['1', '2'] }),
+      },
+      makeOldNodeInfo({ associated_registered_node: [1, 2] }),
+    );
+    expect(tx.associatedRegisteredNodes).toBeNull();
+  });
+
+  test('clearing a previously non-empty list sets the SDK field to []', () => {
+    const tx = createNodeUpdateTransaction(
+      {
+        ...common,
+        ...makeUpdateData({ associatedRegisteredNodes: [] }),
+      },
+      makeOldNodeInfo({ associated_registered_node: [1, 2] }),
+    );
+    expect(tx.associatedRegisteredNodes).toEqual([]);
+  });
+
+  test('modifying the list sets the new Longs', () => {
+    const tx = createNodeUpdateTransaction(
+      {
+        ...common,
+        ...makeUpdateData({ associatedRegisteredNodes: ['3', '4'] }),
+      },
+      makeOldNodeInfo({ associated_registered_node: [1, 2] }),
+    );
+    expect(tx.associatedRegisteredNodes).toEqual(longs([3, 4]));
+  });
+
+  test('adding to a previously empty list sets the new Longs', () => {
+    const tx = createNodeUpdateTransaction(
+      {
+        ...common,
+        ...makeUpdateData({ associatedRegisteredNodes: ['5'] }),
+      },
+      makeOldNodeInfo({ associated_registered_node: [] }),
+    );
+    expect(tx.associatedRegisteredNodes).toEqual(longs([5]));
+  });
+
+  test('no oldData and empty list leaves the SDK field null (no-op update)', () => {
+    const tx = createNodeUpdateTransaction(
+      {
+        ...common,
+        ...makeUpdateData({ associatedRegisteredNodes: [] }),
+      },
+      null,
+    );
+    expect(tx.associatedRegisteredNodes).toBeNull();
+  });
+});
+
+// End-to-end: build → freeze → serialize → deserialize → inspect. This
+// exercises the full path that produces a real transaction, and proves the
+// field actually survives proto encoding (and gets decoded into the right
+// shape on the other end). Anything that asserts only on the in-memory SDK
+// object would miss a wire-format regression.
+describe('NodeCreate proto roundtrip — associatedRegisteredNodes', () => {
+  function freezeAndRoundtrip(tx: NodeCreateTransaction): NodeCreateTransaction {
+    tx.setNodeAccountIds([new AccountId(0, 0, 3)]);
+    tx.freeze();
+    const decoded = Transaction.fromBytes(tx.toBytes());
+    expect(decoded).toBeInstanceOf(NodeCreateTransaction);
+    return decoded as NodeCreateTransaction;
+  }
+
+  test('values survive a build → freeze → fromBytes round trip', () => {
+    const built = createNodeCreateTransaction({
+      ...common,
+      ...makeNodeData({ associatedRegisteredNodes: ['1', '7', '12'] }),
+    });
+    const decoded = freezeAndRoundtrip(built);
+    expect(longStrings(decoded.associatedRegisteredNodes)).toEqual(['1', '7', '12']);
+  });
+
+  test('empty list round-trips as an empty list on the wire', () => {
+    const built = createNodeCreateTransaction({ ...common, ...makeNodeData() });
+    const decoded = freezeAndRoundtrip(built);
+    expect(decoded.associatedRegisteredNodes).toEqual([]);
+  });
+});
+
+describe('NodeUpdate proto roundtrip — associatedRegisteredNodes', () => {
+  function freezeAndRoundtrip(tx: NodeUpdateTransaction): NodeUpdateTransaction {
+    tx.setNodeAccountIds([new AccountId(0, 0, 3)]);
+    tx.freeze();
+    const decoded = Transaction.fromBytes(tx.toBytes());
+    expect(decoded).toBeInstanceOf(NodeUpdateTransaction);
+    return decoded as NodeUpdateTransaction;
+  }
+
+  test('unchanged list: the wrapper is absent (null after decode) — "no change" on the wire', () => {
+    const built = createNodeUpdateTransaction(
+      {
+        ...common,
+        ...makeUpdateData({ associatedRegisteredNodes: ['1', '2'] }),
+      },
+      makeOldNodeInfo({ associated_registered_node: [1, 2] }),
+    );
+    const decoded = freezeAndRoundtrip(built);
+    expect(decoded.associatedRegisteredNodes).toBeNull();
+  });
+
+  test('cleared list: the wrapper is present with an empty array — "clear" on the wire', () => {
+    const built = createNodeUpdateTransaction(
+      {
+        ...common,
+        ...makeUpdateData({ associatedRegisteredNodes: [] }),
+      },
+      makeOldNodeInfo({ associated_registered_node: [1, 2] }),
+    );
+    const decoded = freezeAndRoundtrip(built);
+    expect(decoded.associatedRegisteredNodes).toEqual([]);
+  });
+
+  test('modified list: new values are present after decode', () => {
+    const built = createNodeUpdateTransaction(
+      {
+        ...common,
+        ...makeUpdateData({ associatedRegisteredNodes: ['3', '4'] }),
+      },
+      makeOldNodeInfo({ associated_registered_node: [1, 2] }),
+    );
+    const decoded = freezeAndRoundtrip(built);
+    expect(longStrings(decoded.associatedRegisteredNodes)).toEqual(['3', '4']);
+  });
+});


### PR DESCRIPTION
**Description**:
This pull request introduces support for managing and displaying "Associated Registered Nodes" (per HIP-1137) in the Node Create and Node Update flows. It adds a reusable, robust multi-input component for handling lists and ranges of node IDs, ensures correct data binding and validation throughout the UI, and updates transaction details to display this information clearly. Styling and service logic are also updated to support these changes.

**Related issue(s)**:

Fixes #2829 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
