### PR TITLE
feat: adding front-end support for registered node update transactions

### DIFF
--- a/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserPage.vue
+++ b/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserPage.vue
@@ -13,6 +13,7 @@ import {
   NodeDeleteTransaction,
   NodeUpdateTransaction,
   RegisteredNodeCreateTransaction,
+  RegisteredNodeUpdateTransaction,
   RegisteredNodeDeleteTransaction,
   TransferTransaction,
   Transaction as SDKTransaction,
@@ -219,6 +220,7 @@ const transactionDetailsTitle = computed(() => transactionType.value!);
               <RegisteredNodeDetails
                 v-if="
                   transaction instanceof RegisteredNodeCreateTransaction ||
+                  transaction instanceof RegisteredNodeUpdateTransaction ||
                   transaction instanceof RegisteredNodeDeleteTransaction
                 "
                 :organization-transaction="null"

--- a/front-end/src/renderer/components/Transaction/Create/NodeUpdate/NodeUpdate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/NodeUpdate/NodeUpdate.vue
@@ -71,7 +71,8 @@ const handleDraftLoaded = (transaction: Transaction) => {
 };
 
 const handleUpdateData = (newData: NodeUpdateData) => {
-  nodeData.nodeId.value = parseInt(newData.nodeId);
+  const n = parseInt(newData.nodeId);
+  nodeData.nodeId.value = isNaN(n) ? null : n;
   newNodeAccountData.accountId.value = newData.nodeAccountId;
   Object.assign(data, newData);
 };

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeUpdate/RegisteredNodeUpdate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeUpdate/RegisteredNodeUpdate.vue
@@ -126,7 +126,8 @@ const handleDraftLoaded = (transaction: Transaction) => {
 };
 
 const handleUpdateData = (newData: RegisteredNodeUpdateData) => {
-  nodeData.registeredNodeId.value = parseInt(newData.registeredNodeId);
+  const n = parseInt(newData.registeredNodeId);
+  nodeData.registeredNodeId.value = isNaN(n) ? null : n;
   Object.assign(data, {
     ...newData,
     serviceEndpoints: decorateEndpointsWithUiIds(newData.serviceEndpoints),

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeUpdate/RegisteredNodeUpdate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeUpdate/RegisteredNodeUpdate.vue
@@ -1,0 +1,233 @@
+<script setup lang="ts">
+import type { CreateTransactionFunc } from '@renderer/components/Transaction/Create/BaseTransaction';
+import BaseTransaction from '@renderer/components/Transaction/Create/BaseTransaction';
+import {
+  type ComponentRegisteredServiceEndpoint,
+  createRegisteredNodeUpdateTransaction,
+  parseIpv4ToBytes,
+  parsePort,
+  type RegisteredNodeUpdateData,
+} from '@renderer/utils/sdk/createTransactions';
+
+import { computed, reactive, ref, watch } from 'vue';
+import { Transaction, RegisteredNodeUpdateTransaction } from '@hiero-ledger/sdk';
+
+import { useRoute } from 'vue-router';
+import { ToastManager } from '@renderer/utils/ToastManager';
+
+import {
+  exceedsUtf8ByteLimit,
+  getComponentRegisteredEndpoints,
+  getRegisteredNodeUpdateData,
+} from '@renderer/utils';
+import RegisteredNodeUpdateFormData from './RegisteredNodeUpdateFormData.vue';
+import useRegisteredNodeId from '@renderer/composables/useRegisteredNodeId.ts';
+
+/* HIP-1137 limits — enforced by the consensus node, mirrored here so we never
+   send a request that we already know will be rejected. */
+const MAX_SERVICE_ENDPOINTS = 50;
+const MAX_DESCRIPTION_BYTES = 100;
+
+/* Composables */
+const route = useRoute();
+const toastManager = ToastManager.inject();
+const nodeData = useRegisteredNodeId();
+
+/* State */
+const baseTransactionRef = ref<InstanceType<typeof BaseTransaction> | null>(null);
+
+const data = reactive<RegisteredNodeUpdateData>({
+  registeredNodeId: '',
+  description: '',
+  adminKey: null,
+  serviceEndpoints: [],
+});
+
+/* Computed */
+const createTransaction = computed<CreateTransactionFunc>(() => {
+  return common =>
+    createRegisteredNodeUpdateTransaction({
+      ...common,
+      ...(data as RegisteredNodeUpdateData),
+    });
+});
+
+const createDisabled = computed(() => {
+  return (
+    nodeData.registeredNodeInfo.value === null ||
+    data.adminKey === null ||
+    data.serviceEndpoints.length === 0 ||
+    data.serviceEndpoints.length > MAX_SERVICE_ENDPOINTS ||
+    exceedsUtf8ByteLimit(data.description, MAX_DESCRIPTION_BYTES) ||
+    createServiceEndpointsDisabled.value
+  );
+});
+
+const createServiceEndpointsDisabled = computed(() => {
+  for (const ep of data.serviceEndpoints) {
+    if (!ep.type) {
+      return true;
+    }
+    const hasIp = Boolean(ep.ipAddressV4?.trim());
+    const hasDomain = Boolean(ep.domainName?.trim());
+    if (!hasIp && !hasDomain) {
+      return true;
+    }
+    if (hasIp && hasDomain) {
+      return true;
+    }
+    if (hasIp && parseIpv4ToBytes(ep.ipAddressV4 ?? '') === null) {
+      return true;
+    }
+    if (parsePort(ep.port ?? '') === null) {
+      return true;
+    }
+    if (
+      ep.type === 'generalService' &&
+      ep.endpointDescription &&
+      exceedsUtf8ByteLimit(ep.endpointDescription, MAX_DESCRIPTION_BYTES)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+});
+
+/**
+ * `uiId` is a render-side stable key for `<EndpointRow>` (see Vue's list `:key`
+ * rules — never use `index` for editable lists). It lives in the form's data
+ * model but must NEVER leak into the SDK-serialized transaction OR into the
+ * shape returned by `getRegisteredNodeData` (which is JSON-stringified by
+ * `transactionsDataMatch`). So `getRegisteredNodeData` deliberately doesn't
+ * populate `uiId`, and we decorate endpoints with a fresh UUID *only at form
+ * intake* — preserving any uiId the user/Vue already has for that row.
+ */
+const makeUiId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `ep-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+const decorateEndpointsWithUiIds = (
+  endpoints: ComponentRegisteredServiceEndpoint[],
+): ComponentRegisteredServiceEndpoint[] =>
+  endpoints.map(ep => (ep.uiId ? ep : { ...ep, uiId: makeUiId() }));
+
+/* Handlers */
+const handleDraftLoaded = (transaction: Transaction) => {
+  if (transaction instanceof RegisteredNodeUpdateTransaction) {
+    if (transaction.registeredNodeId) {
+      nodeData.registeredNodeId.value = transaction.registeredNodeId.toNumber();
+    }
+  }
+  handleUpdateData(getRegisteredNodeUpdateData(transaction));
+};
+
+const handleUpdateData = (newData: RegisteredNodeUpdateData) => {
+  nodeData.registeredNodeId.value = parseInt(newData.registeredNodeId);
+  Object.assign(data, {
+    ...newData,
+    serviceEndpoints: decorateEndpointsWithUiIds(newData.serviceEndpoints),
+  });
+};
+
+const handleExecutedSuccess = async () => {
+  toastManager.success(`Registered Node ${data.registeredNodeId} Updated`);
+};
+
+/* Functions */
+const preCreateAssert = () => {
+  if (!data.adminKey) {
+    throw new Error('Admin Key Required');
+  }
+
+  if (data.serviceEndpoints.length === 0) {
+    throw new Error('At least one Service Endpoint is required');
+  }
+
+  if (data.serviceEndpoints.length > MAX_SERVICE_ENDPOINTS) {
+    throw new Error(
+      `A registered node may have at most ${MAX_SERVICE_ENDPOINTS} service endpoints`,
+    );
+  }
+
+  if (data.description && exceedsUtf8ByteLimit(data.description, MAX_DESCRIPTION_BYTES)) {
+    throw new Error(`Description must be ≤ ${MAX_DESCRIPTION_BYTES} bytes`);
+  }
+
+  data.serviceEndpoints.forEach((ep, i) => {
+    if (!ep.type) {
+      throw new Error(`Endpoint ${i + 1}: type is required`);
+    }
+    const hasIp = Boolean(ep.ipAddressV4?.trim());
+    const hasDomain = Boolean(ep.domainName?.trim());
+    if (!hasIp && !hasDomain) {
+      throw new Error(`Endpoint ${i + 1}: IP address or domain name is required`);
+    }
+    if (hasIp && hasDomain) {
+      throw new Error(`Endpoint ${i + 1}: cannot have both IP and domain`);
+    }
+    if (hasIp && parseIpv4ToBytes(ep.ipAddressV4 ?? '') === null) {
+      throw new Error(`Endpoint ${i + 1}: invalid IPv4 address`);
+    }
+    if (parsePort(ep.port ?? '') === null) {
+      throw new Error(`Endpoint ${i + 1}: port must be a number in [0, 65535]`);
+    }
+    if (
+      ep.type === 'generalService' &&
+      ep.endpointDescription &&
+      exceedsUtf8ByteLimit(ep.endpointDescription, MAX_DESCRIPTION_BYTES)
+    ) {
+      throw new Error(`Endpoint ${i + 1}: description must be ≤ ${MAX_DESCRIPTION_BYTES} bytes`);
+    }
+  });
+
+  return true;
+};
+
+/* Watchers */
+watch(nodeData.registeredNodeInfo, registeredNodeInfo => {
+  if (registeredNodeInfo === null) {
+    data.description = '';
+    data.adminKey = null;
+    data.serviceEndpoints = [];
+  } else if (!route.query.draftId) {
+    data.description = registeredNodeInfo.description ?? '';
+    data.adminKey = registeredNodeInfo.admin_key;
+    data.serviceEndpoints = getComponentRegisteredEndpoints(
+      registeredNodeInfo.service_endpoints as any,
+    );
+  }
+});
+// Only fields that change the network-required *signer set* should trigger
+// `updateTransactionKey()` — which performs a mirror-node round trip via
+// `appCache.computeSignatureKey`. For RegisteredNodeCreate, the signer rule
+// (per HIP-1137) is "the new `admin_key` must sign", so only `data.adminKey`
+// affects the recompute. Endpoint fields (IP, port, TLS, type) and the
+// description never change who has to sign. Matches `NodeCreate.vue`'s
+// narrow watcher shape — a deep watcher here would issue a network call on
+// every keystroke into every endpoint field.
+watch(
+  () => data.adminKey,
+  () => {
+    baseTransactionRef.value?.updateTransactionKey();
+  },
+);
+</script>
+
+<template>
+  <BaseTransaction
+    ref="baseTransactionRef"
+    :create-transaction="createTransaction"
+    :pre-create-assert="preCreateAssert"
+    :create-disabled="createDisabled"
+    @executed:success="handleExecutedSuccess"
+    @draft-loaded="handleDraftLoaded"
+  >
+    <template #default>
+      <RegisteredNodeUpdateFormData :data="data" @update:data="handleUpdateData" />
+    </template>
+  </BaseTransaction>
+</template>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeUpdate/RegisteredNodeUpdateFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeUpdate/RegisteredNodeUpdateFormData.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import type { RegisteredNodeData, RegisteredNodeUpdateData } from '@renderer/utils/sdk';
+
+import AppInput from '@renderer/components/ui/AppInput.vue';
+import RegisteredNodeFormData from '@renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue';
+
+/* Props */
+const props = defineProps<{
+  data: RegisteredNodeUpdateData;
+}>();
+
+/* Emits */
+const emit = defineEmits<{
+  (event: 'update:data', data: RegisteredNodeUpdateData): void;
+}>();
+
+/* Handlers */
+const handleRegisteredNodeDataUpdate = (data: RegisteredNodeData) => {
+  emit('update:data', {
+    ...props.data,
+    ...data,
+  });
+};
+</script>
+
+<template>
+  <!-- Registered Node ID -->
+  <div class="form-group mt-6 col-8 col-xxxl-6">
+    <label class="form-label">Registered Node ID <span class="text-danger">*</span></label>
+    <AppInput
+      :model-value="data.registeredNodeId"
+      @update:model-value="
+        emit('update:data', {
+          ...data,
+          registeredNodeId: $event,
+        })
+      "
+      maxlength="2"
+      class="form-control is-fill"
+      placeholder="Enter Registered Node ID"
+    />
+  </div>
+
+  <RegisteredNodeFormData :data="data" @update:data="handleRegisteredNodeDataUpdate" />
+</template>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeUpdate/index.ts
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeUpdate/index.ts
@@ -1,0 +1,2 @@
+import RegisteredNodeUpdate from './RegisteredNodeUpdate.vue';
+export default RegisteredNodeUpdate;

--- a/front-end/src/renderer/components/Transaction/Create/txTypeComponentMapping.ts
+++ b/front-end/src/renderer/components/Transaction/Create/txTypeComponentMapping.ts
@@ -12,6 +12,7 @@ import NodeCreate from './NodeCreate';
 import NodeDelete from './NodeDelete';
 import NodeUpdate from './NodeUpdate';
 import RegisteredNodeCreate from './RegisteredNodeCreate';
+import RegisteredNodeUpdate from './RegisteredNodeUpdate';
 import RegisteredNodeDelete from './RegisteredNodeDelete';
 import SystemDelete from './SystemDelete';
 import SystemUndelete from './SystemUndelete';
@@ -32,6 +33,7 @@ export const transactionTypeKeys = {
   nodeDelete: 'NodeDeleteTransaction',
   nodeUpdate: 'NodeUpdateTransaction',
   registeredNodeCreate: 'RegisteredNodeCreateTransaction',
+  registeredNodeUpdate: 'RegisteredNodeUpdateTransaction',
   registeredNodeDelete: 'RegisteredNodeDeleteTransaction',
   systemDelete: 'SystemDeleteTransaction',
   systemUndelete: 'SystemUndeleteTransaction',
@@ -52,6 +54,7 @@ const txTypeComponentMapping = {
   [transactionTypeKeys.nodeDelete]: NodeDelete,
   [transactionTypeKeys.nodeUpdate]: NodeUpdate,
   [transactionTypeKeys.registeredNodeCreate]: RegisteredNodeCreate,
+  [transactionTypeKeys.registeredNodeUpdate]: RegisteredNodeUpdate,
   [transactionTypeKeys.registeredNodeDelete]: RegisteredNodeDelete,
   [transactionTypeKeys.systemDelete]: SystemDelete,
   [transactionTypeKeys.systemUndelete]: SystemUndelete,

--- a/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
@@ -9,6 +9,7 @@ import {
   KeyList,
   PublicKey,
   RegisteredNodeCreateTransaction,
+  RegisteredNodeUpdateTransaction,
   RegisteredNodeDeleteTransaction,
   Transaction,
 } from '@hiero-ledger/sdk';
@@ -36,6 +37,7 @@ onBeforeMount(() => {
   if (
     !(
       props.transaction instanceof RegisteredNodeCreateTransaction ||
+      props.transaction instanceof RegisteredNodeUpdateTransaction ||
       props.transaction instanceof RegisteredNodeDeleteTransaction
     )
   ) {
@@ -51,17 +53,26 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
 
 <template>
   <div class="mt-5 row flex-wrap">
-
     <!-- Registered Node ID -->
-    <div v-if="transaction instanceof RegisteredNodeDeleteTransaction" :class="commonColClass">
+    <div
+      v-if="
+        transaction instanceof RegisteredNodeUpdateTransaction ||
+        transaction instanceof RegisteredNodeDeleteTransaction
+      "
+      :class="commonColClass"
+    >
       <h4 :class="detailItemLabelClass">Registered Node ID</h4>
       <p :class="detailItemValueClass" data-testid="p-node-details-node-id">
         {{ transaction.registeredNodeId?.toString() ?? '' }}
       </p>
     </div>
 
-    <template v-if="transaction instanceof RegisteredNodeCreateTransaction">
-
+    <template
+      v-if="
+        transaction instanceof RegisteredNodeCreateTransaction ||
+        transaction instanceof RegisteredNodeUpdateTransaction
+      "
+    >
       <!-- Description -->
       <div v-if="transaction.description" :class="commonColClass">
         <h4 :class="detailItemLabelClass">Description</h4>
@@ -92,7 +103,10 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
       </div>
 
       <!-- Service Endpoints -->
-      <div v-if="transaction.serviceEndpoints.length > 0" class="col-12 my-3">
+      <div
+        v-if="transaction.serviceEndpoints !== null && transaction.serviceEndpoints.length > 0"
+        class="col-12 my-3"
+      >
         <h4 :class="detailItemLabelClass">Service Endpoints</h4>
         <table class="table-custom">
           <thead class="thin">

--- a/front-end/src/renderer/components/Transaction/Details/txTypeComponentMapping.ts
+++ b/front-end/src/renderer/components/Transaction/Details/txTypeComponentMapping.ts
@@ -26,6 +26,7 @@ export const transactionTypeKeys = {
   nodeUpdate: 'NodeUpdateTransaction',
   nodeDelete: 'NodeDeleteTransaction',
   registeredNodeCreate: 'RegisteredNodeCreateTransaction',
+  registeredNodeUpdate: 'RegisteredNodeUpdateTransaction',
   registeredNodeDelete: 'RegisteredNodeDeleteTransaction',
 };
 
@@ -45,6 +46,7 @@ const txTypeComponentMapping = {
   [transactionTypeKeys.nodeUpdate]: NodeDetails,
   [transactionTypeKeys.nodeDelete]: NodeDetails,
   [transactionTypeKeys.registeredNodeCreate]: RegisteredNodeDetails,
+  [transactionTypeKeys.registeredNodeUpdate]: RegisteredNodeDetails,
   [transactionTypeKeys.registeredNodeDelete]: RegisteredNodeDetails,
 };
 

--- a/front-end/src/renderer/components/TransactionSelectionModal.vue
+++ b/front-end/src/renderer/components/TransactionSelectionModal.vue
@@ -63,6 +63,10 @@ const transactionGroups = computed<MenuGroup[]>(() => {
           name: transactionTypeKeys.registeredNodeCreate,
         },
         {
+          label: 'Registered Node Update',
+          name: transactionTypeKeys.registeredNodeUpdate,
+        },
+        {
           label: 'Registered Node Delete',
           name: transactionTypeKeys.registeredNodeDelete,
         },

--- a/front-end/src/renderer/utils/sdk/createTransactions.ts
+++ b/front-end/src/renderer/utils/sdk/createTransactions.ts
@@ -24,6 +24,7 @@ import {
   NodeDeleteTransaction,
   NodeUpdateTransaction,
   RegisteredNodeCreateTransaction,
+  RegisteredNodeUpdateTransaction,
   RegisteredNodeDeleteTransaction,
   RegisteredServiceEndpoint,
   RpcRelayServiceEndpoint,
@@ -167,6 +168,13 @@ export interface ComponentRegisteredServiceEndpoint extends ComponentServiceEndp
 }
 
 export type RegisteredNodeData = {
+  description: string;
+  adminKey: Key | null;
+  serviceEndpoints: ComponentRegisteredServiceEndpoint[];
+};
+
+export type RegisteredNodeUpdateData = {
+  registeredNodeId: string;
   description: string;
   adminKey: Key | null;
   serviceEndpoints: ComponentRegisteredServiceEndpoint[];
@@ -731,6 +739,32 @@ export function createRegisteredNodeCreateTransaction(
 ): RegisteredNodeCreateTransaction {
   const transaction = new RegisteredNodeCreateTransaction();
   setTransactionCommonData(transaction, data);
+
+  if (data.adminKey) {
+    transaction.setAdminKey(data.adminKey);
+  }
+
+  if (data.description && data.description.length > 0) {
+    transaction.setDescription(data.description);
+  }
+
+  const endpoints = getRegisteredServiceEndpoints(data.serviceEndpoints);
+  if (endpoints.length > 0) {
+    transaction.setServiceEndpoints(endpoints);
+  }
+
+  return transaction;
+}
+
+export function createRegisteredNodeUpdateTransaction(
+  data: TransactionCommonData & RegisteredNodeUpdateData,
+): RegisteredNodeUpdateTransaction {
+  const transaction = new RegisteredNodeUpdateTransaction();
+  setTransactionCommonData(transaction, data);
+
+  if (data.registeredNodeId) {
+    transaction.setRegisteredNodeId(Long.fromString(data.registeredNodeId));
+  }
 
   if (data.adminKey) {
     transaction.setAdminKey(data.adminKey);

--- a/front-end/src/renderer/utils/sdk/getData.ts
+++ b/front-end/src/renderer/utils/sdk/getData.ts
@@ -1,12 +1,4 @@
 import {
-  ServiceEndpoint,
-  SystemDeleteTransaction,
-  SystemUndeleteTransaction,
-  Timestamp,
-  type Transaction,
-} from '@hiero-ledger/sdk';
-
-import {
   AccountAllowanceApproveTransaction,
   AccountCreateTransaction,
   AccountDeleteTransaction,
@@ -25,8 +17,14 @@ import {
   NodeUpdateTransaction,
   RegisteredNodeCreateTransaction,
   RegisteredNodeDeleteTransaction,
+  RegisteredNodeUpdateTransaction,
   type RegisteredServiceEndpoint,
   RpcRelayServiceEndpoint,
+  ServiceEndpoint,
+  SystemDeleteTransaction,
+  SystemUndeleteTransaction,
+  Timestamp,
+  type Transaction,
   TransferTransaction,
 } from '@hiero-ledger/sdk';
 
@@ -49,6 +47,7 @@ import type {
   RegisteredEndpointType,
   RegisteredNodeData,
   RegisteredNodeDeleteData,
+  RegisteredNodeUpdateData,
   SystemData,
   SystemDeleteData,
   SystemUndeleteData,
@@ -323,7 +322,7 @@ const getRegisteredEndpointType = (
  * `transactionsDataMatch` produce mismatched JSON (uiIds are freshly generated
  * per call), spuriously marking every loaded draft as "unsaved".
  */
-const getComponentRegisteredEndpoint = (
+export const getComponentRegisteredEndpoint = (
   endpoint: RegisteredServiceEndpoint,
 ): ComponentRegisteredServiceEndpoint => {
   const ipBytes = endpoint.ipAddress;
@@ -348,6 +347,11 @@ const getComponentRegisteredEndpoint = (
   return base;
 };
 
+export const getComponentRegisteredEndpoints = (endpoints: RegisteredServiceEndpoint[]):
+  ComponentRegisteredServiceEndpoint[] => {
+  return endpoints.map(endpoint => getComponentRegisteredEndpoint(endpoint));
+};
+
 export function getRegisteredNodeData(transaction: Transaction): RegisteredNodeData {
   assertTransactionType(transaction, RegisteredNodeCreateTransaction);
 
@@ -356,6 +360,19 @@ export function getRegisteredNodeData(transaction: Transaction): RegisteredNodeD
   );
 
   return {
+    description: transaction.description ?? '',
+    adminKey: transaction.adminKey ?? null,
+    serviceEndpoints: endpoints,
+  };
+}
+
+export function getRegisteredNodeUpdateData(transaction: Transaction): RegisteredNodeUpdateData {
+  assertTransactionType(transaction, RegisteredNodeUpdateTransaction);
+
+  const endpoints = (transaction.serviceEndpoints ?? []).map(getComponentRegisteredEndpoint);
+
+  return {
+    registeredNodeId: transaction.registeredNodeId?.toString() ?? '',
     description: transaction.description ?? '',
     adminKey: transaction.adminKey ?? null,
     serviceEndpoints: endpoints,
@@ -500,6 +517,14 @@ const transactionHandlers = new Map<
     tx => ({
       ...getTransactionCommonData(tx),
       ...getRegisteredNodeData(tx),
+    }),
+  ],
+
+  [
+    RegisteredNodeUpdateTransaction,
+    tx => ({
+      ...getTransactionCommonData(tx),
+      ...getRegisteredNodeUpdateData(tx),
     }),
   ],
 

--- a/front-end/src/renderer/utils/sdk/transactions.ts
+++ b/front-end/src/renderer/utils/sdk/transactions.ts
@@ -14,6 +14,7 @@ import {
   NodeDeleteTransaction,
   NodeUpdateTransaction,
   RegisteredNodeCreateTransaction,
+  RegisteredNodeUpdateTransaction,
   RegisteredNodeDeleteTransaction,
   SystemDeleteTransaction,
   SystemUndeleteTransaction,
@@ -106,6 +107,8 @@ export const getTransactionType = (
     transactionType = 'Node Delete Transaction';
   } else if (transaction instanceof RegisteredNodeCreateTransaction) {
     transactionType = 'Registered Node Create Transaction';
+  } else if (transaction instanceof RegisteredNodeUpdateTransaction) {
+    transactionType = 'Registered Node Update Transaction';
   } else if (transaction instanceof RegisteredNodeDeleteTransaction) {
     transactionType = 'Registered Node Delete Transaction';
   } else if (transaction instanceof SystemDeleteTransaction) {

--- a/front-end/src/renderer/utils/transactionSignatureModels/index.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/index.ts
@@ -16,6 +16,7 @@ export * from './file-append-transaction.model';
 export * from './file-update-transaction.model';
 export * from './freeze-transaction.model';
 export * from './registered-node-create-transaction.model';
+export * from './registered-node-update-transaction.model';
 export * from './registered-node-delete-transaction.model';
 export * from './system-delete-transaction.model';
 export * from './transaction-factory';

--- a/front-end/src/renderer/utils/transactionSignatureModels/registered-node-update-transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/registered-node-update-transaction.model.ts
@@ -1,0 +1,47 @@
+import { Key, RegisteredNodeUpdateTransaction } from '@hiero-ledger/sdk';
+
+import { TransactionBaseModel } from './transaction.model';
+import type { AccountByIdCache } from '@renderer/caches/mirrorNode/AccountByIdCache';
+import type { RegisteredNodeByIdCache } from '@renderer/caches/mirrorNode/RegisteredNodeByIdCache';
+import { createLogger } from '@renderer/utils/logger';
+
+const logger = createLogger('renderer.transaction.signatureModel.registerNodeDelete');
+
+export default class RegisteredNodeUpdateTransactionModel extends TransactionBaseModel<RegisteredNodeUpdateTransaction> {
+  override async getRegisteredNodeKeys(
+    mirrorNodeLink: string,
+    _accountInfoCache: AccountByIdCache,
+    registeredNodeInfoCache: RegisteredNodeByIdCache,
+  ): Promise<{ registeredNodeId: number; key: Key } | null> {
+    const registeredNodeId = this.transaction.registeredNodeId?.toNumber() ?? null;
+
+    try {
+      if (registeredNodeId == null) {
+        return null;
+      }
+
+      const registeredNodeInfo = await registeredNodeInfoCache.lookup(
+        registeredNodeId,
+        mirrorNodeLink,
+      );
+
+      if (registeredNodeInfo === null) {
+        logger.warn(`No node info found for node ${registeredNodeId}`);
+        return null;
+      }
+
+      if (registeredNodeInfo.admin_key === null) {
+        logger.warn(`No admin key found for node ${registeredNodeId}`);
+        return null;
+      }
+
+      return { registeredNodeId, key: registeredNodeInfo.admin_key };
+    } catch (error) {
+      logger.warn('Failed to resolve node admin signing key', {
+        error,
+        registeredNodeId,
+      });
+      throw error;
+    }
+  }
+}

--- a/front-end/src/renderer/utils/transactionSignatureModels/transaction-factory.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/transaction-factory.ts
@@ -15,6 +15,7 @@ import NodeCreateTransactionModel from './node-create-transaction.model';
 import NodeUpdateTransactionModel from './node-update-transaction.model';
 import NodeDeleteTransactionModel from './node-delete-transaction.model';
 import RegisteredNodeCreateTransactionModel from './registered-node-create-transaction.model';
+import RegisteredNodeUpdateTransactionModel from './registered-node-update-transaction.model';
 import RegisteredNodeDeleteTransactionModel from './registered-node-delete-transaction.model';
 import { getTransactionType } from '../sdk/transactions';
 
@@ -41,6 +42,7 @@ export default class TransactionFactory {
       NodeUpdateTransaction: NodeUpdateTransactionModel,
       NodeDeleteTransaction: NodeDeleteTransactionModel,
       RegisteredNodeCreateTransaction: RegisteredNodeCreateTransactionModel,
+      RegisteredNodeUpdateTransaction: RegisteredNodeUpdateTransactionModel,
       RegisteredNodeDeleteTransaction: RegisteredNodeDeleteTransactionModel,
     };
 


### PR DESCRIPTION
**Description**:

Changes below:
- add `Registered Node Update` transaction to `Create Transaction` modal
- enable `Draft Creation` form to create a `RegisteredNodeUpdate` transaction
- enable `TransactionDetails` page to display specific info to `RegisteredNodeUpdate` transaction

In addition they fix a latent issue in `NodeUpdate.vue`.

***New `Registered Node Delete` command in `Transaction Selection` modal:***
<img width="758" height="460" alt="image" src="https://github.com/user-attachments/assets/6f48891d-c9f0-4e74-84eb-447b8f240522" />

***Form for creating Registered Node Update transaction:***
<img width="1465" height="1306" alt="image" src="https://github.com/user-attachments/assets/5871b32f-ec81-4486-b874-c1a6dafc70d4" />


***Transaction Details for registered node update transaction:***
<img width="1465" height="1248" alt="image" src="https://github.com/user-attachments/assets/5cc1adcc-c641-4c8a-abd1-bddc3ecf1942" />

**Related issue(s)**:

Fixes #2888 
Fixes #2827

**Notes for reviewer**:

```
M   front-end/src/renderer/components/TransactionSelectionModal.vue
    # Adds 'Registered Node Update' command to Transaction Type selection modal.

A   front-end/src/renderer/components/Transaction/Create/RegisteredNodeUpdate/RegisteredNodeUpdate.vue
A   front-end/src/renderer/components/Transaction/Create/RegisteredNodeUpdate/RegisteredNodeUpdateFormData.vue
A   front-end/src/renderer/components/Transaction/Create/RegisteredNodeUpdate/index.ts
M   front-end/src/renderer/components/Transaction/Create/txTypeComponentMapping.ts
M   front-end/src/renderer/utils/sdk/createTransactions.ts
M   front-end/src/renderer/utils/sdk/getData.ts
M   front-end/src/renderer/utils/sdk/transactions.ts
    # Enables draft editor to create and update RegisteredNodeUpdateTransaction.

M   front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
M   front-end/src/renderer/components/Transaction/Details/txTypeComponentMapping.ts
M   front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserPage.vue
    # Enables transaction details and TransactionBrowserPage to display RegisteredNodeUpdateTransaction.

A   front-end/src/renderer/utils/transactionSignatureModels/registered-node-update-transaction.model.ts
M   front-end/src/renderer/utils/transactionSignatureModels/index.ts
M   front-end/src/renderer/utils/transactionSignatureModels/transaction-factory.ts
    # New transaction model for RegisterdNodeUpdateTransaction.

M   front-end/src/renderer/components/Transaction/Create/NodeUpdate/NodeUpdate.vue
    # handleUpdateData() now avoids to send NaN to mirror node 
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
