### PR TITLE
fix: Modal not appearing on subsequent "Remove" attempts

### DIFF
--- a/front-end/src/renderer/components/Contacts/DeleteContactModal.vue
+++ b/front-end/src/renderer/components/Contacts/DeleteContactModal.vue
@@ -1,33 +1,18 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
-
 import AppCustomIcon from '@renderer/components/ui/AppCustomIcon.vue';
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppModal from '@renderer/components/ui/AppModal.vue';
 
 /* Props */
-const props = defineProps<{
-  show: boolean;
-}>();
+const show = defineModel<boolean>('show', { required: true });
 
 /* Emits */
-const emit = defineEmits(['update:show', 'update:delete']);
-
-/* State */
-const show = ref(props.show);
-
-/* Watchers */
-watch(
-  () => props.show,
-  value => {
-    show.value = value;
-  },
-);
+const emit = defineEmits(['update:delete']);
 
 /* Handlers */
 function handleDeleteAccount() {
   emit('update:delete');
-  emit('update:show', false);
+  show.value = false;
 }
 </script>
 <template>
@@ -43,7 +28,7 @@ function handleDeleteAccount() {
       <hr class="separator my-5" />
       <div class="row mt-4">
         <div class="col-6">
-          <AppButton color="borderless" class="w-100" @click="emit('update:show', false)"
+          <AppButton color="borderless" class="w-100" @click="show=false"
             >Cancel</AppButton
           >
         </div>


### PR DESCRIPTION
**Description**:
Root cause is duplicated and ambiguous `props.show` and `show` `Ref` in `DeleteContactModal.vue`.
Replacing both by a single `show` `v-model` fixes the issue.

**Related issue(s)**:

Fixes #1563

**Notes for reviewer**:

```
M   front-end/src/renderer/components/Contacts/DeleteContactModal.vue
    # Replaced combination of ambiguous props.show and Ref<show> by a single show v-model.

```
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
