### PR TITLE
feat: re-worked endpoint editing in Registered Node Create/Update

### DIFF
--- a/front-end/src/renderer/components/InputStatus.ts
+++ b/front-end/src/renderer/components/InputStatus.ts
@@ -1,0 +1,5 @@
+export enum InputStatus {
+  empty,
+  invalid,
+  valid,
+}

--- a/front-end/src/renderer/components/IpDomainInputStatus.ts
+++ b/front-end/src/renderer/components/IpDomainInputStatus.ts
@@ -1,5 +1,0 @@
-export enum IpDomainInputStatus {
-  empty,
-  invalid,
-  valid,
-}

--- a/front-end/src/renderer/components/PortInput.vue
+++ b/front-end/src/renderer/components/PortInput.vue
@@ -14,8 +14,11 @@ const inputText = ref<string>('');
 /* Computed */
 const inputValue = computed<number | null>(() => {
   const trimmed = inputText.value.trim();
-  const n = parseInt(trimmed);
-  return isNaN(n) ? null : n;
+  if (trimmed.length === 0) return null;
+  // Number() rejects partial strings like "12abc" (unlike parseInt).
+  const n = Number(trimmed);
+  if (!Number.isInteger(n) || n < 0 || n > 65535) return null;
+  return n;
 });
 const inputStatus = computed<InputStatus>(() => {
   let result: InputStatus;

--- a/front-end/src/renderer/components/PortInput.vue
+++ b/front-end/src/renderer/components/PortInput.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import { isValidFqdn, VALID_IPV4_REGEX } from '@renderer/utils/endpointUtils';
 import { computed, ref, watch } from 'vue';
 import { InputStatus } from './InputStatus';
 
 /* Props */
-const value = defineModel<string | Uint8Array | null>({ required: true });
+const value = defineModel<number | null>({ required: true });
 const emit = defineEmits<{
   (e: 'status', value: InputStatus): void;
 }>();
@@ -13,18 +12,10 @@ const emit = defineEmits<{
 const inputText = ref<string>('');
 
 /* Computed */
-const inputValue = computed<string | Uint8Array | null>(() => {
-  let result: string | Uint8Array | null;
-
+const inputValue = computed<number | null>(() => {
   const trimmed = inputText.value.trim();
-  if (isValidFqdn(trimmed)) {
-    result = trimmed;
-  } else if (trimmed.match(VALID_IPV4_REGEX)) {
-    result = Uint8Array.from(trimmed.split('.').map(Number));
-  } else {
-    result = null;
-  }
-  return result;
+  const n = parseInt(trimmed);
+  return isNaN(n) ? null : n;
 });
 const inputStatus = computed<InputStatus>(() => {
   let result: InputStatus;
@@ -43,10 +34,8 @@ const inputStatus = computed<InputStatus>(() => {
 watch(
   value,
   () => {
-    if (value.value instanceof Uint8Array) {
-      inputText.value = value.value.join('.');
-    } else if (typeof value.value === 'string') {
-      inputText.value = value.value;
+    if (value.value !== null) {
+      inputText.value = value.value.toString();
     } else {
       inputText.value = '';
     }
@@ -66,11 +55,7 @@ watch(
 </script>
 
 <template>
-  <input
-    v-model="inputText"
-    placeholder="Enter Domain Name or IP Address"
-    class="form-control is-fill"
-  />
+  <input v-model="inputText" placeholder="0-65535" class="form-control is-fill" />
 </template>
 
 <style scoped></style>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/BlockNodeApiLabel.ts
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/BlockNodeApiLabel.ts
@@ -1,0 +1,27 @@
+import { BlockNodeApi } from '@hiero-ledger/sdk';
+
+export const labelForBlockNodeApi = (apiOrNumber: BlockNodeApi | number) => {
+  let result: string;
+  const apiCode = typeof apiOrNumber === 'number' ? apiOrNumber : Number(apiOrNumber);
+  switch (apiCode) {
+    case Number(BlockNodeApi.Other):
+      result = 'Other';
+      break;
+    case Number(BlockNodeApi.Status):
+      result = 'Status';
+      break;
+    case Number(BlockNodeApi.Publish):
+      result = 'Publish';
+      break;
+    case Number(BlockNodeApi.SubscribeStream):
+      result = 'Sub. Stream';
+      break;
+    case Number(BlockNodeApi.StateProof):
+      result = 'State Proof';
+      break;
+    default:
+      result = apiCode.toString();
+      break;
+  }
+  return result;
+};

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/BlockNodeApiOptions.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/BlockNodeApiOptions.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { BlockNodeApi } from '@hiero-ledger/sdk';
+import { labelForBlockNodeApi } from '@renderer/components/Transaction/Create/RegisteredNodeCreate/BlockNodeApiLabel.ts';
+
+/* Props */
+const value = defineModel<number[]>({ required: true });
+
+/* Computed */
+const allApis = computed(() => [
+  BlockNodeApi.Other,
+  BlockNodeApi.Status,
+  BlockNodeApi.Publish,
+  BlockNodeApi.SubscribeStream,
+  BlockNodeApi.StateProof,
+]);
+
+/* Helpers */
+function isApiSelected(api: BlockNodeApi) {
+  return value.value.includes(Number(api));
+}
+function toggleApi(api: BlockNodeApi, checked: boolean) {
+  const current = new Set(value.value);
+  if (checked) current.add(Number(api));
+  else current.delete(Number(api));
+  value.value = Array.from(current);
+}
+</script>
+
+<template>
+  <div class="d-flex flex-wrap gap-3">
+    <label
+      v-for="api in allApis"
+      :key="api.toString()"
+      class="d-inline-flex align-items-center gap-2 text-small"
+    >
+      <input
+        type="checkbox"
+        :checked="isApiSelected(api)"
+        :data-testid="`checkbox-registered-endpoint-api-${Number(api)}`"
+        @change="toggleApi(api, ($event.target as HTMLInputElement).checked)"
+      />
+      {{ labelForBlockNodeApi(api) }}
+    </label>
+  </div>
+</template>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/BlockNodeApiOptions.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/BlockNodeApiOptions.vue
@@ -23,7 +23,9 @@ function toggleApi(api: BlockNodeApi, checked: boolean) {
   const current = new Set(value.value);
   if (checked) current.add(Number(api));
   else current.delete(Number(api));
-  value.value = Array.from(current);
+
+  // Keep a canonical order so equivalent selections produce identical payloads.
+  value.value = Array.from(current).sort((a, b) => a - b);
 }
 </script>
 

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
@@ -12,7 +12,7 @@ import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppSwitch from '@renderer/components/ui/AppSwitch.vue';
 import AppTextArea from '@renderer/components/ui/AppTextArea.vue';
 import IpDomainInput from '@renderer/components/IpDomainInput.vue';
-import { IpDomainInputStatus } from '@renderer/components/IpDomainInputStatus';
+import { InputStatus } from '@renderer/components/InputStatus';
 
 /* Props */
 const props = defineProps<{
@@ -29,7 +29,7 @@ const emit = defineEmits<{
 
 /* State */
 const ipOrDomain = ref<string | Uint8Array | null>(null);
-const ipOrDomainStatus = ref<IpDomainInputStatus>(IpDomainInputStatus.empty);
+const ipOrDomainStatus = ref<InputStatus>(InputStatus.empty);
 
 /**
  * Block-node API options shown to the user.

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
@@ -1,235 +1,84 @@
 <script setup lang="ts">
-import type {
-  ComponentRegisteredServiceEndpoint,
-  RegisteredEndpointType,
-} from '@renderer/utils/sdk';
-
-import { computed, ref, watch } from 'vue';
-
-import { BlockNodeApi } from '@hiero-ledger/sdk';
-
+import { computed } from 'vue';
+import type { ComponentRegisteredServiceEndpoint } from '@renderer/utils/sdk';
 import AppButton from '@renderer/components/ui/AppButton.vue';
-import AppSwitch from '@renderer/components/ui/AppSwitch.vue';
-import AppTextArea from '@renderer/components/ui/AppTextArea.vue';
-import IpDomainInput from '@renderer/components/IpDomainInput.vue';
-import { InputStatus } from '@renderer/components/InputStatus';
+import { RegisteredNodeTypeLabel } from './RegisteredNodeTypeLabel';
+import { labelForBlockNodeApi } from "./BlockNodeApiLabel";
 
 /* Props */
 const props = defineProps<{
   endpoint: ComponentRegisteredServiceEndpoint;
   index: number;
-  typeOptions: { value: RegisteredEndpointType; label: string }[];
 }>();
 
 /* Emits */
 const emit = defineEmits<{
-  (event: 'update:endpoint', endpoint: ComponentRegisteredServiceEndpoint): void;
   (event: 'delete'): void;
 }>();
 
-/* State */
-const ipOrDomain = ref<string | Uint8Array | null>(null);
-const ipOrDomainStatus = ref<InputStatus>(InputStatus.empty);
-
-/**
- * Block-node API options shown to the user.
- *
- * Derived at module-evaluation time from the SDK's `BlockNodeApi` static
- * instances rather than a hand-maintained list — so when the SDK adds a new
- * enum value in a future release, this UI picks it up automatically.
- *
- * `Number(api)` invokes `BlockNodeApi.valueOf()` (which returns the numeric
- * proto code) without reaching into the underscore-prefixed `_code` field.
- *
- * NOTE: keep this in sync with `@hiero-ledger/sdk` `BlockNodeApi`. As of
- * v2.84.0 the enumerable statics are: OTHER, STATUS, PUBLISH, SUBSCRIBE_STREAM,
- * STATE_PROOF. If a future SDK build switches those to non-enumerable, this
- * extraction returns an empty array — `assertHasBlockNodeApiOptions` below
- * makes that failure loud rather than silently disabling all checkboxes.
- */
-const BLOCK_NODE_API_OPTIONS: { code: number; label: string }[] = Object.values(
-  BlockNodeApi as unknown as Record<string, unknown>,
-)
-  .filter((v): v is InstanceType<typeof BlockNodeApi> => v instanceof BlockNodeApi)
-  .map(api => ({ code: Number(api), label: api.toString() }))
-  .sort((a, b) => a.code - b.code);
-
-if (BLOCK_NODE_API_OPTIONS.length === 0) {
-  // Loud failure — silent zero-option list would hide the block-node API
-  // checkboxes entirely without any indication something is wrong.
-  // eslint-disable-next-line no-console -- diagnostic only fires on SDK shape regression
-  console.error(
-    '[RegisteredNodeCreate/EndpointRow] No BlockNodeApi enum values discovered ' +
-      'on the SDK class. The SDK build may have changed static enumerability — ' +
-      'block-node API checkboxes will not render. Update the option-derivation ' +
-      'strategy in EndpointRow.vue.',
-  );
-}
-
 /* Computed */
-const blockNodeApiOptions = computed(() => BLOCK_NODE_API_OPTIONS);
-
-/* Helpers */
-function patch(partial: Partial<ComponentRegisteredServiceEndpoint>) {
-  emit('update:endpoint', { ...props.endpoint, ...partial });
-}
-
-function handleTypeChange(value: RegisteredEndpointType) {
-  // Reset subtype-specific fields when switching type so we don't carry stale data.
-  patch({
-    type: value,
-    endpointApis: value === 'blockNode' ? [] : undefined,
-    endpointDescription: value === 'generalService' ? '' : undefined,
-  });
-}
-
-function handlePortInput(e: Event) {
-  const target = e.target as HTMLInputElement;
-  patch({ port: target.value.replace(/[^0-9]/g, '') });
-}
-
-function toggleApi(code: number, checked: boolean) {
-  const current = new Set(props.endpoint.endpointApis ?? []);
-  if (checked) current.add(code);
-  else current.delete(code);
-  patch({ endpointApis: Array.from(current).sort((a, b) => a - b) });
-}
-
-function isApiSelected(code: number) {
-  return (props.endpoint.endpointApis ?? []).includes(code);
-}
-
-/* Watchers */
-watch(
-  [() => props.endpoint.ipAddressV4, () => props.endpoint.domainName],
-  () => {
-    if (props.endpoint.ipAddressV4 !== '') {
-      ipOrDomain.value = props.endpoint.ipAddressV4;
-    } else if (props.endpoint.domainName !== '') {
-      ipOrDomain.value = props.endpoint.domainName;
-    } else {
-      ipOrDomain.value = '';
-    }
-  },
-  { immediate: true },
+const endpointType = computed(
+  () => RegisteredNodeTypeLabel[props.endpoint.type] ?? props.endpoint.type,
 );
-watch([ipOrDomain, ipOrDomainStatus], () => {
-  if (ipOrDomain.value instanceof Uint8Array) {
-    patch({ ipAddressV4: ipOrDomain.value.join('.'), domainName: '' });
-  } else if (typeof ipOrDomain.value === 'string') {
-    patch({ ipAddressV4: '', domainName: ipOrDomain.value ?? '' });
+const ipOrDomain = computed(() => {
+  let result: string;
+  if (props.endpoint.ipAddressV4 !== null && props.endpoint.ipAddressV4 !== '') {
+    result = props.endpoint.ipAddressV4;
+  } else if (props.endpoint.domainName !== null && props.endpoint.domainName !== '') {
+    result = props.endpoint.domainName;
   } else {
-    patch({ ipAddressV4: '', domainName: '' });
+    result = '';
   }
+  return result;
 });
+const endpointInfo = computed(() => {
+  let result: string;
+  switch (props.endpoint.type) {
+    case 'blockNode':
+      result = blockNodeAPIs.value;
+      break;
+    case 'mirrorNode':
+    case 'rpcRelay':
+      result = '';
+      break;
+    case 'generalService':
+      result = props.endpoint.endpointDescription ?? '';
+      break;
+    default:
+      result = '?';
+      break;
+  }
+  return result;
+});
+const blockNodeAPIs = computed(() => {
+  let result: string;
+  const apis = props.endpoint.endpointApis;
+  if (apis) {
+    result = apis.map(api => labelForBlockNodeApi(api)).join(',');
+  } else {
+    result = 'No API';
+  }
+  return result;
+});
+
+/* Others */
 </script>
 
 <template>
-  <div class="border rounded p-4 mt-4" :data-testid="`registered-endpoint-row-${index}`">
-    <div class="d-flex align-items-center justify-content-between mb-3">
-      <h5 class="text-small fw-bold mb-0">Endpoint #{{ index + 1 }}</h5>
+  <tr>
+    <td class="col text-start">{{ endpointType }}</td>
+    <td class="col text-start">{{ ipOrDomain }}</td>
+    <td class="col text-start">{{ props.endpoint.port }}</td>
+    <td class="col text-start">{{ props.endpoint.requiresTls ? 'Yes' : 'No' }}</td>
+    <td class="col text-start">{{ endpointInfo }}</td>
+    <td class="col text-end">
       <AppButton
         type="button"
         color="danger"
         :data-testid="`button-delete-registered-endpoint-${index}`"
         @click="emit('delete')"
+        >Delete</AppButton
       >
-        Delete
-      </AppButton>
-    </div>
-
-    <!-- Type selector / Address (IPv4 or Domain) / Port -->
-    <div class="row flex-nowrap align-items-end mt-3">
-      <div class="col-3">
-        <label class="form-label">Type <span class="text-danger">*</span></label>
-        <select
-          class="form-control is-fill"
-          :value="endpoint.type"
-          :data-testid="`select-registered-endpoint-type-${index}`"
-          @change="
-            handleTypeChange(($event.target as HTMLSelectElement).value as RegisteredEndpointType)
-          "
-        >
-          <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">
-            {{ opt.label }}
-          </option>
-        </select>
-      </div>
-      <div class="col-6">
-        <div class="d-flex align-items-center justify-content-between mb-2">
-          <label class="form-label mb-0">
-            IP/Domain
-            <span class="text-danger">*</span>
-          </label>
-        </div>
-        <IpDomainInput
-          v-model="ipOrDomain"
-          @status="ipOrDomainStatus = $event"
-          :data-testid="`input-registered-endpoint-address-${index}`"
-        />
-      </div>
-      <div class="col-2">
-        <label class="form-label">Port <span class="text-danger">*</span></label>
-        <input
-          :value="endpoint.port ?? ''"
-          @input="handlePortInput"
-          class="form-control is-fill"
-          placeholder="0-65535"
-          :data-testid="`input-registered-endpoint-port-${index}`"
-        />
-      </div>
-      <div class="col-auto">
-        <label class="form-label">TLS</label>
-        <AppSwitch
-          :checked="endpoint.requiresTls"
-          @update:checked="patch({ requiresTls: $event })"
-          size="md"
-          :name="`registered-endpoint-tls-${index}`"
-          :data-testid="`switch-registered-endpoint-tls-${index}`"
-        />
-      </div>
-    </div>
-
-    <!-- Block Node — endpoint APIs -->
-    <div v-if="endpoint.type === 'blockNode'" class="form-group mt-4">
-      <label class="form-label">Block Node APIs</label>
-      <div class="text-micro text-muted mb-2">
-        Select which block-node APIs this endpoint serves.
-      </div>
-      <div class="d-flex flex-wrap gap-3">
-        <label
-          v-for="opt in blockNodeApiOptions"
-          :key="opt.code"
-          class="d-inline-flex align-items-center gap-2 text-small"
-        >
-          <input
-            type="checkbox"
-            :checked="isApiSelected(opt.code)"
-            :data-testid="`checkbox-registered-endpoint-${index}-api-${opt.code}`"
-            @change="toggleApi(opt.code, ($event.target as HTMLInputElement).checked)"
-          />
-          {{ opt.label }}
-        </label>
-      </div>
-    </div>
-
-    <!-- General Service — description -->
-    <div v-if="endpoint.type === 'generalService'" class="form-group mt-4">
-      <label class="form-label">Endpoint Description</label>
-      <AppTextArea
-        :model-value="endpoint.endpointDescription ?? ''"
-        @update:model-value="patch({ endpointDescription: $event })"
-        :filled="true"
-        placeholder="Describe what this general-service endpoint provides"
-        :data-testid="`textarea-registered-endpoint-general-desc-${index}`"
-      />
-    </div>
-  </div>
+    </td>
+  </tr>
 </template>
-
-<style scoped>
-.form-switch.form-switch-md {
-  margin-bottom: 0.5rem;
-  margin-top: 0.5rem;
-}
-</style>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/EndpointRow.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue';
 import type { ComponentRegisteredServiceEndpoint } from '@renderer/utils/sdk';
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import { RegisteredNodeTypeLabel } from './RegisteredNodeTypeLabel';
-import { labelForBlockNodeApi } from "./BlockNodeApiLabel";
+import { labelForBlockNodeApi } from './BlockNodeApiLabel';
 
 /* Props */
 const props = defineProps<{
@@ -53,7 +53,7 @@ const endpointInfo = computed(() => {
 const blockNodeAPIs = computed(() => {
   let result: string;
   const apis = props.endpoint.endpointApis;
-  if (apis) {
+  if (apis && apis.length > 0) {
     result = apis.map(api => labelForBlockNodeApi(api)).join(',');
   } else {
     result = 'No API';
@@ -73,9 +73,9 @@ const blockNodeAPIs = computed(() => {
     <td class="col text-start">{{ endpointInfo }}</td>
     <td class="col text-end">
       <AppButton
-        type="button"
-        color="danger"
         :data-testid="`button-delete-registered-endpoint-${index}`"
+        color="danger"
+        type="button"
         @click="emit('delete')"
         >Delete</AppButton
       >

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue
@@ -246,8 +246,4 @@ function handleDeleteEndpoint(index: number) {
 </template>
 
 <style scoped>
-.form-switch.form-switch-md {
-  margin-bottom: 0.5rem;
-  margin-top: 0.5rem;
-}
 </style>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue
@@ -64,8 +64,9 @@ function handleAddEndpoint() {
     domainName: typeof ipOrDomain.value === 'string' ? ipOrDomain.value : null,
     port: port.value !== null ? port.value.toString() : '',
     requiresTls: requiresTls.value,
-    endpointApis: blockNodeApiOptions.value,
-    endpointDescription: endpointDescription.value,
+    endpointApis: endpointType.value === 'blockNode' ? blockNodeApiOptions.value : undefined,
+    endpointDescription:
+      endpointType.value === 'generalService' ? endpointDescription.value : undefined,
   };
 
   emit('update:data', {
@@ -78,6 +79,7 @@ function handleAddEndpoint() {
   port.value = null;
   requiresTls.value = false;
   blockNodeApiOptions.value = [];
+  endpointDescription.value = '';
 }
 
 function handleDeleteEndpoint(index: number) {

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue
@@ -34,6 +34,7 @@ const emit = defineEmits<{
 
 /* Constants */
 const DESCRIPTION_MAX_BYTES = 100;
+const MAX_SERVICE_ENDPOINTS = 50;
 
 /* State */
 const endpointType = ref<RegisteredEndpointType>('blockNode');
@@ -49,7 +50,11 @@ const endpointDescription = ref<string>('');
 const descriptionByteLength = computed(() => utf8ByteLength(props.data.description ?? ''));
 const isDescriptionTooLong = computed(() => descriptionByteLength.value > DESCRIPTION_MAX_BYTES);
 const addEndPointEnabled = computed(() => {
-  return ipOrDomain.value !== null && port.value !== null;
+  return (
+    ipOrDomain.value !== null &&
+    port.value !== null &&
+    props.data.serviceEndpoints.length < MAX_SERVICE_ENDPOINTS
+  );
 });
 
 /* Handlers */
@@ -245,5 +250,4 @@ function handleDeleteEndpoint(index: number) {
   </div>
 </template>
 
-<style scoped>
-</style>
+<style scoped></style>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue
@@ -5,14 +5,21 @@ import type {
   RegisteredNodeData,
 } from '@renderer/utils/sdk';
 
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 
 import { utf8ByteLength } from '@renderer/utils';
 
 import AppInput from '@renderer/components/ui/AppInput.vue';
 import AppButton from '@renderer/components/ui/AppButton.vue';
+import AppTextArea from '@renderer/components/ui/AppTextArea.vue';
 import KeyField from '@renderer/components/KeyField.vue';
 import EndpointRow from './EndpointRow.vue';
+import AppSwitch from '@renderer/components/ui/AppSwitch.vue';
+import IpDomainInput from '@renderer/components/IpDomainInput.vue';
+import { InputStatus } from '@renderer/components/InputStatus';
+import { RegisteredNodeTypeLabel } from '@renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeTypeLabel';
+import PortInput from '@renderer/components/PortInput.vue';
+import BlockNodeApiOptions from '@renderer/components/Transaction/Create/RegisteredNodeCreate/BlockNodeApiOptions.vue';
 
 /* Props */
 const props = defineProps<{
@@ -28,9 +35,22 @@ const emit = defineEmits<{
 /* Constants */
 const DESCRIPTION_MAX_BYTES = 100;
 
+/* State */
+const endpointType = ref<RegisteredEndpointType>('blockNode');
+const ipOrDomain = ref<string | Uint8Array | null>(null);
+const ipOrDomainStatus = ref<InputStatus>(InputStatus.empty);
+const port = ref<number | null>(null);
+const portStatus = ref<InputStatus>(InputStatus.empty);
+const requiresTls = ref<boolean>(false);
+const blockNodeApiOptions = ref<number[]>([]);
+const endpointDescription = ref<string>('');
+
 /* Computed */
 const descriptionByteLength = computed(() => utf8ByteLength(props.data.description ?? ''));
 const isDescriptionTooLong = computed(() => descriptionByteLength.value > DESCRIPTION_MAX_BYTES);
+const addEndPointEnabled = computed(() => {
+  return ipOrDomain.value !== null && port.value !== null;
+});
 
 /* Handlers */
 function handleAddEndpoint() {
@@ -38,25 +58,26 @@ function handleAddEndpoint() {
   // RegisteredNodeCreate.vue) is the single owner of uiId generation. That
   // keeps uiId out of `getRegisteredNodeData`'s output, which keeps
   // `transactionsDataMatch` deterministic across reloads.
-  const blank: ComponentRegisteredServiceEndpoint = {
-    type: 'blockNode',
-    ipAddressV4: '',
-    domainName: '',
-    port: '',
-    requiresTls: false,
-    endpointApis: [],
+  const newItem: ComponentRegisteredServiceEndpoint = {
+    type: endpointType.value,
+    ipAddressV4: ipOrDomain.value instanceof Uint8Array ? ipOrDomain.value.join('.') : null,
+    domainName: typeof ipOrDomain.value === 'string' ? ipOrDomain.value : null,
+    port: port.value !== null ? port.value.toString() : '',
+    requiresTls: requiresTls.value,
+    endpointApis: blockNodeApiOptions.value,
+    endpointDescription: endpointDescription.value,
   };
 
   emit('update:data', {
     ...props.data,
-    serviceEndpoints: [...props.data.serviceEndpoints, blank],
+    serviceEndpoints: [...props.data.serviceEndpoints, newItem],
   });
-}
 
-function handleUpdateEndpoint(index: number, endpoint: ComponentRegisteredServiceEndpoint) {
-  const next = [...props.data.serviceEndpoints];
-  next[index] = endpoint;
-  emit('update:data', { ...props.data, serviceEndpoints: next });
+  // Keeps endPointType unchanged
+  ipOrDomain.value = null;
+  port.value = null;
+  requiresTls.value = false;
+  blockNodeApiOptions.value = [];
 }
 
 function handleDeleteEndpoint(index: number) {
@@ -64,21 +85,6 @@ function handleDeleteEndpoint(index: number) {
   next.splice(index, 1);
   emit('update:data', { ...props.data, serviceEndpoints: next });
 }
-
-/** Stable row key — never `index`, since deleting/reordering with `index` keys
- * causes Vue to re-use DOM nodes from the wrong row (focus jumps, stale state).
- * Falls back gracefully if `uiId` is somehow missing (legacy drafts). */
-function rowKey(endpoint: ComponentRegisteredServiceEndpoint, index: number): string {
-  return endpoint.uiId ?? `legacy-${index}`;
-}
-
-/* Type helper for template */
-const endpointTypeOptions: { value: RegisteredEndpointType; label: string }[] = [
-  { value: 'blockNode', label: 'Block Node' },
-  { value: 'mirrorNode', label: 'Mirror Node' },
-  { value: 'rpcRelay', label: 'RPC Relay' },
-  { value: 'generalService', label: 'General Service' },
-];
 </script>
 
 <template>
@@ -117,43 +123,129 @@ const endpointTypeOptions: { value: RegisteredEndpointType; label: string }[] = 
       :class="isDescriptionTooLong ? 'text-warning' : 'text-muted'"
       data-testid="text-registered-description-byte-counter"
     >
-      {{ descriptionByteLength }} / {{ DESCRIPTION_MAX_BYTES }}{{ isDescriptionTooLong ? " - too long" : "" }}
+      {{ descriptionByteLength }} / {{ DESCRIPTION_MAX_BYTES
+      }}{{ isDescriptionTooLong ? ' - too long' : '' }}
     </div>
   </div>
 
-  <hr class="separator my-5" />
-
   <!-- Service Endpoints -->
-  <div class="d-flex align-items-center justify-content-between">
-    <label class="form-label mb-0">
+  <div class="form-group mt-6 col-12 col-xxxl-6">
+    <label class="form-label">
       Service Endpoints
       <span v-if="required" class="text-danger">*</span>
     </label>
-    <AppButton
-      color="primary"
-      type="button"
-      data-testid="button-add-registered-endpoint"
-      :disabled="data.serviceEndpoints.length >= 50"
-      @click="handleAddEndpoint"
-    >
-      Add Endpoint
-    </AppButton>
+    <div class="border rounded mt-1 p-4">
+      <div class="row align-items-end flex-nowrap">
+        <!-- Type -->
+        <div class="col-2">
+          <label class="form-label">Type</label>
+          <select
+            class="form-control is-fill"
+            v-model="endpointType"
+            data-testid="select-registered-endpoint-type"
+          >
+            <option v-for="opt in Object.keys(RegisteredNodeTypeLabel)" :key="opt" :value="opt">
+              {{ RegisteredNodeTypeLabel[opt as RegisteredEndpointType] }}
+            </option>
+          </select>
+        </div>
+        <!-- IP/Domain -->
+        <div class="col-5">
+          <label class="form-label">IP/Domain <span class="text-danger">*</span></label>
+          <IpDomainInput
+            v-model="ipOrDomain"
+            @status="ipOrDomainStatus = $event"
+            data-testid="input-registered-endpoint-address"
+          />
+        </div>
+        <!-- Port -->
+        <div class="col-2">
+          <label class="form-label">Port <span class="text-danger">*</span></label>
+          <PortInput
+            v-model="port"
+            @status="portStatus = $event"
+            data-testid="input-registered-endpoint-port"
+          />
+        </div>
+        <!-- TLS -->
+        <div class="col-auto">
+          <label class="form-label">TLS</label>
+          <AppSwitch
+            v-model:checked="requiresTls"
+            size="md"
+            name="registered-endpoint-tls"
+            data-testid="switch-registered-endpoint-tls"
+          />
+        </div>
+        <!-- Add Endpoint -->
+        <div class="col-auto">
+          <AppButton
+            color="primary"
+            type="button"
+            :disabled="!addEndPointEnabled"
+            @click="handleAddEndpoint"
+            data-testid="button-add-registered-endpoint"
+          >
+            Add Endpoint
+          </AppButton>
+        </div>
+      </div>
+      <div class="row align-items-end flex-nowrap">
+        <!-- Block Node API options -->
+        <div v-if="endpointType === 'blockNode'" class="form-group mt-4">
+          <label class="form-label">Block Node APIs</label>
+          <BlockNodeApiOptions v-model="blockNodeApiOptions" />
+        </div>
+        <!-- General service description -->
+        <div v-else-if="endpointType === 'generalService'" class="form-group mt-4">
+          <label class="form-label">Description</label>
+          <AppTextArea
+            v-model="endpointDescription"
+            :filled="true"
+            placeholder="Describe what this general-service endpoint provides"
+            data-testid="textarea-registered-endpoint-general-desc"
+          />
+        </div>
+      </div>
+      <table class="table-custom mt-5">
+        <thead class="thin">
+          <tr>
+            <th class="text-start">Type</th>
+            <th class="text-start">IP/Domain</th>
+            <th class="text-start">Port</th>
+            <th class="text-start">TLS</th>
+            <th class="text-start">APIs/Description</th>
+            <th class="text-end">Action</th>
+          </tr>
+        </thead>
+        <tbody class="thin">
+          <template v-if="data.serviceEndpoints.length == 0">
+            <tr>
+              <td class="col text-center" colspan="6">
+                <span class="text-secondary">
+                  No service endpoint.<br />At least one item must be added.
+                </span>
+              </td>
+            </tr>
+          </template>
+          <template v-else>
+            <template v-for="(endpoint, index) in data.serviceEndpoints" :key="endpoint.uiId">
+              <EndpointRow
+                :endpoint="endpoint"
+                :index="index"
+                @delete="handleDeleteEndpoint(index)"
+              />
+            </template>
+          </template>
+        </tbody>
+      </table>
+    </div>
   </div>
-  <div class="text-micro text-muted mt-1 mb-3">
-    At least one endpoint is required. A registered node may have up to 50 endpoints.
-  </div>
-
-  <div v-if="data.serviceEndpoints.length === 0" class="text-muted text-small">
-    No endpoints added yet — click "Add Endpoint" to create one.
-  </div>
-
-  <EndpointRow
-    v-for="(endpoint, index) in data.serviceEndpoints"
-    :key="rowKey(endpoint, index)"
-    :endpoint="endpoint"
-    :index="index"
-    :type-options="endpointTypeOptions"
-    @update:endpoint="handleUpdateEndpoint(index, $event)"
-    @delete="handleDeleteEndpoint(index)"
-  />
 </template>
+
+<style scoped>
+.form-switch.form-switch-md {
+  margin-bottom: 0.5rem;
+  margin-top: 0.5rem;
+}
+</style>

--- a/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeTypeLabel.ts
+++ b/front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeTypeLabel.ts
@@ -1,0 +1,8 @@
+import type { RegisteredEndpointType } from '@renderer/utils';
+
+export const RegisteredNodeTypeLabel: Record<RegisteredEndpointType, string> = {
+  blockNode: 'Block Node',
+  mirrorNode: 'Mirror Node',
+  rpcRelay: 'RPC Relay',
+  generalService: 'General Service',
+};

--- a/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
@@ -15,6 +15,7 @@ import {
 } from '@hiero-ledger/sdk';
 
 import KeyStructureModal from '@renderer/components/KeyStructureModal.vue';
+import { labelForBlockNodeApi } from '@renderer/components/Transaction/Create/RegisteredNodeCreate/BlockNodeApiLabel.ts';
 
 /* Props */
 const props = defineProps<{
@@ -30,6 +31,11 @@ const typeLabel: Record<string, string> = {
   mirrorNode: 'Mirror Node',
   rpcRelay: 'RPC Relay',
   generalService: 'General Service',
+};
+
+/* Helpers */
+const blockNodeAPIs = (endpoint: BlockNodeServiceEndpoint) => {
+  return endpoint.endpointApis.map(api => labelForBlockNodeApi(api)).join(',');
 };
 
 /* Hooks */
@@ -112,11 +118,10 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
           <thead class="thin">
             <tr>
               <th class="text-start">Type</th>
-              <th class="text-start">IP Address</th>
-              <th class="text-start">Domain Name</th>
+              <th class="text-start">IP/Domain</th>
               <th class="text-start">Port</th>
               <th class="text-start">TLS</th>
-              <th class="text-start">Extra</th>
+              <th class="text-start">APIs/Description</th>
             </tr>
           </thead>
           <tbody class="thin">
@@ -130,16 +135,15 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
         -->
             <tr v-for="(endpoint, index) of transaction.serviceEndpoints" :key="index">
               <td class="col text-start">{{ typeLabel[endpoint.type] ?? endpoint.type }}</td>
-              <td class="col text-start">{{ endpoint.ipAddress }}</td>
-              <td class="col text-start">{{ endpoint.domainName }}</td>
+              <td class="col text-start">{{ endpoint.ipAddress ?? endpoint.domainName ?? '' }}</td>
               <td class="col text-start">{{ endpoint.port }}</td>
               <td class="col text-start">{{ endpoint.requiresTls ? 'Yes' : 'No' }}</td>
               <td class="col text-start">
                 <template v-if="endpoint instanceof BlockNodeServiceEndpoint">
-                  {{ (endpoint.endpointApis ?? []).length }} API(s)
+                  {{ blockNodeAPIs(endpoint) }}
                 </template>
                 <template v-else-if="endpoint instanceof GeneralServiceEndpoint">
-                  {{ endpoint.description || '' }}
+                  {{ endpoint.description ?? '' }}
                 </template>
               </td>
             </tr>


### PR DESCRIPTION
**Description**:

Changes below re-work service endpoints editing in `Registered Node Create`/`Update`.
They use the same approach as `Node Create`/`Update`:
- Endpoint list is displayed as a table
- Each row provides a `Delete` action to remove an endpoint
- New endpoint is added using inline fields and `Add Endpoint` action

<img width="895" height="808" alt="image" src="https://github.com/user-attachments/assets/12120be0-ca37-4ab9-98b9-7dd6c016574c" />

<img width="895" height="551" alt="image" src="https://github.com/user-attachments/assets/4e7bef27-a22f-4869-ab14-b020b7882dce" />

<img width="895" height="722" alt="image" src="https://github.com/user-attachments/assets/8e6ed368-e514-4eb5-9945-3ca145cdd060" />

**Related issue(s)**:

Fixes #2895

**Notes for reviewer**:
```
M   front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeFormData.vue
M   front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/Create/RegisteredNodeCreate/EndpointRow.vue
A   front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/BlockNodeApiOptions.vue
M   front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/RegisteredNodeTypeLabel.ts
A   front-end/src/renderer/components/Transaction/Create/RegisteredNodeCreate/BlockNodeApiLabel.ts
    # RegisteredNodeForm now displays endpoints as a table that can be populate and updated
    # using Add Endpoint and Delete Endpoint actions.

M   front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
    # Aligned on RegisteredNodeFormData layout.

A   front-end/src/renderer/components/PortInput.vue
    # Handles input of a port number.
    # Informs parent about input validity using @status event.

A   front-end/src/renderer/components/InputStatus.ts
R   front-end/src/renderer/components/IpDomainInputStatus.ts
M   front-end/src/renderer/components/IpDomainInput.vue
    # Renamed IpDomainInputStatus as InputStatus
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
