### PR TITLE
fix: recover gracefully when the macOS Keychain Deny (part 2)

### DIFF
--- a/front-end/src/renderer/pages/Migrate/components/SetupPersonalForm.vue
+++ b/front-end/src/renderer/pages/Migrate/components/SetupPersonalForm.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeMount, onMounted, reactive, ref, watch } from 'vue';
 
-import { encrypt, isKeychainAvailable } from '@renderer/services/safeStorageService';
+import { initializeUseKeychain, isKeychainAvailable } from '@renderer/services/safeStorageService';
 
 import { isEmail, isPasswordStrong } from '@renderer/utils';
 
@@ -9,6 +9,7 @@ import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppInput from '@renderer/components/ui/AppInput.vue';
 import AppPasswordInput from '@renderer/components/ui/AppPasswordInput.vue';
 import AppSeparator from '@renderer/components/ui/AppSeparator.vue';
+import useSafeStorage, { SafeStorageStatus } from '@renderer/stores/storeSafeStorage.ts';
 
 /* Types */
 export type ModelValue =
@@ -33,6 +34,9 @@ const emit = defineEmits<{
   (event: 'submit', value: ModelValue): void;
   (event: 'migration:cancel'): void;
 }>();
+
+/* Stores */
+const safeStorage = useSafeStorage();
 
 /* State */
 const keychainSelected = ref(false);
@@ -60,6 +64,7 @@ const tooltipContent = computed(
     </div>
   `,
 );
+const safeStorageDenied = computed(() => safeStorage.status === SafeStorageStatus.denied);
 
 /* Handlers */
 const handleOnFormSubmit = async () => {
@@ -84,20 +89,21 @@ const handleOnFormSubmit = async () => {
 const handleCancel = () => emit('migration:cancel');
 
 const handleUseKeychain = async () => {
-  const keychainAvailable = await isKeychainAvailable();
+  if ((await safeStorage.encryptString('gain_access')) !== null) {
+    // We have access to safe storage (ie keychain)
+    try {
+      await initializeUseKeychain(true);
+    } catch {
+      // Must be ignored
+    }
 
-  if (!keychainAvailable) {
-    throw Error('Keychain not available');
+    keychainSelected.value = true;
+    emit('submit', {
+      useKeychain: true,
+      email: null,
+      password: null,
+    });
   }
-
-  await encrypt('gain_access');
-
-  keychainSelected.value = true;
-  emit('submit', {
-    useKeychain: true,
-    email: null,
-    password: null,
-  });
 };
 
 /* Functions */
@@ -185,7 +191,7 @@ watch(inputPassword, pass => {
     <template v-if="keychainAvailable">
       <AppSeparator class="my-5" text="or" />
 
-      <div class="d-grid">
+      <div class="d-flex flex-column align-content-center align-items-stretch">
         <AppButton
           color="secondary"
           type="button"
@@ -193,8 +199,18 @@ watch(inputPassword, pass => {
           loading-text="Migrating..."
           :loading="loading && keychainSelected"
           data-testid="button-setup-personal-keychain"
+          :disabled="safeStorageDenied"
           >Continue with Keychain</AppButton
         >
+        <p
+          v-if="safeStorageDenied"
+          class="text-micro text-secondary text-center align-self-center mt-3 mb-3"
+          style="max-width: 300px"
+        >
+          Continue with Keychain is disabled.<br />
+          You need to restart the application, start data migration again and authorize Keychain
+          access.
+        </p>
       </div>
     </template>
 


### PR DESCRIPTION
**Description**:
This is the second part for fixing #2800 and a follow-up of #2899.

When user starts from a fresh install and choose data migration, `Personal Information` dialog is displayed:

<img width="510" height="690" alt="image" src="https://github.com/user-attachments/assets/99a5b5fd-4853-45e9-8b34-9325178b882c" />

Then user clicks on `Continue with Keychain` and macOS informs the user that TT is trying to access the Keychain and ask if this access should be authorized (`Autoriser`) or denied (`Refuser`):

<img width="510" height="690" alt="image" src="https://github.com/user-attachments/assets/c941c14d-3179-473d-945d-d61326b554cc" />

If user denies access to Keychain (ie clicks on `Refuser`), then `Personal Information` dialog remains open and informs user:

<img width="510" height="690" alt="image" src="https://github.com/user-attachments/assets/88221c7e-9acd-45c9-8545-732910dc0190" />

User has now two options:
1) `Cancel` and continue registering process and `Sign Up` with e-mail and password
2) Restart the application, choose data migration again AND AUTHORIZE access to keychain

**Related issue(s)**:

Fixes #2800

**Notes for reviewer**:

The following scenario enables to make (at the same time) `Personal Information` dialog appear and trigger macOS Keychain authorization dialog (and thus see the effect this  PR):

0) Check that you have TTv1 data to migrate in your $HOME folder

1) Reset TTv2 installation
1.1) Exit TTv2 if needed
1.2) Remove `$HOME/Library/Application Support/hedera-transaction-tool`
1.3) Starts `Keychain Access`
1.3.1) Search for 'hedera'
1.3.2) Remove `hedera-transaction-tool Safe Storage` entry

2) Initialize TTv2 and exit application
2.1) Start TTv2
2.2) Click `I Understand and Agree` in `Important note` dialog
2.3) Click `No` if TTv2 proposes to `migrate data` from TTv1
2.4) Click `Sign in with KeyChain` in `Register` dialog
2.5) Click `Skip` in `Account Setup` dialog
        => `History` tab is displayed and empty
2.6) Exit TTv2

3) Patch Keychain ACL using `Keychain Access`
3.1) Start `Keychain Access`
3.2) Search for 'hedera'
3.3) Select `hedera-transaction-tool Safe Storage` entry
3.4) `File` > `Get Info`
3.5) Navigate to `Access Control` tab
3.6) Remove `Hedera Transaction Tool` item from application list
3.7) Click `Save Changes`
3.8) Exit `Keychain Access`

4) Start TTv2 and reset application
4.1) Start TTv2
4.2) Navigate to `Settings` > `Profile`
       => `Reset Application` section is displayed
4.3) Click `Reset` button and confirm
       => TTv2 initialization process starts again
       => TTv2 proposes to migrate data
4.4) Click `Yes`
        => `Recovery Phrase Password` dialog appears
4.5) Click `Skip`
        => `Personal Information` dialog appears
4.6) Click `Continue with KeyChain`
       => macOS displays the keychain authorization dialog 👍 👍 👍
4.7) Click `Deny`
       => `Personal Information` dialog remains open and informs user
       => `Continue with Keychain` button is now disabled
       => Some inline help is now available just below the button

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
