### PR TITLE
feat: improving user feedback of Payer ID field in Draft creation

### DIFF
--- a/front-end/src/renderer/components/AccountIdInput.vue
+++ b/front-end/src/renderer/components/AccountIdInput.vue
@@ -17,6 +17,7 @@ import {
 
 import { ITEM_SEPARATOR } from '@renderer/components/ui/AppAutoComplete.vue';
 import AppAutoComplete from '@renderer/components/ui/AppAutoComplete.vue';
+import { compareAccountIds } from '@renderer/utils/sortAccounts';
 
 /* Props */
 const props = defineProps<{
@@ -45,10 +46,11 @@ const formattedAccountIds = computed(() => {
     result = props.items;
   } else {
     const linkedAccounts = accountIds.value.map(a => a.account_id);
-    const ownedAccounts = user.publicKeysToAccountsFlattened
-    result = linkedAccounts.sort()
+    const ownedAccounts = user.publicKeysToAccountsFlattened;
+    result = linkedAccounts
       .concat(linkedAccounts.length > 0 && ownedAccounts.length > 0 ? [ITEM_SEPARATOR] : [])
-      .concat(ownedAccounts.sort());
+      .concat(ownedAccounts);
+    result.sort(compareAccountIds);
   }
   if (props.isNodeCreationPrivRequired) {
     // We keep privileged accounts only

--- a/front-end/src/renderer/components/AccountIdInput.vue
+++ b/front-end/src/renderer/components/AccountIdInput.vue
@@ -47,10 +47,17 @@ const formattedAccountIds = computed(() => {
   } else {
     const linkedAccounts = accountIds.value.map(a => a.account_id);
     const ownedAccounts = user.publicKeysToAccountsFlattened;
-    result = linkedAccounts
-      .concat(linkedAccounts.length > 0 && ownedAccounts.length > 0 ? [ITEM_SEPARATOR] : [])
-      .concat(ownedAccounts);
-    result.sort(compareAccountIds);
+    linkedAccounts.sort(compareAccountIds);
+    ownedAccounts.sort(compareAccountIds);
+    if (linkedAccounts.length > 0 && ownedAccounts.length > 0) {
+      result = linkedAccounts.concat([ITEM_SEPARATOR]).concat(ownedAccounts);
+    } else if (linkedAccounts.length > 0) {
+      result = linkedAccounts;
+    } else if (ownedAccounts.length > 0) {
+      result = ownedAccounts;
+    } else {
+      result = [];
+    }
   }
   if (props.isNodeCreationPrivRequired) {
     // We keep privileged accounts only

--- a/front-end/src/renderer/components/AccountIdInput.vue
+++ b/front-end/src/renderer/components/AccountIdInput.vue
@@ -8,7 +8,12 @@ import useNetworkStore from '@renderer/stores/storeNetwork';
 
 import { getAll } from '@renderer/services/accountsService';
 
-import { formatAccountId, getAccountIdWithChecksum, isUserLoggedIn } from '@renderer/utils';
+import {
+  formatAccountId,
+  getAccountIdWithChecksum,
+  isNodeCreationAuthorizedFeePayer,
+  isUserLoggedIn,
+} from '@renderer/utils';
 
 import { ITEM_SEPARATOR } from '@renderer/components/ui/AppAutoComplete.vue';
 import AppAutoComplete from '@renderer/components/ui/AppAutoComplete.vue';
@@ -18,6 +23,7 @@ const props = defineProps<{
   modelValue: string;
   items?: string[];
   dataTestid?: string;
+  isNodeCreationPrivRequired?: boolean;
 }>();
 
 /* Emits */
@@ -43,6 +49,10 @@ const formattedAccountIds = computed(() => {
     result = linkedAccounts.sort()
       .concat(linkedAccounts.length > 0 && ownedAccounts.length > 0 ? [ITEM_SEPARATOR] : [])
       .concat(ownedAccounts.sort());
+  }
+  if (props.isNodeCreationPrivRequired) {
+    // We keep privileged accounts only
+    result = result.filter(accountId => isNodeCreationAuthorizedFeePayer(accountId));
   }
   return result.map(id => getAccountIdWithChecksum(id));
 });

--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
@@ -22,6 +22,8 @@ import {
   FileUpdateTransaction,
   Hbar,
   KeyList,
+  NodeCreateTransaction,
+  RegisteredNodeCreateTransaction,
   Timestamp,
   Transaction,
   TransactionId,
@@ -166,6 +168,13 @@ const hasDescriptionChanged = computed(() => {
 
 const hasDataChanged = computed(() => hasTransactionChanged.value || hasDescriptionChanged.value);
 
+const isNodeCreationPrivRequired = computed(() => {
+  return (
+    initialTransaction.value instanceof NodeCreateTransaction ||
+    initialTransaction.value instanceof RegisteredNodeCreateTransaction
+  );
+});
+
 /* Handlers */
 const handleDraftLoaded = async (transaction: Transaction) => {
   initialTransaction.value = transaction;
@@ -198,9 +207,7 @@ const handleCreate = async () => {
           if (nanoOffset === 0) return initialTx.toBytes();
           const offsetTimestamp = applyNanoOffset(baseValidStart, nanoOffset);
           const retryTx = createTransaction(capturedData);
-          retryTx.setTransactionId(
-            TransactionId.withValidStart(payerAccountId, offsetTimestamp),
-          );
+          retryTx.setTransactionId(TransactionId.withValidStart(payerAccountId, offsetTimestamp));
           return retryTx.toBytes();
         }
       : undefined;
@@ -420,6 +427,7 @@ defineExpose({
           @update:payer-id="handlePayerIdUpdate"
           v-model:valid-start="data.validStart"
           v-model:max-transaction-fee="data.maxTransactionFee as Hbar"
+          :is-node-creation-priv-required="isNodeCreationPrivRequired"
         />
 
         <div class="row mt-6">

--- a/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
@@ -13,7 +13,7 @@ import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts
 
 import * as claim from '@renderer/services/claimService';
 
-import { isUserLoggedIn, stringifyHbar } from '@renderer/utils';
+import { isUserLoggedIn, isValidAccountForNodeCreation, stringifyHbar } from '@renderer/utils';
 
 import AppHbarInput from '@renderer/components/ui/AppHbarInput.vue';
 import AccountIdInput from '@renderer/components/AccountIdInput.vue';
@@ -24,6 +24,7 @@ const props = defineProps<{
   payerId: string;
   validStart: Date;
   maxTransactionFee: Hbar;
+  isNodeCreationPrivRequired: boolean;
 }>();
 
 /* Emits */
@@ -98,7 +99,7 @@ const columnClass = 'col-4 col-xxxl-3';
         data-testid="input-payer-account"
       />
       <div class="text-micro mt-2">
-        <span v-if="account.isLoading.value" class="invisible">Loading…</span>
+        <span v-if="payerId == '' || account.isLoading.value" class="invisible">plcrhldr</span>
         <span
           v-else-if="account.accountInfo.value === null"
           class="text-warning bi bi-exclamation-triangle-fill me-1"
@@ -106,10 +107,18 @@ const columnClass = 'col-4 col-xxxl-3';
           Account does not exist
         </span>
         <span
-          v-else-if="account.accountInfo.value?.deleted"
+          v-else-if="account.accountInfo.value.deleted"
           class="text-warning bi bi-exclamation-triangle-fill me-1"
         >
           Account is deleted
+        </span>
+        <span
+          v-else-if="
+            props.isNodeCreationPrivRequired && !isValidAccountForNodeCreation(props.payerId)
+          "
+          class="text-warning bi bi-exclamation-triangle-fill me-1"
+        >
+          Account ID should be belong to 0.0.2 and 0.0.55 range
         </span>
         <span v-else class="text-muted">
           Balance:

--- a/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
@@ -100,6 +100,7 @@ const columnClass = 'col-4 col-xxxl-3';
         @update:modelValue="handlePayerChange"
         :filled="true"
         placeholder="Enter Payer ID"
+        :is-node-creation-priv-required="props.isNodeCreationPrivRequired"
         data-testid="input-payer-account"
       />
       <div class="text-micro mt-2">

--- a/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
@@ -87,27 +87,39 @@ watch(
 const columnClass = 'col-4 col-xxxl-3';
 </script>
 <template>
-  <div class="row flex-wrap align-items-end">
+  <div class="row flex-wrap align-items-start">
     <div class="form-group" :class="[columnClass]">
       <label class="form-label">Payer ID <span class="text-danger">*</span></label>
-      <label v-if="account.accountInfo.value?.deleted" class="d-block form-label text-danger me-3"
-        ><span class="bi bi-exclamation-triangle-fill me-1"></span> Account is deleted</label
-      >
-      <label class="d-block form-label text-secondary"
-        >Balance:
-        {{
-          account.isValid.value
-            ? stringifyHbar((account.accountInfo.value?.balance as Hbar) || new Hbar(0))
-            : '-'
-        }}</label
-      >
-        <AccountIdInput
-          :modelValue="payerId"
-          @update:modelValue="handlePayerChange"
-          :filled="true"
-          placeholder="Enter Payer ID"
-          data-testid="input-payer-account"
-        />
+      <AccountIdInput
+        :modelValue="payerId"
+        @update:modelValue="handlePayerChange"
+        :filled="true"
+        placeholder="Enter Payer ID"
+        data-testid="input-payer-account"
+      />
+      <div class="text-micro mt-2">
+        <span v-if="account.isLoading.value" class="invisible">Loading…</span>
+        <span
+          v-else-if="account.accountInfo.value === null"
+          class="text-warning bi bi-exclamation-triangle-fill me-1"
+        >
+          Account does not exist
+        </span>
+        <span
+          v-else-if="account.accountInfo.value?.deleted"
+          class="text-warning bi bi-exclamation-triangle-fill me-1"
+        >
+          Account is deleted
+        </span>
+        <span v-else class="text-muted">
+          Balance:
+          {{
+            account.isValid.value
+              ? stringifyHbar((account.accountInfo.value?.balance as Hbar) || new Hbar(0))
+              : '-'
+          }}
+        </span>
+      </div>
     </div>
     <div class="form-group" :class="[columnClass]">
       <label class="form-label"

--- a/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
@@ -119,7 +119,7 @@ const columnClass = 'col-4 col-xxxl-3';
           "
           class="text-warning bi bi-exclamation-triangle-fill me-1"
         >
-          Account ID should be belong to 0.0.2 and 0.0.55 range
+          Account ID should be belong to the 0.0.2-0.0.55 range
         </span>
         <span v-else class="text-muted">
           Balance:

--- a/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
@@ -13,11 +13,7 @@ import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts
 
 import * as claim from '@renderer/services/claimService';
 
-import {
-  isNodeCreationAuthorizedFeePayer,
-  isUserLoggedIn,
-  stringifyHbar,
-} from '@renderer/utils';
+import { isNodeCreationAuthorizedFeePayer, isUserLoggedIn, stringifyHbar } from '@renderer/utils';
 
 import AppHbarInput from '@renderer/components/ui/AppHbarInput.vue';
 import AccountIdInput from '@renderer/components/AccountIdInput.vue';
@@ -104,7 +100,7 @@ const columnClass = 'col-4 col-xxxl-3';
         data-testid="input-payer-account"
       />
       <div class="text-micro mt-2">
-        <span v-if="payerId == '' || account.isLoading.value" class="invisible">plcrhldr</span>
+        <span v-if="payerId == '' || account.isLoading.value" class="invisible">&nbsp;</span>
         <span
           v-else-if="account.accountInfo.value === null"
           class="text-warning bi bi-exclamation-triangle-fill me-1"

--- a/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
@@ -13,7 +13,11 @@ import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts
 
 import * as claim from '@renderer/services/claimService';
 
-import { isUserLoggedIn, isValidAccountForNodeCreation, stringifyHbar } from '@renderer/utils';
+import {
+  isNodeCreationAuthorizedFeePayer,
+  isUserLoggedIn,
+  stringifyHbar,
+} from '@renderer/utils';
 
 import AppHbarInput from '@renderer/components/ui/AppHbarInput.vue';
 import AccountIdInput from '@renderer/components/AccountIdInput.vue';
@@ -114,7 +118,7 @@ const columnClass = 'col-4 col-xxxl-3';
         </span>
         <span
           v-else-if="
-            props.isNodeCreationPrivRequired && !isValidAccountForNodeCreation(props.payerId)
+            props.isNodeCreationPrivRequired && !isNodeCreationAuthorizedFeePayer(props.payerId)
           "
           class="text-warning bi bi-exclamation-triangle-fill me-1"
         >

--- a/front-end/src/renderer/composables/useAccountId.ts
+++ b/front-end/src/renderer/composables/useAccountId.ts
@@ -20,12 +20,14 @@ export default function useAccountId() {
   const accountId = ref<string>('');
   const accountInfo = ref<IAccountInfoParsed | null>(null);
   const allowances = ref<CryptoAllowance[]>([]);
+  const loading = ref<boolean>(false);
 
   const accountInfoController = ref<AbortController | null>(null);
   const allowancesController = ref<AbortController | null>(null);
 
   /* Computed */
-  const isValid = computed(() => Boolean(accountInfo.value));
+  const isValid = computed(() => accountInfo.value);
+  const isLoading = computed(() => loading.value);
 
   /* Injected */
   const accountByIdCache = AppCache.inject().mirrorAccountById;
@@ -75,6 +77,7 @@ export default function useAccountId() {
 
     if (!newAccountId) return resetData();
 
+    loading.value = true;
     try {
       const baseId = newAccountId.split('-')[0];
       AccountId.fromString(baseId);
@@ -97,6 +100,8 @@ export default function useAccountId() {
       allowances.value = accountAllowancesRes;
     } catch {
       resetData();
+    } finally {
+      loading.value = false;
     }
   });
 
@@ -155,6 +160,7 @@ export default function useAccountId() {
     keysFlattened,
     allowances,
     isValid,
+    isLoading,
     getSpenderAllowance,
     getStakedToString,
     getFormattedPendingRewards,

--- a/front-end/src/renderer/composables/useAccountId.ts
+++ b/front-end/src/renderer/composables/useAccountId.ts
@@ -26,7 +26,7 @@ export default function useAccountId() {
   const allowancesController = ref<AbortController | null>(null);
 
   /* Computed */
-  const isValid = computed(() => accountInfo.value);
+  const isValid = computed(() => accountInfo.value !== null);
   const isLoading = computed(() => loading.value);
 
   /* Injected */

--- a/front-end/src/renderer/utils/sdk/validation.ts
+++ b/front-end/src/renderer/utils/sdk/validation.ts
@@ -60,11 +60,15 @@ export function exceedsUtf8ByteLimit(str: string, byteLimit: number): boolean {
   return utf8ByteLength(str) > byteLimit;
 }
 
-export function isValidAccountForNodeCreation(accountId: string): boolean {
+/**
+ * Only accounts between 0.0.2 and 0.0.55 are authorized to create nodes or registered nodes.
+ */
+
+export function isNodeCreationAuthorizedFeePayer(accountId: AccountId | string): boolean {
   let result: boolean;
   try {
-    const aid = AccountId.fromString(accountId);
-    result = aid.shard.isZero() && aid.realm.isZero() && aid.num.gte(2) && aid.num.lte(55);
+    const id = typeof accountId === 'string' ? AccountId.fromString(accountId) : accountId;
+    result = id.shard.isZero() && id.realm.isZero() && id.num.gte(2) && id.num.lte(55);
   } catch {
     result = false;
   }

--- a/front-end/src/renderer/utils/sdk/validation.ts
+++ b/front-end/src/renderer/utils/sdk/validation.ts
@@ -1,4 +1,4 @@
-import { FileUpdateTransaction, type Transaction } from '@hiero-ledger/sdk';
+import { AccountId, FileUpdateTransaction, type Transaction } from '@hiero-ledger/sdk';
 
 const TREASURY = '0.0.2';
 const SYSTEM_ADMIN = '0.0.50';
@@ -58,4 +58,15 @@ export function utf8ByteLength(str: string): number {
 /** Returns true if the string's UTF-8 byte length is strictly greater than the limit. */
 export function exceedsUtf8ByteLimit(str: string, byteLimit: number): boolean {
   return utf8ByteLength(str) > byteLimit;
+}
+
+export function isValidAccountForNodeCreation(accountId: string): boolean {
+  let result: boolean;
+  try {
+    const aid = AccountId.fromString(accountId);
+    result = aid.shard.isZero() && aid.realm.isZero() && aid.num.gte(2) && aid.num.lte(55);
+  } catch {
+    result = false;
+  }
+  return result;
 }

--- a/front-end/src/renderer/utils/sortAccounts.ts
+++ b/front-end/src/renderer/utils/sortAccounts.ts
@@ -1,0 +1,24 @@
+import { AccountId } from '@hiero-ledger/sdk';
+
+export function compareAccountIds(a1: AccountId | string, a2: AccountId | string): number {
+  let result: number;
+
+  try {
+    const id1 = a1 instanceof AccountId ? a1 : AccountId.fromString(a1);
+    const id2 = a2 instanceof AccountId ? a2 : AccountId.fromString(a2);
+    if (!id1.realm.eq(id2.realm)) {
+      result = id1.realm.lt(id2.realm) ? -1 : 1;
+    } else if (!id1.shard.eq(id2.shard)) {
+      result = id1.shard.lt(id2.shard) ? -1 : 1;
+    } else if (!id1.num.eq(id2.num)) {
+      result = id1.num.lt(id2.num) ? -1 : 1;
+    } else {
+      result = 0;
+    }
+  } catch {
+    // Emergency code
+    result = a1.toString().localeCompare(a2.toString());
+  }
+
+  return result;
+}


### PR DESCRIPTION
**Description**:

Changes below improve user feedback related to `Payer ID` field in `Draft Editor`.
Logic for controlling `Payer ID` field is shared across all transactions.
Thus those changes applies to all types of transaction.

Most visible change is `Balance` value which is now displayed below `Payer ID` field:
- this provides better alignment
- this is consistent with other input controls (like length display in `Description` fields)

<img width="1164" height="932" alt="image" src="https://github.com/user-attachments/assets/90c14505-3300-4d0c-aade-f25be6a4ddf5" />

Line below `Payer ID` is now used as status line:
- when everything is ok, it displays `Balance`
- when there is an issue with value in `Payer ID` field, it displays a status message

Here are the messages that can be displayed:

<img width="386" height="126" alt="image" src="https://github.com/user-attachments/assets/e4071196-30e4-44bf-8906-755e56611aeb" />

<img width="386" height="126" alt="image" src="https://github.com/user-attachments/assets/ec0ba46b-cdce-4c1e-9695-51de57d8e409" />

Message below is specific to Node Create and Registered Node transactions:
<img width="386" height="126" alt="image" src="https://github.com/user-attachments/assets/7bab2078-2dbe-4190-840e-337ce7892ac7" />

Additional change: account suggestions displayed by Payer ID field are now sorted by realm/shard/num:

<img width="386" height="462" alt="image" src="https://github.com/user-attachments/assets/088624be-c57b-4a7f-9dd8-edee73987300" />


**Related issue(s)**:

First step for #2895

**Notes for reviewer**:

```
M   front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
    # BaseTransaction now passes TransactionIdControls.props.is-node-creation-priv-required
    # to indicate if transaction expects a payer id with node creation priviledge (2..55).

M   front-end/src/renderer/components/Transaction/TransactionIdControls.vue
M   front-end/src/renderer/composables/useAccountId.ts
    # TransactionIdControls now places balance below payer id text field.
    # It also provides  additional user feedback messages.
    # And it forwards is-node-creation-priv-required to AccountIdInput.

M   front-end/src/renderer/components/AccountIdInput.vue
M   front-end/src/renderer/utils/sdk/validation.ts
A   front-end/src/renderer/utils/sortAccounts.ts
    # AccountIdInput now filters account suggestions when is-node-creation-priv-required is true.
    # It also sorts account suggestions by realm/shard/num using compareAccountIds() from sortAccounts.ts
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
