### PR TITLE
feat: provide sign all&next functionality to the transaction groups

### DIFF
--- a/front-end/eslint.config.cjs
+++ b/front-end/eslint.config.cjs
@@ -49,7 +49,7 @@ module.exports = [
       'src/renderer/utils/logger.ts',
     ],
     rules: {
-      'no-console': 'error',
+      'no-console': 'warn',
     },
   },
 ];

--- a/front-end/src/renderer/components/SplitSignButtonDropdown.vue
+++ b/front-end/src/renderer/components/SplitSignButtonDropdown.vue
@@ -8,6 +8,8 @@ import { GO_NEXT_AFTER_SIGN } from '@shared/constants';
 
 /* Props */
 const props = defineProps<{
+  actionText: string;
+  actionNextText: string;
   loading?: boolean;
   loadingText?: string;
   disabled?: boolean;
@@ -46,7 +48,7 @@ onBeforeMount(async () => {
       color="primary"
       type="submit"
     >
-      {{ goToNext ? 'Sign & Next' : 'Sign' }}
+      {{ goToNext ? props.actionNextText : props.actionText }}
     </AppButton>
     <AppButton
       :disabled="props.disabled || props.loading"
@@ -111,7 +113,7 @@ onBeforeMount(async () => {
 
 .main-button {
   border-right: 1px solid rgba(255, 255, 255, 0.3);
-  min-width: 120px;
+  min-width: 136.5px;
 }
 
 .option-label {

--- a/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
@@ -307,6 +307,8 @@ const computeVisibleButtons = (
         <NextTransactionCursor />
         <div v-if="visibleButtons.length > 0">
           <SplitSignButtonDropdown
+            :action-text="sign"
+            :action-next-text="signAndNext"
             v-if="visibleButtons[0] === sign"
             :disabled="isRefreshing"
             :loading="Boolean(loadingStates[sign])"

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -48,12 +48,14 @@ import SignAllController from '@renderer/pages/TransactionGroupDetails/SignAllCo
 import CancelAllController from '@renderer/pages/TransactionGroupDetails/CancelAllController.vue';
 import ExportAllController from '@renderer/pages/TransactionGroupDetails/ExportAllController.vue';
 import ApproveAllController from '@renderer/pages/TransactionGroupDetails/ApproveAllController.vue';
+import SplitSignButtonDropdown from '@renderer/components/SplitSignButtonDropdown.vue';
 
 /* Types */
 type ActionButton =
   | 'Reject All'
   | 'Approve All'
   | 'Sign All'
+  | 'Sign All & Next'
   | 'Cancel All'
   | 'Export All (Transaction Tool 1.0)';
 
@@ -63,6 +65,7 @@ const logger = createLogger('renderer.page.transactionGroupDetails');
 const reject: ActionButton = 'Reject All';
 const approve: ActionButton = 'Approve All';
 const sign: ActionButton = 'Sign All';
+const signAndNext: ActionButton = 'Sign All & Next';
 const cancel: ActionButton = 'Cancel All';
 const exportName: ActionButton = 'Export All (Transaction Tool 1.0)';
 
@@ -127,6 +130,7 @@ const loadingStates = reactive<{ [key: string]: string | null }>({
 });
 
 const signAllStarted = ref(false);
+const goNextAfterSignAll = ref(false);
 const cancelAllStarted = ref(false);
 const exportAllStarted = ref(false);
 const approveAllStarted = ref(false);
@@ -235,7 +239,14 @@ const handleDetails = async (id: number) => {
 };
 
 const didSignAll = async (groupId: number | null /*, signed: boolean */) => {
-  if (groupId !== null) {
+  if (goNextAfterSignAll.value) {
+    // We route to the next transaction
+    if (nextTransaction.hasNext) {
+      await nextTransaction.routeToNext(router);
+    } else {
+      await nextTransaction.routeUp(router);
+    }
+  } else if (groupId !== null) {
     await fetchGroup(groupId);
   }
 };
@@ -248,7 +259,9 @@ const handleAction = async (value: ActionButton) => {
       isApproved.value = value === approve;
       break;
     case sign:
+    case signAndNext:
       signAllStarted.value = true;
+      goNextAfterSignAll.value = value === signAndNext;
       break;
     case cancel:
       cancelAllStarted.value = true;
@@ -366,7 +379,6 @@ async function fetchGroup(id: string | number) {
       }
 
       await updateFirstSignableGroupItemAfterFetch();
-
     } catch (error) {
       router.back();
       throw error;
@@ -411,7 +423,16 @@ async function fetchGroupOnNotif(groupId: string | number) {
             <NextTransactionCursor />
             <template v-if="visibleButtons.length > 0">
               <div>
+                <SplitSignButtonDropdown
+                  :action-text="sign"
+                  :action-next-text="signAndNext"
+                  v-if="visibleButtons[0] === sign"
+                  :disabled="Boolean(loadingStates[visibleButtons[0]])"
+                  :loading="Boolean(loadingStates[sign])"
+                  :loading-text="loadingStates[sign] || ''"
+                />
                 <AppButton
+                  v-else
                   :color="primaryButtons.includes(visibleButtons[0]) ? 'primary' : 'secondary'"
                   :data-testid="buttonsDataTestIds[visibleButtons[0]]"
                   :disabled="Boolean(loadingStates[visibleButtons[0]])"

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -424,10 +424,11 @@ async function fetchGroupOnNotif(groupId: string | number) {
             <template v-if="visibleButtons.length > 0">
               <div>
                 <SplitSignButtonDropdown
-                  :action-text="sign"
-                  :action-next-text="signAndNext"
                   v-if="visibleButtons[0] === sign"
-                  :disabled="Boolean(loadingStates[visibleButtons[0]])"
+                  :action-next-text="signAndNext"
+                  :action-text="sign"
+                  :data-testid="buttonsDataTestIds[sign]"
+                  :disabled="Boolean(loadingStates[sign])"
                   :loading="Boolean(loadingStates[sign])"
                   :loading-text="loadingStates[sign] || ''"
                 />


### PR DESCRIPTION
**Description**:

Similar to the `Sign/Sign & Next` functionality available on the _Transaction Details_, provide `Sign All/Sign All & Next` on the _Transaction Group Details_. So when iterating over the `Ready to Sign` list of nodes, the user can seamlessly sign either transactions or groups and advance to the next node with a single click.

Fixes #2767

**Notes for reviewer**:

```
M       front-end/src/renderer/components/SplitSignButtonDropdown.vue
M       front-end/src/renderer/pages/TransactionDetails/components/TransactionDetailsHeader.vue
        # make labels configurable in SplitSignButtonDropdown component

M       front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
        # provide `Sign All & Next` in groups

M       front-end/eslint.config.cjs
        # unrelated: restore ability to use console.log for debugging (trigger build warning instead of error)

```