### PR TITLE
fix: recover gracefully when the macOS Keychain Deny (part 1)

### DIFF
--- a/front-end/src/renderer/pages/UserLogin/components/KeychainOption.vue
+++ b/front-end/src/renderer/pages/UserLogin/components/KeychainOption.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 
 import useUserStore from '@renderer/stores/storeUser';
+import useSafeStorage, { SafeStorageStatus } from '@renderer/stores/storeSafeStorage.js';
 
 import useSetupStores from '@renderer/composables/user/useSetupStores';
 
 import {
-  encrypt,
   getStaticUser,
   initializeUseKeychain,
   isKeychainAvailable,
@@ -16,6 +16,7 @@ import AppButton from '@renderer/components/ui/AppButton.vue';
 
 /* Stores */
 const user = useUserStore();
+const safeStorage = useSafeStorage();
 
 /* Composables */
 const setupStores = useSetupStores();
@@ -23,16 +24,25 @@ const setupStores = useSetupStores();
 /* State */
 const show = ref(false);
 
+/* Computed */
+const safeStorageDenied = computed(() => safeStorage.status === SafeStorageStatus.denied);
+
 /* Handlers */
 const handleUseKeychain = async () => {
-  await initializeUseKeychain(true);
+  if ((await safeStorage.encryptString('gain_access')) !== null) {
+    // We have access to safe storage (ie keychain)
+    try {
+      await initializeUseKeychain(true);
+    } catch {
+      // Must be ignored
+    }
 
-  await encrypt('gain_access');
-  const staticUser = await getStaticUser();
-  user.setAccountSetupStarted(true);
-  await user.login(staticUser.id, staticUser.email, true);
-  await user.refetchOrganizations();
-  await setupStores();
+    const staticUser = await getStaticUser();
+    user.setAccountSetupStarted(true);
+    await user.login(staticUser.id, staticUser.email, true);
+    await user.refetchOrganizations();
+    await setupStores();
+  }
 };
 
 /* Hooks */
@@ -45,11 +55,21 @@ onMounted(async () => {
 });
 </script>
 <template>
-  <div v-if="show" class="d-grid">
+  <div v-if="show" class="d-flex flex-column align-content-center align-items-stretch">
     <AppButton
       color="secondary"
       data-testid="button-keychain-login"
       @click="handleUseKeychain"
-    >Sign in with Keychain</AppButton>
+      :disabled="safeStorageDenied"
+      >Sign in with Keychain</AppButton
+    >
+    <p
+      v-if="safeStorageDenied"
+      class="text-micro text-secondary text-center align-self-center mt-3 mb-3"
+      style="max-width: 300px"
+    >
+      Sign In with Keychain is disabled.<br />
+      You need to restart the application, sign with Keychain again and authorize Keychain access.
+    </p>
   </div>
 </template>

--- a/front-end/src/renderer/stores/storeSafeStorage.ts
+++ b/front-end/src/renderer/stores/storeSafeStorage.ts
@@ -1,0 +1,60 @@
+import { ref, type Ref } from 'vue';
+import { defineStore } from 'pinia';
+import { decrypt, encrypt } from '@renderer/services/safeStorageService';
+
+export enum SafeStorageStatus {
+  notDetermined,
+  denied,
+  authorized,
+}
+
+export interface SafeStorageStore {
+  status: Ref<SafeStorageStatus>;
+  encryptString(data: string): Promise<string | null>;
+  decryptString(data: string, encoding?: BufferEncoding): Promise<string | null>;
+}
+
+export default defineStore('safeStorage', (): SafeStorageStore => {
+  const status = ref(SafeStorageStatus.notDetermined);
+
+  const deniedMessage = 'Encryption is not available';
+  const encryptString = async (data: string): Promise<string | null> => {
+    let result: string | null;
+    try {
+      result = await encrypt(data);
+      status.value = SafeStorageStatus.authorized;
+    } catch (error) {
+      if (error instanceof Error && error.message.includes(deniedMessage)) {
+        // User has denied keychain usage
+        result = null;
+        status.value = SafeStorageStatus.denied;
+      } else {
+        throw error;
+      }
+    }
+    return Promise.resolve(result);
+  };
+
+  const decryptString = async (data: string, encoding?: BufferEncoding): Promise<string | null> => {
+    let result: string | null;
+    try {
+      result = await decrypt(data, encoding);
+      status.value = SafeStorageStatus.authorized;
+    } catch (error) {
+      if (error instanceof Error && error.message.includes(deniedMessage)) {
+        // User has denied keychain usage
+        result = null;
+        status.value = SafeStorageStatus.denied;
+      } else {
+        throw error;
+      }
+    }
+    return Promise.resolve(result);
+  };
+
+  return {
+    status,
+    encryptString,
+    decryptString,
+  };
+});


### PR DESCRIPTION
**Description**:
Changes below make sure that TT correctly react when `Register` dialog is presented and user denies access to macOS Keychain.

Starting from a fully clean install, user is first presented the `Register` dialog:

<img width="510" height="695" alt="image" src="https://github.com/user-attachments/assets/e5951ed4-0d54-477b-863d-b69bb7c8366d" />

Then user clicks on Sign with Keychain and macOS informs the user that TT is trying to access the Keychain and ask if this access should be authorized (`Autoriser`) or denied (`Refuser`):

<img width="510" height="690" alt="image" src="https://github.com/user-attachments/assets/8f66e624-db92-41c5-8409-8dcd3400fe5e" />

If user denies access to Keychain (ie clicks on `Refuser`), then `Register` dialog remains open and informs user:

<img width="510" height="690" alt="image" src="https://github.com/user-attachments/assets/bc5b8056-a9ca-4ca2-9a19-2a0d72ef5121" />

User has now two options:
   1) `Sign Up` with e-mail and password
   2) Restart the application, `Sign with Keychain` again AND AUTHORIZE access to keychain


**Related issue(s)**:

First part of #2800

**Notes for reviewer**:

```
A   front-end/src/renderer/stores/storeSafeStorage.ts
    # new store which encapsulates calls to safe storage.
    # and maintains an authorization status : notDetermined, denied and authorized.

M   front-end/src/renderer/pages/UserLogin/components/KeychainOption.vue
    # KeychainOption view now uses storeSafeStorage and provides user feedback when keychain access is denied.
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
