### PR TITLE
feat: improving service endpoint layout in Registered Node create/update form

### DIFF
--- a/front-end/src/renderer/components/IpDomainInput.vue
+++ b/front-end/src/renderer/components/IpDomainInput.vue
@@ -13,7 +13,7 @@ const emit = defineEmits<{
 const inputText = ref<string>('');
 
 /* Computed */
-const inputValue = computed<string | null>(() => {
+const inputValue = computed<string | Uint8Array | null>(() => {
   let result: string | Uint8Array | null;
 
   const trimmed = inputText.value.trim();

--- a/front-end/src/renderer/components/IpDomainInput.vue
+++ b/front-end/src/renderer/components/IpDomainInput.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { isValidFqdn, VALID_IPV4_REGEX } from '@renderer/utils/endpointUtils';
+import { computed, ref, watch } from 'vue';
+import { IpDomainInputStatus } from './IpDomainInputStatus';
+
+/* Props */
+const value = defineModel<string | Uint8Array | null>({ required: true });
+const emit = defineEmits<{
+  (e: 'status', value: IpDomainInputStatus): void;
+}>();
+
+/* State */
+const inputText = ref<string>('');
+
+/* Computed */
+const inputValue = computed<string | null>(() => {
+  let result: string | Uint8Array | null;
+
+  const trimmed = inputText.value.trim();
+  if (isValidFqdn(trimmed)) {
+    result = trimmed;
+  } else if (trimmed.match(VALID_IPV4_REGEX)) {
+    result = Uint8Array.from(trimmed.split('.').map(Number));
+  } else {
+    result = null;
+  }
+  return result;
+});
+const inputStatus = computed<IpDomainInputStatus>(() => {
+  let result: IpDomainInputStatus;
+  const trimmed = inputText.value.trim();
+  if (trimmed.length === 0) {
+    result = IpDomainInputStatus.empty;
+  } else if (inputValue.value !== null) {
+    result = IpDomainInputStatus.valid;
+  } else {
+    result = IpDomainInputStatus.invalid;
+  }
+  return result;
+});
+
+/* Watchers */
+watch(
+  value,
+  () => {
+    if (value.value instanceof Uint8Array) {
+      inputText.value = value.value.join('.');
+    } else if (typeof value.value === 'string') {
+      inputText.value = value.value;
+    } else {
+      inputText.value = '';
+    }
+  },
+  { immediate: true },
+);
+watch(inputValue, () => {
+  value.value = inputValue.value;
+});
+watch(
+  inputStatus,
+  (newStatus: IpDomainInputStatus) => {
+    emit('status', newStatus);
+  },
+  { immediate: true },
+);
+</script>
+
+<template>
+  <input
+    v-model="inputText"
+    placeholder="Enter Domain Name or IP Address"
+    class="form-control is-fill"
+  />
+</template>
+
+<style scoped></style>

--- a/front-end/src/renderer/components/IpDomainInputStatus.ts
+++ b/front-end/src/renderer/components/IpDomainInputStatus.ts
@@ -1,0 +1,5 @@
+export enum IpDomainInputStatus {
+  empty,
+  invalid,
+  valid,
+}

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
@@ -4,14 +4,15 @@ import type {
   RegisteredEndpointType,
 } from '@renderer/utils/sdk';
 
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 import { BlockNodeApi } from '@hiero-ledger/sdk';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
-import AppInput from '@renderer/components/ui/AppInput.vue';
 import AppSwitch from '@renderer/components/ui/AppSwitch.vue';
 import AppTextArea from '@renderer/components/ui/AppTextArea.vue';
+import IpDomainInput from '@renderer/components/IpDomainInput.vue';
+import { IpDomainInputStatus } from '@renderer/components/IpDomainInputStatus';
 
 /* Props */
 const props = defineProps<{
@@ -25,6 +26,10 @@ const emit = defineEmits<{
   (event: 'update:endpoint', endpoint: ComponentRegisteredServiceEndpoint): void;
   (event: 'delete'): void;
 }>();
+
+/* State */
+const ipOrDomain = ref<string | Uint8Array | null>(null);
+const ipOrDomainStatus = ref<IpDomainInputStatus>(IpDomainInputStatus.empty);
 
 /**
  * Block-node API options shown to the user.
@@ -61,6 +66,7 @@ if (BLOCK_NODE_API_OPTIONS.length === 0) {
   );
 }
 
+/* Computed */
 const blockNodeApiOptions = computed(() => BLOCK_NODE_API_OPTIONS);
 
 /* Helpers */
@@ -82,32 +88,6 @@ function handlePortInput(e: Event) {
   patch({ port: target.value.replace(/[^0-9]/g, '') });
 }
 
-/**
- * IP / Domain are mutually exclusive per the proto `oneof address` rule. We
- * surface that with an explicit switch + single text field rather than two
- * inputs whose state silently clears the other on type. Initial mode is
- * derived from whichever field has data so drafts and round-trips pick up
- * the correct view.
- */
-const addressMode = ref<'ipv4' | 'domain'>(
-  props.endpoint.domainName ? 'domain' : 'ipv4',
-);
-
-function handleAddressModeChange(useDomain: boolean) {
-  addressMode.value = useDomain ? 'domain' : 'ipv4';
-  // Clear the now-inactive field so we never carry stale data into the
-  // SDK builder. Not silent — the user just toggled the switch.
-  patch(useDomain ? { ipAddressV4: '' } : { domainName: '' });
-}
-
-function handleAddressInput(value: string) {
-  patch(
-    addressMode.value === 'ipv4'
-      ? { ipAddressV4: value, domainName: '' }
-      : { domainName: value, ipAddressV4: '' },
-  );
-}
-
 function toggleApi(code: number, checked: boolean) {
   const current = new Set(props.endpoint.endpointApis ?? []);
   if (checked) current.add(code);
@@ -118,6 +98,30 @@ function toggleApi(code: number, checked: boolean) {
 function isApiSelected(code: number) {
   return (props.endpoint.endpointApis ?? []).includes(code);
 }
+
+/* Watchers */
+watch(
+  [() => props.endpoint.ipAddressV4, () => props.endpoint.domainName],
+  () => {
+    if (props.endpoint.ipAddressV4 !== '') {
+      ipOrDomain.value = props.endpoint.ipAddressV4;
+    } else if (props.endpoint.domainName !== '') {
+      ipOrDomain.value = props.endpoint.domainName;
+    } else {
+      ipOrDomain.value = '';
+    }
+  },
+  { immediate: true },
+);
+watch([ipOrDomain, ipOrDomainStatus], () => {
+  if (ipOrDomain.value instanceof Uint8Array) {
+    patch({ ipAddressV4: ipOrDomain.value.join('.'), domainName: '' });
+  } else if (typeof ipOrDomain.value === 'string') {
+    patch({ ipAddressV4: '', domainName: ipOrDomain.value ?? '' });
+  } else {
+    patch({ ipAddressV4: '', domainName: '' });
+  }
+});
 </script>
 
 <template>
@@ -142,9 +146,7 @@ function isApiSelected(code: number) {
         :value="endpoint.type"
         :data-testid="`select-registered-endpoint-type-${index}`"
         @change="
-          handleTypeChange(
-            ($event.target as HTMLSelectElement).value as RegisteredEndpointType,
-          )
+          handleTypeChange(($event.target as HTMLSelectElement).value as RegisteredEndpointType)
         "
       >
         <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">
@@ -158,25 +160,13 @@ function isApiSelected(code: number) {
       <div class="col-8 col-xxxl-6">
         <div class="d-flex align-items-center justify-content-between mb-2">
           <label class="form-label mb-0">
-            {{ addressMode === 'ipv4' ? 'IPv4 Address' : 'Domain Name' }}
+            IP/Domain
             <span class="text-danger">*</span>
           </label>
-          <AppSwitch
-            :checked="addressMode === 'domain'"
-            @update:checked="handleAddressModeChange"
-            size="sm"
-            :name="`registered-endpoint-address-mode-${index}`"
-            label="Use domain name"
-            :data-testid="`switch-registered-endpoint-address-mode-${index}`"
-          />
         </div>
-        <AppInput
-          :model-value="
-            addressMode === 'ipv4' ? (endpoint.ipAddressV4 ?? '') : (endpoint.domainName ?? '')
-          "
-          @update:model-value="handleAddressInput"
-          :filled="true"
-          :placeholder="addressMode === 'ipv4' ? 'e.g. 10.0.0.1' : 'e.g. node.example.com'"
+        <IpDomainInput
+          v-model="ipOrDomain"
+          @status="ipOrDomainStatus = $event"
           :data-testid="`input-registered-endpoint-address-${index}`"
         />
       </div>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
@@ -138,26 +138,24 @@ watch([ipOrDomain, ipOrDomainStatus], () => {
       </AppButton>
     </div>
 
-    <!-- Type selector -->
-    <div class="form-group">
-      <label class="form-label">Type <span class="text-danger">*</span></label>
-      <select
-        class="form-control is-fill"
-        :value="endpoint.type"
-        :data-testid="`select-registered-endpoint-type-${index}`"
-        @change="
-          handleTypeChange(($event.target as HTMLSelectElement).value as RegisteredEndpointType)
-        "
-      >
-        <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">
-          {{ opt.label }}
-        </option>
-      </select>
-    </div>
-
-    <!-- Address (IPv4 or Domain) / Port -->
+    <!-- Type selector / Address (IPv4 or Domain) / Port -->
     <div class="row align-items-end mt-3">
-      <div class="col-8 col-xxxl-6">
+      <div class="col-3 col-xxxl-6">
+        <label class="form-label">Type <span class="text-danger">*</span></label>
+        <select
+          class="form-control is-fill"
+          :value="endpoint.type"
+          :data-testid="`select-registered-endpoint-type-${index}`"
+          @change="
+            handleTypeChange(($event.target as HTMLSelectElement).value as RegisteredEndpointType)
+          "
+        >
+          <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">
+            {{ opt.label }}
+          </option>
+        </select>
+      </div>
+      <div class="col-6 col-xxxl-6">
         <div class="d-flex align-items-center justify-content-between mb-2">
           <label class="form-label mb-0">
             IP/Domain
@@ -170,7 +168,7 @@ watch([ipOrDomain, ipOrDomainStatus], () => {
           :data-testid="`input-registered-endpoint-address-${index}`"
         />
       </div>
-      <div class="col-4 col-xxxl-3">
+      <div class="col-2 col-xxxl-3">
         <label class="form-label">Port <span class="text-danger">*</span></label>
         <input
           :value="endpoint.port ?? ''"
@@ -180,18 +178,16 @@ watch([ipOrDomain, ipOrDomainStatus], () => {
           :data-testid="`input-registered-endpoint-port-${index}`"
         />
       </div>
-    </div>
-
-    <!-- TLS switch -->
-    <div class="form-group mt-4">
-      <AppSwitch
-        :checked="endpoint.requiresTls"
-        @update:checked="patch({ requiresTls: $event })"
-        size="md"
-        :name="`registered-endpoint-tls-${index}`"
-        label="Requires TLS"
-        :data-testid="`switch-registered-endpoint-tls-${index}`"
-      />
+      <div class="col-md-auto">
+        <label class="form-label">TLS</label>
+        <AppSwitch
+          :checked="endpoint.requiresTls"
+          @update:checked="patch({ requiresTls: $event })"
+          size="md"
+          :name="`registered-endpoint-tls-${index}`"
+          :data-testid="`switch-registered-endpoint-tls-${index}`"
+        />
+      </div>
     </div>
 
     <!-- Block Node — endpoint APIs -->
@@ -230,3 +226,10 @@ watch([ipOrDomain, ipOrDomainStatus], () => {
     </div>
   </div>
 </template>
+
+<style scoped>
+.form-switch.form-switch-md {
+  margin-bottom: 0.5rem;
+  margin-top: 0.5rem;
+}
+</style>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
@@ -139,8 +139,8 @@ watch([ipOrDomain, ipOrDomainStatus], () => {
     </div>
 
     <!-- Type selector / Address (IPv4 or Domain) / Port -->
-    <div class="row align-items-end mt-3">
-      <div class="col-3 col-xxxl-6">
+    <div class="row flex-nowrap align-items-end mt-3">
+      <div class="col-3">
         <label class="form-label">Type <span class="text-danger">*</span></label>
         <select
           class="form-control is-fill"
@@ -155,7 +155,7 @@ watch([ipOrDomain, ipOrDomainStatus], () => {
           </option>
         </select>
       </div>
-      <div class="col-6 col-xxxl-6">
+      <div class="col-6">
         <div class="d-flex align-items-center justify-content-between mb-2">
           <label class="form-label mb-0">
             IP/Domain
@@ -168,7 +168,7 @@ watch([ipOrDomain, ipOrDomainStatus], () => {
           :data-testid="`input-registered-endpoint-address-${index}`"
         />
       </div>
-      <div class="col-2 col-xxxl-3">
+      <div class="col-2">
         <label class="form-label">Port <span class="text-danger">*</span></label>
         <input
           :value="endpoint.port ?? ''"
@@ -178,7 +178,7 @@ watch([ipOrDomain, ipOrDomainStatus], () => {
           :data-testid="`input-registered-endpoint-port-${index}`"
         />
       </div>
-      <div class="col-md-auto">
+      <div class="col-auto">
         <label class="form-label">TLS</label>
         <AppSwitch
           :checked="endpoint.requiresTls"


### PR DESCRIPTION
**Description**:

Changes below improve `Service Endpoint` editing in `Registered Node Create/Update` transaction draft.

Flag `Use domain name` is removed and `IP Address/Domain` textfield accepts both syntax (like in `Node Create`/`Update`):

- Before
<img width="575" height="95" alt="image" src="https://github.com/user-attachments/assets/cd34eddb-4101-494b-bbe6-6787a098380f" />

- After
<img width="434" height="110" alt="image" src="https://github.com/user-attachments/assets/c6357267-bf8e-46ba-8dcc-383457f69eb0" />



`Type`, `IP / Domain`, `Port` and `TLS` fields are now layed out on the same line:

- Before
<img width="900" height="470" alt="image" src="https://github.com/user-attachments/assets/55564122-00bd-4a51-926d-ba4c926edeeb" />

- After
<img width="900" height="356" alt="image" src="https://github.com/user-attachments/assets/e6fee74d-b7db-480e-b4e7-df2db9556202" />


**Related issue(s)**:

Part 3 for #2895.

**Notes for reviewer**:

```
M   front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
    # Now removes Use domain name checkbox and uses IpDomainInput which accepts 
    # both IP address and domain name in the same textfield.
    # Type, IP / Domain, Port and TLS flags are now placed on the same line.
    
A   front-end/src/renderer/components/IpDomainInput.vue
A   front-end/src/renderer/components/IpDomainInputStatus.ts
    # An <input> element setup to type either an IP address V4 or a domaine name.
    # IpDomainInput.props.value represents IP address as an Uint8Array and domain name as a string.
    # IpDomainINput.emit.status provides a status: empty, invalid and valid.
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
