### PR TITLE
feat: adding support for RegisteredNodeDeleteTransaction to front-end

### DIFF
--- a/back-end/libs/common/src/transaction-signature/mirror-node.client.ts
+++ b/back-end/libs/common/src/transaction-signature/mirror-node.client.ts
@@ -14,6 +14,7 @@ import {
   RegisteredNodeInfoParsed,
   RegisteredNodesResponse,
 } from '@app/common';
+import { parseRegisteredNodeInfo } from '@app/common/utils/sdk/registered-node';
 
 const HTTP_STATUS = {
   OK: 200,

--- a/back-end/libs/common/src/transaction-signature/mirror-node.client.ts
+++ b/back-end/libs/common/src/transaction-signature/mirror-node.client.ts
@@ -14,7 +14,6 @@ import {
   RegisteredNodeInfoParsed,
   RegisteredNodesResponse,
 } from '@app/common';
-import { parseRegisteredNodeInfo } from '@app/common/utils/sdk/registered-node';
 
 const HTTP_STATUS = {
   OK: 200,

--- a/front-end/src/renderer/caches/AppCache.ts
+++ b/front-end/src/renderer/caches/AppCache.ts
@@ -48,6 +48,7 @@ export class AppCache {
       mirrorNodeUrl,
       this.mirrorAccountById,
       this.mirrorNodeById,
+      this.mirrorRegisteredNodeById,
       this.backendPublicKeyOwner,
       organization,
     );

--- a/front-end/src/renderer/caches/AppCache.ts
+++ b/front-end/src/renderer/caches/AppCache.ts
@@ -11,6 +11,7 @@ import { AccountByPublicKeyCache } from './mirrorNode/AccountByPublicKeyCache';
 import TransactionFactory from '@renderer/utils/transactionSignatureModels/transaction-factory.ts';
 import { createLogger } from '@renderer/utils';
 import { TokenByIdCache } from '@renderer/caches/mirrorNode/TokenByIdCache';
+import { RegisteredNodeByIdCache } from '@renderer/caches/mirrorNode/RegisteredNodeByIdCache';
 
 export class AppCache {
   private static readonly injectKey = Symbol();
@@ -22,6 +23,7 @@ export class AppCache {
   public readonly mirrorNodeById = new NodeByIdCache();
   public readonly mirrorTransactionById = new TransactionByIdCache();
   public readonly mirrorTokenById = new TokenByIdCache();
+  public readonly mirrorRegisteredNodeById = new RegisteredNodeByIdCache();
 
   // Backend
   public readonly backendTransaction = new BackendTransactionCache();

--- a/front-end/src/renderer/caches/mirrorNode/RegisteredNodeByIdCache.ts
+++ b/front-end/src/renderer/caches/mirrorNode/RegisteredNodeByIdCache.ts
@@ -1,0 +1,27 @@
+import axios, { type AxiosResponse } from 'axios';
+import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
+import type { IRegisteredNode, IRegisteredNodesResponse } from '@shared/interfaces';
+
+export class RegisteredNodeByIdCache extends EntityCache<number, IRegisteredNode | null> {
+  //
+  // EntityCache
+  //
+
+  protected override async load(
+    nodeId: number,
+    mirrorNodeURL: string,
+  ): Promise<IRegisteredNode | null> {
+    let result: IRegisteredNode | null = null;
+
+    let nextURL: string | null =
+      mirrorNodeURL + '/api/v1/network/registered-nodes?limit=100&registerednode.id=' + nodeId;
+    while (result === null && nextURL !== null) {
+      const response: AxiosResponse<IRegisteredNodesResponse> =
+        await axios.get<IRegisteredNodesResponse>(nextURL);
+      const registeredNodes = response.data.registered_nodes ?? [];
+      result = registeredNodes.length > 0 ? registeredNodes[0] : null;
+      nextURL = response.data.links.next ?? null;
+    }
+    return result;
+  }
+}

--- a/front-end/src/renderer/caches/mirrorNode/RegisteredNodeByIdCache.ts
+++ b/front-end/src/renderer/caches/mirrorNode/RegisteredNodeByIdCache.ts
@@ -14,7 +14,7 @@ export class RegisteredNodeByIdCache extends EntityCache<number, IRegisteredNode
     let result: IRegisteredNode | null = null;
 
     let nextURL: string | null =
-      mirrorNodeURL + '/api/v1/network/registered-nodes?limit=100&registerednode.id=' + nodeId;
+      mirrorNodeURL + '/api/v1/network/registered-nodes?registerednode.id=' + nodeId;
     while (result === null && nextURL !== null) {
       const response: AxiosResponse<IRegisteredNodesResponse> =
         await axios.get<IRegisteredNodesResponse>(nextURL);

--- a/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserPage.vue
+++ b/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserPage.vue
@@ -13,6 +13,7 @@ import {
   NodeDeleteTransaction,
   NodeUpdateTransaction,
   RegisteredNodeCreateTransaction,
+  RegisteredNodeDeleteTransaction,
   TransferTransaction,
   Transaction as SDKTransaction,
   SystemDeleteTransaction,
@@ -216,7 +217,10 @@ const transactionDetailsTitle = computed(() => transactionType.value!);
               />
 
               <RegisteredNodeDetails
-                v-if="transaction instanceof RegisteredNodeCreateTransaction"
+                v-if="
+                  transaction instanceof RegisteredNodeCreateTransaction ||
+                  transaction instanceof RegisteredNodeDeleteTransaction
+                "
                 :organization-transaction="null"
                 :transaction="transaction"
               />

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeDelete/RegisteredNodeDelete.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeDelete/RegisteredNodeDelete.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import type { CreateTransactionFunc } from '@renderer/components/Transaction/Create/BaseTransaction';
+import BaseTransaction from '@renderer/components/Transaction/Create/BaseTransaction';
+import RegisteredNodeDeleteFormData from '@renderer/components/Transaction/Create/RegisteredNodeDelete/RegisteredNodeDeleteFormData.vue';
+import type { RegisteredNodeDeleteData } from '@renderer/utils/sdk/createTransactions';
+import { createRegisteredNodeDeleteTransaction } from '@renderer/utils/sdk/createTransactions';
+
+import { computed, reactive, ref } from 'vue';
+import { RegisteredNodeDeleteTransaction, Transaction } from '@hiero-ledger/sdk';
+
+import { ToastManager } from '@renderer/utils/ToastManager';
+import useRegisteredNodeId from '@renderer/composables/useRegisteredNodeId';
+
+import { getRegisteredNodeDeleteData } from '@renderer/utils';
+
+/* Composables */
+const toastManager = ToastManager.inject();
+const nodeData = useRegisteredNodeId();
+
+/* State */
+const baseTransactionRef = ref<InstanceType<typeof BaseTransaction> | null>(null);
+
+const data = reactive<RegisteredNodeDeleteData>({
+  registeredNodeId: '',
+});
+
+/* Computed */
+const createTransaction = computed<CreateTransactionFunc>(() => {
+  return common =>
+    createRegisteredNodeDeleteTransaction({
+      ...common,
+      ...(data as RegisteredNodeDeleteData),
+    });
+});
+
+const createDisabled = computed(() => {
+  return nodeData.registeredNodeInfo.value === null;
+});
+
+/* Handlers */
+const handleDraftLoaded = (transaction: Transaction) => {
+  if (
+    transaction instanceof RegisteredNodeDeleteTransaction &&
+    transaction.registeredNodeId !== null
+  ) {
+    nodeData.registeredNodeId.value = transaction.registeredNodeId.toNumber();
+  } else {
+    nodeData.registeredNodeId.value = null;
+  }
+  handleUpdateData(getRegisteredNodeDeleteData(transaction));
+};
+
+const handleUpdateData = (newData: RegisteredNodeDeleteData) => {
+  nodeData.registeredNodeId.value = parseInt(newData.registeredNodeId);
+  Object.assign(data, newData);
+};
+
+const handleExecutedSuccess = async () => {
+  toastManager.success(`Node ${data.registeredNodeId} Deleted`);
+};
+</script>
+
+<template>
+  <BaseTransaction
+    ref="baseTransactionRef"
+    :create-transaction="createTransaction"
+    :create-disabled="createDisabled"
+    @executed:success="handleExecutedSuccess"
+    @draft-loaded="handleDraftLoaded"
+  >
+    <template #default>
+      <RegisteredNodeDeleteFormData
+        :data="data as RegisteredNodeDeleteData"
+        @update:data="handleUpdateData"
+        required
+      />
+    </template>
+  </BaseTransaction>
+</template>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeDelete/RegisteredNodeDeleteFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeDelete/RegisteredNodeDeleteFormData.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import type { RegisteredNodeDeleteData } from '@renderer/utils/sdk';
+
+import AppInput from '@renderer/components/ui/AppInput.vue';
+
+/* Props */
+defineProps<{
+  data: RegisteredNodeDeleteData;
+}>();
+
+/* Emits */
+const emit = defineEmits<{
+  (event: 'update:data', data: RegisteredNodeDeleteData): void;
+}>();
+
+/* Misc */
+const columnClass = 'col-4 col-xxxl-3';
+</script>
+<template>
+  <div class="form-group" :class="[columnClass]">
+    <label class="form-label">Registered Node ID <span class="text-danger">*</span></label>
+    <AppInput
+      :model-value="data.registeredNodeId"
+      @update:model-value="
+        emit('update:data', {
+          ...data,
+          registeredNodeId: $event,
+        })
+      "
+      maxlength="2"
+      class="form-control is-fill"
+      placeholder="Enter Registered Node ID"
+    />
+  </div>
+</template>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeDelete/index.ts
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeDelete/index.ts
@@ -1,0 +1,2 @@
+import RegisteredNodeDelete from './RegisteredNodeDelete.vue';
+export default RegisteredNodeDelete;

--- a/front-end/src/renderer/components/Transaction/Create/txTypeComponentMapping.ts
+++ b/front-end/src/renderer/components/Transaction/Create/txTypeComponentMapping.ts
@@ -12,6 +12,7 @@ import NodeCreate from './NodeCreate';
 import NodeDelete from './NodeDelete';
 import NodeUpdate from './NodeUpdate';
 import RegisteredNodeCreate from './RegisteredNodeCreate';
+import RegisteredNodeDelete from './RegisteredNodeDelete';
 import SystemDelete from './SystemDelete';
 import SystemUndelete from './SystemUndelete';
 
@@ -31,6 +32,7 @@ export const transactionTypeKeys = {
   nodeDelete: 'NodeDeleteTransaction',
   nodeUpdate: 'NodeUpdateTransaction',
   registeredNodeCreate: 'RegisteredNodeCreateTransaction',
+  registeredNodeDelete: 'RegisteredNodeDeleteTransaction',
   systemDelete: 'SystemDeleteTransaction',
   systemUndelete: 'SystemUndeleteTransaction',
 };
@@ -50,6 +52,7 @@ const txTypeComponentMapping = {
   [transactionTypeKeys.nodeDelete]: NodeDelete,
   [transactionTypeKeys.nodeUpdate]: NodeUpdate,
   [transactionTypeKeys.registeredNodeCreate]: RegisteredNodeCreate,
+  [transactionTypeKeys.registeredNodeDelete]: RegisteredNodeDelete,
   [transactionTypeKeys.systemDelete]: SystemDelete,
   [transactionTypeKeys.systemUndelete]: SystemUndelete,
 };

--- a/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
@@ -1,17 +1,17 @@
 <script setup lang="ts">
 import type { ITransactionFull } from '@shared/interfaces';
-import type { ComponentRegisteredServiceEndpoint } from '@renderer/utils/sdk';
 
-import { computed, onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref } from 'vue';
 
 import {
+  BlockNodeServiceEndpoint,
+  GeneralServiceEndpoint,
   KeyList,
   PublicKey,
   RegisteredNodeCreateTransaction,
+  RegisteredNodeDeleteTransaction,
   Transaction,
 } from '@hiero-ledger/sdk';
-
-import { getRegisteredNodeData } from '@renderer/utils';
 
 import KeyStructureModal from '@renderer/components/KeyStructureModal.vue';
 
@@ -24,20 +24,6 @@ const props = defineProps<{
 /* State */
 const isKeyStructureModalShown = ref(false);
 
-/* Computed */
-const data = computed(() => {
-  if (!(props.transaction instanceof RegisteredNodeCreateTransaction)) {
-    return null;
-  }
-  return getRegisteredNodeData(props.transaction);
-});
-
-const adminKey = computed(() => data.value?.adminKey ?? null);
-const description = computed(() => data.value?.description ?? '');
-const endpoints = computed<ComponentRegisteredServiceEndpoint[]>(
-  () => data.value?.serviceEndpoints ?? [],
-);
-
 const typeLabel: Record<string, string> = {
   blockNode: 'Block Node',
   mirrorNode: 'Mirror Node',
@@ -47,7 +33,12 @@ const typeLabel: Record<string, string> = {
 
 /* Hooks */
 onBeforeMount(() => {
-  if (!(props.transaction instanceof RegisteredNodeCreateTransaction)) {
+  if (
+    !(
+      props.transaction instanceof RegisteredNodeCreateTransaction ||
+      props.transaction instanceof RegisteredNodeDeleteTransaction
+    )
+  ) {
     throw new Error('Transaction is not Registered Node Create');
   }
 });
@@ -59,33 +50,38 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
 </script>
 
 <template>
-  <div
-    v-if="transaction instanceof RegisteredNodeCreateTransaction"
-    class="mt-5 row flex-wrap"
-  >
+  <!-- Registered Node ID -->
+  <div v-if="transaction instanceof RegisteredNodeDeleteTransaction" :class="commonColClass">
+    <h4 :class="detailItemLabelClass">Registered Node ID</h4>
+    <p :class="detailItemValueClass" data-testid="p-node-details-node-id">
+      {{ transaction.registeredNodeId?.toString() ?? '' }}
+    </p>
+  </div>
+
+  <div v-if="transaction instanceof RegisteredNodeCreateTransaction" class="mt-5 row flex-wrap">
     <!-- Description -->
-    <div v-if="description" :class="commonColClass">
+    <div v-if="transaction.description" :class="commonColClass">
       <h4 :class="detailItemLabelClass">Description</h4>
       <p :class="detailItemValueClass" data-testid="p-registered-node-details-description">
-        {{ description }}
+        {{ transaction.description }}
       </p>
     </div>
 
     <!-- Admin Key -->
-    <div v-if="adminKey" class="col-12 my-3">
+    <div v-if="transaction.adminKey" class="col-12 my-3">
       <h4 :class="detailItemLabelClass">Admin Key</h4>
       <p :class="detailItemValueClass" data-testid="p-registered-node-details-admin-key">
-        <template v-if="adminKey instanceof KeyList">
+        <template v-if="transaction.adminKey instanceof KeyList">
           <span class="link-primary cursor-pointer" @click="isKeyStructureModalShown = true">
             See details
           </span>
         </template>
-        <template v-else-if="adminKey instanceof PublicKey">
+        <template v-else-if="transaction.adminKey instanceof PublicKey">
           <span class="overflow-hidden">
             <span class="text-semi-bold text-pink">
-              {{ adminKey._key._type }}
+              {{ transaction.adminKey._key._type }}
             </span>
-            {{ adminKey.toStringRaw() }}
+            {{ transaction.adminKey.toStringRaw() }}
           </span>
         </template>
         <template v-else>None</template>
@@ -93,7 +89,7 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
     </div>
 
     <!-- Service Endpoints -->
-    <div v-if="endpoints.length > 0" class="col-12 my-3">
+    <div v-if="transaction.serviceEndpoints.length > 0" class="col-12 my-3">
       <h4 :class="detailItemLabelClass">Service Endpoints</h4>
       <table class="table-custom">
         <thead class="thin">
@@ -108,25 +104,25 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
         </thead>
         <tbody class="thin">
           <!--
-            `:key="index"` is intentional here. The list is rendered read-only
-            (no inputs, no focus, no editable state), so Vue's "don't use index
-            as key" rule — which exists to avoid swapping DOM around the wrong
-            data when items are inserted/deleted/edited — doesn't apply. The
-            editable form (`EndpointRow` in RegisteredNodeFormData) uses the
-            `uiId`-based key for that reason.
-          -->
-          <tr v-for="(endpoint, index) of endpoints" :key="index">
+          `:key="index"` is intentional here. The list is rendered read-only
+          (no inputs, no focus, no editable state), so Vue's "don't use index
+          as key" rule — which exists to avoid swapping DOM around the wrong
+          data when items are inserted/deleted/edited — doesn't apply. The
+          editable form (`EndpointRow` in RegisteredNodeFormData) uses the
+          `uiId`-based key for that reason.
+        -->
+          <tr v-for="(endpoint, index) of transaction.serviceEndpoints" :key="index">
             <td class="col text-start">{{ typeLabel[endpoint.type] ?? endpoint.type }}</td>
-            <td class="col text-start">{{ endpoint.ipAddressV4 }}</td>
+            <td class="col text-start">{{ endpoint.ipAddress }}</td>
             <td class="col text-start">{{ endpoint.domainName }}</td>
             <td class="col text-start">{{ endpoint.port }}</td>
             <td class="col text-start">{{ endpoint.requiresTls ? 'Yes' : 'No' }}</td>
             <td class="col text-start">
-              <template v-if="endpoint.type === 'blockNode'">
+              <template v-if="endpoint instanceof BlockNodeServiceEndpoint">
                 {{ (endpoint.endpointApis ?? []).length }} API(s)
               </template>
-              <template v-else-if="endpoint.type === 'generalService'">
-                {{ endpoint.endpointDescription || '' }}
+              <template v-else-if="endpoint instanceof GeneralServiceEndpoint">
+                {{ endpoint.description || '' }}
               </template>
             </td>
           </tr>
@@ -135,9 +131,9 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
     </div>
 
     <KeyStructureModal
-      v-if="adminKey"
+      v-if="transaction.adminKey"
       v-model:show="isKeyStructureModalShown"
-      :account-key="adminKey"
+      :account-key="transaction.adminKey"
     />
   </div>
 </template>

--- a/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
@@ -50,60 +50,63 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
 </script>
 
 <template>
-  <!-- Registered Node ID -->
-  <div v-if="transaction instanceof RegisteredNodeDeleteTransaction" :class="commonColClass">
-    <h4 :class="detailItemLabelClass">Registered Node ID</h4>
-    <p :class="detailItemValueClass" data-testid="p-node-details-node-id">
-      {{ transaction.registeredNodeId?.toString() ?? '' }}
-    </p>
-  </div>
+  <div class="mt-5 row flex-wrap">
 
-  <div v-if="transaction instanceof RegisteredNodeCreateTransaction" class="mt-5 row flex-wrap">
-    <!-- Description -->
-    <div v-if="transaction.description" :class="commonColClass">
-      <h4 :class="detailItemLabelClass">Description</h4>
-      <p :class="detailItemValueClass" data-testid="p-registered-node-details-description">
-        {{ transaction.description }}
+    <!-- Registered Node ID -->
+    <div v-if="transaction instanceof RegisteredNodeDeleteTransaction" :class="commonColClass">
+      <h4 :class="detailItemLabelClass">Registered Node ID</h4>
+      <p :class="detailItemValueClass" data-testid="p-node-details-node-id">
+        {{ transaction.registeredNodeId?.toString() ?? '' }}
       </p>
     </div>
 
-    <!-- Admin Key -->
-    <div v-if="transaction.adminKey" class="col-12 my-3">
-      <h4 :class="detailItemLabelClass">Admin Key</h4>
-      <p :class="detailItemValueClass" data-testid="p-registered-node-details-admin-key">
-        <template v-if="transaction.adminKey instanceof KeyList">
-          <span class="link-primary cursor-pointer" @click="isKeyStructureModalShown = true">
-            See details
-          </span>
-        </template>
-        <template v-else-if="transaction.adminKey instanceof PublicKey">
-          <span class="overflow-hidden">
-            <span class="text-semi-bold text-pink">
-              {{ transaction.adminKey._key._type }}
+    <template v-if="transaction instanceof RegisteredNodeCreateTransaction">
+
+      <!-- Description -->
+      <div v-if="transaction.description" :class="commonColClass">
+        <h4 :class="detailItemLabelClass">Description</h4>
+        <p :class="detailItemValueClass" data-testid="p-registered-node-details-description">
+          {{ transaction.description }}
+        </p>
+      </div>
+
+      <!-- Admin Key -->
+      <div v-if="transaction.adminKey" class="col-12 my-3">
+        <h4 :class="detailItemLabelClass">Admin Key</h4>
+        <p :class="detailItemValueClass" data-testid="p-registered-node-details-admin-key">
+          <template v-if="transaction.adminKey instanceof KeyList">
+            <span class="link-primary cursor-pointer" @click="isKeyStructureModalShown = true">
+              See details
             </span>
-            {{ transaction.adminKey.toStringRaw() }}
-          </span>
-        </template>
-        <template v-else>None</template>
-      </p>
-    </div>
+          </template>
+          <template v-else-if="transaction.adminKey instanceof PublicKey">
+            <span class="overflow-hidden">
+              <span class="text-semi-bold text-pink">
+                {{ transaction.adminKey._key._type }}
+              </span>
+              {{ transaction.adminKey.toStringRaw() }}
+            </span>
+          </template>
+          <template v-else>None</template>
+        </p>
+      </div>
 
-    <!-- Service Endpoints -->
-    <div v-if="transaction.serviceEndpoints.length > 0" class="col-12 my-3">
-      <h4 :class="detailItemLabelClass">Service Endpoints</h4>
-      <table class="table-custom">
-        <thead class="thin">
-          <tr>
-            <th class="text-start">Type</th>
-            <th class="text-start">IP Address</th>
-            <th class="text-start">Domain Name</th>
-            <th class="text-start">Port</th>
-            <th class="text-start">TLS</th>
-            <th class="text-start">Extra</th>
-          </tr>
-        </thead>
-        <tbody class="thin">
-          <!--
+      <!-- Service Endpoints -->
+      <div v-if="transaction.serviceEndpoints.length > 0" class="col-12 my-3">
+        <h4 :class="detailItemLabelClass">Service Endpoints</h4>
+        <table class="table-custom">
+          <thead class="thin">
+            <tr>
+              <th class="text-start">Type</th>
+              <th class="text-start">IP Address</th>
+              <th class="text-start">Domain Name</th>
+              <th class="text-start">Port</th>
+              <th class="text-start">TLS</th>
+              <th class="text-start">Extra</th>
+            </tr>
+          </thead>
+          <tbody class="thin">
+            <!--
           `:key="index"` is intentional here. The list is rendered read-only
           (no inputs, no focus, no editable state), so Vue's "don't use index
           as key" rule — which exists to avoid swapping DOM around the wrong
@@ -111,29 +114,30 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
           editable form (`EndpointRow` in RegisteredNodeFormData) uses the
           `uiId`-based key for that reason.
         -->
-          <tr v-for="(endpoint, index) of transaction.serviceEndpoints" :key="index">
-            <td class="col text-start">{{ typeLabel[endpoint.type] ?? endpoint.type }}</td>
-            <td class="col text-start">{{ endpoint.ipAddress }}</td>
-            <td class="col text-start">{{ endpoint.domainName }}</td>
-            <td class="col text-start">{{ endpoint.port }}</td>
-            <td class="col text-start">{{ endpoint.requiresTls ? 'Yes' : 'No' }}</td>
-            <td class="col text-start">
-              <template v-if="endpoint instanceof BlockNodeServiceEndpoint">
-                {{ (endpoint.endpointApis ?? []).length }} API(s)
-              </template>
-              <template v-else-if="endpoint instanceof GeneralServiceEndpoint">
-                {{ endpoint.description || '' }}
-              </template>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+            <tr v-for="(endpoint, index) of transaction.serviceEndpoints" :key="index">
+              <td class="col text-start">{{ typeLabel[endpoint.type] ?? endpoint.type }}</td>
+              <td class="col text-start">{{ endpoint.ipAddress }}</td>
+              <td class="col text-start">{{ endpoint.domainName }}</td>
+              <td class="col text-start">{{ endpoint.port }}</td>
+              <td class="col text-start">{{ endpoint.requiresTls ? 'Yes' : 'No' }}</td>
+              <td class="col text-start">
+                <template v-if="endpoint instanceof BlockNodeServiceEndpoint">
+                  {{ (endpoint.endpointApis ?? []).length }} API(s)
+                </template>
+                <template v-else-if="endpoint instanceof GeneralServiceEndpoint">
+                  {{ endpoint.description || '' }}
+                </template>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
 
-    <KeyStructureModal
-      v-if="transaction.adminKey"
-      v-model:show="isKeyStructureModalShown"
-      :account-key="transaction.adminKey"
-    />
+      <KeyStructureModal
+        v-if="transaction.adminKey"
+        v-model:show="isKeyStructureModalShown"
+        :account-key="transaction.adminKey"
+      />
+    </template>
   </div>
 </template>

--- a/front-end/src/renderer/components/Transaction/Details/txTypeComponentMapping.ts
+++ b/front-end/src/renderer/components/Transaction/Details/txTypeComponentMapping.ts
@@ -26,6 +26,7 @@ export const transactionTypeKeys = {
   nodeUpdate: 'NodeUpdateTransaction',
   nodeDelete: 'NodeDeleteTransaction',
   registeredNodeCreate: 'RegisteredNodeCreateTransaction',
+  registeredNodeDelete: 'RegisteredNodeDeleteTransaction',
 };
 
 const txTypeComponentMapping = {
@@ -44,6 +45,7 @@ const txTypeComponentMapping = {
   [transactionTypeKeys.nodeUpdate]: NodeDetails,
   [transactionTypeKeys.nodeDelete]: NodeDetails,
   [transactionTypeKeys.registeredNodeCreate]: RegisteredNodeDetails,
+  [transactionTypeKeys.registeredNodeDelete]: RegisteredNodeDetails,
 };
 
 export default txTypeComponentMapping;

--- a/front-end/src/renderer/components/TransactionSelectionModal.vue
+++ b/front-end/src/renderer/components/TransactionSelectionModal.vue
@@ -62,6 +62,10 @@ const transactionGroups = computed<MenuGroup[]>(() => {
           label: 'Registered Node Create',
           name: transactionTypeKeys.registeredNodeCreate,
         },
+        {
+          label: 'Registered Node Delete',
+          name: transactionTypeKeys.registeredNodeDelete,
+        },
       ],
     },
     {
@@ -81,7 +85,7 @@ const transactionGroups = computed<MenuGroup[]>(() => {
 </script>
 <template>
   <AppModal v-model:show="show" class="large-modal">
-    <div class="p-5" style="height: 330px">
+    <div class="p-5">
       <div class="d-flex align-items-center">
         <i
           class="bi bi-x-lg cursor-pointer me-5"
@@ -104,7 +108,7 @@ const transactionGroups = computed<MenuGroup[]>(() => {
           </template>
         </div>
         <div class="col-7">
-          <div class="border-start ps-2">
+          <div class="border-start ps-2" style="height: 330px">
             <template
               v-for="(item, idx) in transactionGroups[activeGroupIndex].items"
               :key="isLinkItem(item) ? item.name : `sep-${idx}`"

--- a/front-end/src/renderer/composables/useRegisteredNodeId.ts
+++ b/front-end/src/renderer/composables/useRegisteredNodeId.ts
@@ -1,0 +1,54 @@
+import type { IRegisteredNode } from '@shared/interfaces';
+
+import { computed, ref, watch } from 'vue';
+
+import useNetworkStore from '@renderer/stores/storeNetwork';
+
+import { AppCache } from '@renderer/caches/AppCache';
+
+import useAccountId from './useAccountId';
+
+export default function useNodeId() {
+  /* Stores */
+  const networkStore = useNetworkStore();
+
+  /* Composables */
+  const accountData = useAccountId();
+
+  /* Injected */
+  const registeredNodeByIdCache = AppCache.inject().mirrorRegisteredNodeById;
+
+  /* State */
+  const registeredNodeId = ref<number | null>(null);
+  const registeredNodeInfo = ref<IRegisteredNode | null>(null);
+
+  /* Computed */
+  const isValid = computed(() => registeredNodeInfo.value !== null);
+  const key = computed(() => registeredNodeInfo.value?.admin_key);
+
+  /* Watchers */
+  watch(registeredNodeId, async () => {
+
+    if (registeredNodeId.value !== null) {
+      try {
+        registeredNodeInfo.value = await registeredNodeByIdCache.lookup(
+          registeredNodeId.value,
+          networkStore.mirrorNodeBaseURL,
+          true,
+        );
+      } catch {
+        registeredNodeInfo.value = null;
+      }
+    } else {
+      registeredNodeInfo.value = null;
+    }
+  });
+
+  return {
+    registeredNodeId,
+    registeredNodeInfo,
+    key,
+    isValid,
+    accountData,
+  };
+}

--- a/front-end/src/renderer/services/mirrorNodeDataService.ts
+++ b/front-end/src/renderer/services/mirrorNodeDataService.ts
@@ -278,7 +278,7 @@ export const getNodeInfo = async (
   }
 };
 
-const parseNetworkResponseKey = (key: NetworkResponseKey | null | undefined) => {
+export const parseNetworkResponseKey = (key: NetworkResponseKey | null | undefined) => {
   try {
     switch (key?._type) {
       case 'ProtobufEncoded':

--- a/front-end/src/renderer/utils/sdk/createTransactions.ts
+++ b/front-end/src/renderer/utils/sdk/createTransactions.ts
@@ -24,6 +24,7 @@ import {
   NodeDeleteTransaction,
   NodeUpdateTransaction,
   RegisteredNodeCreateTransaction,
+  RegisteredNodeDeleteTransaction,
   RegisteredServiceEndpoint,
   RpcRelayServiceEndpoint,
   ServiceEndpoint,
@@ -169,6 +170,10 @@ export type RegisteredNodeData = {
   description: string;
   adminKey: Key | null;
   serviceEndpoints: ComponentRegisteredServiceEndpoint[];
+};
+
+export type RegisteredNodeDeleteData = {
+  registeredNodeId: string;
 };
 
 export type SystemData = {
@@ -738,6 +743,19 @@ export function createRegisteredNodeCreateTransaction(
   const endpoints = getRegisteredServiceEndpoints(data.serviceEndpoints);
   if (endpoints.length > 0) {
     transaction.setServiceEndpoints(endpoints);
+  }
+
+  return transaction;
+}
+
+export function createRegisteredNodeDeleteTransaction(
+  data: TransactionCommonData & RegisteredNodeDeleteData,
+): RegisteredNodeDeleteTransaction {
+  const transaction = new RegisteredNodeDeleteTransaction();
+  setTransactionCommonData(transaction, data);
+
+  if (data.registeredNodeId) {
+    transaction.setRegisteredNodeId(Long.fromString(data.registeredNodeId));
   }
 
   return transaction;

--- a/front-end/src/renderer/utils/sdk/getData.ts
+++ b/front-end/src/renderer/utils/sdk/getData.ts
@@ -24,6 +24,7 @@ import {
   NodeDeleteTransaction,
   NodeUpdateTransaction,
   RegisteredNodeCreateTransaction,
+  RegisteredNodeDeleteTransaction,
   type RegisteredServiceEndpoint,
   RpcRelayServiceEndpoint,
   TransferTransaction,
@@ -47,6 +48,7 @@ import type {
   NodeUpdateData,
   RegisteredEndpointType,
   RegisteredNodeData,
+  RegisteredNodeDeleteData,
   SystemData,
   SystemDeleteData,
   SystemUndeleteData,
@@ -360,6 +362,13 @@ export function getRegisteredNodeData(transaction: Transaction): RegisteredNodeD
   };
 }
 
+export function getRegisteredNodeDeleteData(transaction: Transaction): RegisteredNodeDeleteData {
+  assertTransactionType(transaction, RegisteredNodeDeleteTransaction);
+  return {
+    registeredNodeId: transaction.registeredNodeId?.toString() ?? '',
+  };
+}
+
 export function getSystemData(
   transaction: SystemDeleteTransaction | SystemUndeleteTransaction,
 ): SystemData {
@@ -491,6 +500,14 @@ const transactionHandlers = new Map<
     tx => ({
       ...getTransactionCommonData(tx),
       ...getRegisteredNodeData(tx),
+    }),
+  ],
+
+  [
+    RegisteredNodeDeleteTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getRegisteredNodeDeleteData(tx),
     }),
   ],
 

--- a/front-end/src/renderer/utils/sdk/transactions.ts
+++ b/front-end/src/renderer/utils/sdk/transactions.ts
@@ -14,6 +14,7 @@ import {
   NodeDeleteTransaction,
   NodeUpdateTransaction,
   RegisteredNodeCreateTransaction,
+  RegisteredNodeDeleteTransaction,
   SystemDeleteTransaction,
   SystemUndeleteTransaction,
   Transaction,
@@ -105,6 +106,8 @@ export const getTransactionType = (
     transactionType = 'Node Delete Transaction';
   } else if (transaction instanceof RegisteredNodeCreateTransaction) {
     transactionType = 'Registered Node Create Transaction';
+  } else if (transaction instanceof RegisteredNodeDeleteTransaction) {
+    transactionType = 'Registered Node Delete Transaction';
   } else if (transaction instanceof SystemDeleteTransaction) {
     transactionType = 'System Delete Transaction';
   } else if (transaction instanceof SystemUndeleteTransaction) {

--- a/front-end/src/renderer/utils/transactionSignatureModels/index.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/index.ts
@@ -16,6 +16,7 @@ export * from './file-append-transaction.model';
 export * from './file-update-transaction.model';
 export * from './freeze-transaction.model';
 export * from './registered-node-create-transaction.model';
+export * from './registered-node-delete-transaction.model';
 export * from './system-delete-transaction.model';
 export * from './transaction-factory';
 export * from './transaction.model';

--- a/front-end/src/renderer/utils/transactionSignatureModels/registered-node-delete-transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/registered-node-delete-transaction.model.ts
@@ -1,0 +1,54 @@
+import { Key, RegisteredNodeDeleteTransaction } from '@hiero-ledger/sdk';
+
+import { TransactionBaseModel } from './transaction.model';
+import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache';
+import type { RegisteredNodeByIdCache } from '@renderer/caches/mirrorNode/RegisteredNodeByIdCache';
+import { createLogger } from '@renderer/utils';
+import { parseNetworkResponseKey } from '@renderer/services/mirrorNodeDataService';
+
+const logger = createLogger('renderer.transaction.signatureModel.registerNodeDelete');
+
+export default class RegisteredNodeDeleteTransactionModel extends TransactionBaseModel<RegisteredNodeDeleteTransaction> {
+  override async getRegisteredNodeKeys(
+    mirrorNodeLink: string,
+    _accountInfoCache: AccountByIdCache,
+    registeredNodeInfoCache: RegisteredNodeByIdCache,
+  ): Promise<{ registeredNodeId: number; key: Key } | null> {
+    const registeredNodeId = this.transaction.registeredNodeId?.toNumber() ?? null;
+
+    try {
+      if (registeredNodeId == null) {
+        return null;
+      }
+
+      const registeredNodeInfo = await registeredNodeInfoCache.lookup(
+        registeredNodeId,
+        mirrorNodeLink,
+      );
+
+      if (registeredNodeInfo === null) {
+        logger.warn(`No node info found for node ${registeredNodeId}`);
+        return null;
+      }
+
+      if (registeredNodeInfo.admin_key === null) {
+        logger.warn(`No admin key found for node ${registeredNodeId}`);
+        return null;
+      }
+
+      const adminKey = parseNetworkResponseKey(registeredNodeInfo.admin_key);
+      if (adminKey === null) {
+        logger.warn(`Malformed admin key found for node ${registeredNodeId}`);
+        return null;
+      }
+
+      return { registeredNodeId, key: adminKey };
+    } catch (error) {
+      logger.warn('Failed to resolve node admin signing key', {
+        error,
+        registeredNodeId,
+      });
+      throw error;
+    }
+  }
+}

--- a/front-end/src/renderer/utils/transactionSignatureModels/registered-node-delete-transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/registered-node-delete-transaction.model.ts
@@ -3,7 +3,7 @@ import { Key, RegisteredNodeDeleteTransaction } from '@hiero-ledger/sdk';
 import { TransactionBaseModel } from './transaction.model';
 import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache';
 import type { RegisteredNodeByIdCache } from '@renderer/caches/mirrorNode/RegisteredNodeByIdCache';
-import { createLogger } from '@renderer/utils';
+import { createLogger } from '@renderer/utils/logger';
 import { parseNetworkResponseKey } from '@renderer/services/mirrorNodeDataService';
 
 const logger = createLogger('renderer.transaction.signatureModel.registerNodeDelete');

--- a/front-end/src/renderer/utils/transactionSignatureModels/transaction-factory.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/transaction-factory.ts
@@ -15,6 +15,7 @@ import NodeCreateTransactionModel from './node-create-transaction.model';
 import NodeUpdateTransactionModel from './node-update-transaction.model';
 import NodeDeleteTransactionModel from './node-delete-transaction.model';
 import RegisteredNodeCreateTransactionModel from './registered-node-create-transaction.model';
+import RegisteredNodeDeleteTransactionModel from './registered-node-delete-transaction.model';
 import { getTransactionType } from '../sdk/transactions';
 
 export default class TransactionFactory {
@@ -40,6 +41,7 @@ export default class TransactionFactory {
       NodeUpdateTransaction: NodeUpdateTransactionModel,
       NodeDeleteTransaction: NodeDeleteTransactionModel,
       RegisteredNodeCreateTransaction: RegisteredNodeCreateTransactionModel,
+      RegisteredNodeDeleteTransaction: RegisteredNodeDeleteTransactionModel,
     };
 
     const transactionType = getTransactionType(

--- a/front-end/src/renderer/utils/transactionSignatureModels/transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/transaction.model.ts
@@ -3,6 +3,7 @@ import { AccountId, Key, PublicKey, Transaction as SDKTransaction } from '@hiero
 import { compareKeys } from '../sdk';
 import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache.ts';
 import type { NodeByIdCache } from '@renderer/caches/mirrorNode/NodeByIdCache.ts';
+import type { RegisteredNodeByIdCache } from '@renderer/caches/mirrorNode/RegisteredNodeByIdCache';
 import type { ConnectedOrganization } from '@renderer/types';
 import type { PublicKeyOwnerCache } from '@renderer/caches/backend/PublicKeyOwnerCache.ts';
 import { flattenKeyList } from '@renderer/services/keyPairService.ts';
@@ -48,14 +49,22 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
     _mirrorNodeLink: string,
     _accountInfoCache: AccountByIdCache,
     _nodeInfoCache: NodeByIdCache,
-  ): Promise<{nodeId: number, key: Key} | null> {
+  ): Promise<{ nodeId: number; key: Key } | null> {
+    return null;
+  }
+
+  async getRegisteredNodeKeys(
+    _mirrorNodeLink: string,
+    _accountInfoCache: AccountByIdCache,
+    _registeredNodeInfoCache: RegisteredNodeByIdCache,
+  ): Promise<{ registeredNodeId: number; key: Key } | null> {
     return null;
   }
 
   async getNewNodeAccountKeys(
     _mirrorNodeLink: string,
     _accountInfoCache: AccountByIdCache,
-  ): Promise<{accountId: string, key: Key} | null> {
+  ): Promise<{ accountId: string; key: Key } | null> {
     return null;
   }
 
@@ -63,6 +72,7 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
     mirrorNodeLink: string,
     accountInfoCache: AccountByIdCache,
     nodeInfoCache: NodeByIdCache,
+    registeredNodeInfoCache: RegisteredNodeByIdCache,
     publicKeyOwnerCache: PublicKeyOwnerCache,
     organization: ConnectedOrganization | null,
   ): Promise<SignatureAudit> {
@@ -71,6 +81,11 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
     const receiverAccounts = this.getReceiverAccounts();
     const newKeys = this.getNewKeys() ?? [];
     const nodeKeys = await this.getNodeKeys(mirrorNodeLink, accountInfoCache, nodeInfoCache);
+    const registeredNodeKeys = await this.getRegisteredNodeKeys(
+      mirrorNodeLink,
+      accountInfoCache,
+      registeredNodeInfoCache,
+    );
     const newNodeKeys = await this.getNewNodeAccountKeys(mirrorNodeLink, accountInfoCache);
 
     /* Create result objects */
@@ -155,6 +170,13 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
       const { accountId, key } = newNodeKeys;
       signatureKeys.push(key);
       newNodeAccountKeys[accountId] = key;
+      currentKeyList.push(key);
+    }
+
+    if (registeredNodeKeys) {
+      const { registeredNodeId, key } = registeredNodeKeys;
+      signatureKeys.push(key);
+      nodeAdminKeys[registeredNodeId] = key;
       currentKeyList.push(key);
     }
 

--- a/front-end/src/shared/interfaces/IRegisteredNode.ts
+++ b/front-end/src/shared/interfaces/IRegisteredNode.ts
@@ -1,0 +1,60 @@
+import type { Key, Links, TimestampRange } from './HederaSchema';
+
+export interface IRegisteredNodesResponse {
+  registered_nodes: IRegisteredNode[] | undefined;
+  links: Links;
+}
+
+export interface IRegisteredNode {
+  admin_key: Key | null;
+  created_timestamp: string | null;
+  description: string | null;
+  registered_node_id: number;
+  service_endpoints: IRegisteredServiceEndPoint[];
+  timestamp: TimestampRange;
+}
+
+export interface IRegisteredServiceEndPoint {
+  block_node: IRegisteredBlockNodeEndpoint | null;
+  domain_name: string | null; // The DNS domain name of the service
+  general_service: IRegisteredGeneralServiceEndpoint | null;
+  ip_address: string | null; // The IP address of the service
+  mirror_node: unknown; // SHOULD BE: RegisteredMirrorNodeEndpoint | null
+  port: number;
+  requires_tls: boolean; // Whether the registered service endpoint requires TLS or not
+  rpc_relay: unknown; // SHOULD BE: RegisteredRpcRelayEndpoint | null
+  type: RegisteredNodeType; // Registered node type
+}
+
+export interface IRegisteredBlockNodeEndpoint {
+  endpoint_apis: RegisteredBlockNodeApi[];
+}
+
+export enum RegisteredBlockNodeApi {
+  OTHER = 'OTHER',
+  STATUS = 'STATUS',
+  PUBLISH = 'PUBLISH',
+  SUBSCRIBE_STREAM = 'SUBSCRIBE_STREAM',
+  STATE_PROOF = 'STATE_PROOF',
+  UNRECOGNIZED = 'UNRECOGNIZED',
+}
+
+export interface IRegisteredGeneralServiceEndpoint {
+  description: string;
+}
+
+//
+// These are currently empty in MN OpenAPI definition
+//
+// export interface IRegisteredMirrorNodeEndpoint {
+// }
+//
+// export interface IRegisteredRpcRelayEndpoint {
+// }
+
+export enum RegisteredNodeType {
+  BLOCK_NODE = 'BLOCK_NODE',
+  GENERAL_SERVICE = 'GENERAL_SERVICE',
+  MIRROR_NODE = 'MIRROR_NODE',
+  RPC_RELAY = 'RPC_RELAY',
+}

--- a/front-end/src/shared/interfaces/index.ts
+++ b/front-end/src/shared/interfaces/index.ts
@@ -1,5 +1,6 @@
 export * from './IAccountInfoParsed';
 export * from './INodeInfoParsed';
+export * from './IRegisteredNode';
 export * from './HederaSchema';
 export * from './Theme';
 export * from './organization';

--- a/front-end/src/shared/interfaces/organization/transactions/index.ts
+++ b/front-end/src/shared/interfaces/organization/transactions/index.ts
@@ -21,6 +21,8 @@ export enum BackEndTransactionType {
   NODE_UPDATE = 'NODE UPDATE',
   NODE_DELETE = 'NODE DELETE',
   REGISTERED_NODE_CREATE = 'REGISTERED NODE CREATE',
+  REGISTERED_NODE_UPDATE = 'REGISTERED NODE UPDATE',
+  REGISTERED_NODE_DELETE = 'REGISTERED NODE DELETE',
 }
 
 export const TransactionTypeName = {
@@ -40,6 +42,8 @@ export const TransactionTypeName = {
   [BackEndTransactionType.NODE_UPDATE]: 'Node Update Transaction',
   [BackEndTransactionType.NODE_DELETE]: 'Node Delete Transaction',
   [BackEndTransactionType.REGISTERED_NODE_CREATE]: 'Registered Node Create Transaction',
+  [BackEndTransactionType.REGISTERED_NODE_UPDATE]: 'Registered Node Update Transaction',
+  [BackEndTransactionType.REGISTERED_NODE_DELETE]: 'Registered Node Delete Transaction',
 };
 
 export enum TransactionStatus {


### PR DESCRIPTION
**Description**:

Changes below:
- add `Registered Node Delete` transaction to `Create Transaction` modal
- enable `Draft Creation` form to create a `RegisteredNodeDelete` transaction
- enable `TransactionDetails` page to display specific info to `RegisteredNodeDelete` transaction

***New `Registered Node Delete` command in `Transaction Selection` modal:***

<img width="779" height="469" alt="image" src="https://github.com/user-attachments/assets/42f9c362-d6e1-41be-a1a3-cdf0ae92e202" />

***Form for creating Registered Node Delete transaction:***

<img width="1212" height="881" alt="image" src="https://github.com/user-attachments/assets/0cd9a463-cc7b-47ad-95d4-4f1f319a96c1" />

***Transaction Details for registered node delete transaction:***

<img width="1209" height="1034" alt="image" src="https://github.com/user-attachments/assets/983d6d52-51cd-4b5e-9cab-9eb280020c51" />


**Related issue(s)**:

Fixes #2885, #2828

**Notes for reviewer**:

```
M   front-end/src/renderer/components/TransactionSelectionModal.vue
    # Transaction selection modal now proposes Registered Node Delete transaction

N   front-end/src/renderer/components/Transaction/Create/RegisteredNodeDelete/index.ts
N   front-end/src/renderer/components/Transaction/Create/RegisteredNodeDelete/RegisteredNodeDelete.vue
N   front-end/src/renderer/components/Transaction/Create/RegisteredNodeDelete/RegisteredNodeDeleteFormData.vue
M   front-end/src/renderer/components/Transaction/Create/txTypeComponentMapping.ts
N   front-end/src/renderer/composables/useRegisteredNodeId.ts
M   front-end/src/renderer/utils/sdk/createTransactions.ts
M   front-end/src/renderer/utils/sdk/getData.ts
    # RegisteredNodeDelete view now enables to edit RegisteredNodeDeleteTransaction

M   front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
M   front-end/src/renderer/components/Transaction/Details/txTypeComponentMapping.ts
M   front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserPage.vue
M   front-end/src/shared/interfaces/organization/transactions/index.ts
M   front-end/src/renderer/utils/sdk/transactions.ts
    # Node details and TransactionBrowser pages now display transaction data specific to registered node delete

M   front-end/src/renderer/utils/transactionSignatureModels/transaction.model.ts
    # Added new generic method: getRegisteredNodeKeys() (sibling of getNodeKeys())

N   front-end/src/renderer/utils/transactionSignatureModels/registered-node-delete-transaction.model.ts
M   front-end/src/renderer/utils/transactionSignatureModels/index.ts
M   front-end/src/renderer/utils/transactionSignatureModels/transaction-factory.ts
M   front-end/src/renderer/services/mirrorNodeDataService.ts
    # Added new model class: RegisteredNodeDeleteTransactionModel
    # It overrides getRegisteredNodeKeys()

N   front-end/src/renderer/caches/mirrorNode/RegisteredNodeByIdCache.ts
M   front-end/src/renderer/caches/AppCache.ts
M   front-end/src/shared/interfaces/index.ts
M   front-end/src/shared/interfaces/IRegisteredNode.ts
    # New RegisteredNodeIdCache caches MN results from /api/v1/network/registered-nodes
```
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
