### PR TITLE
fix: update verifyAccess logic and apply consistently across history endpoints

### DIFF
--- a/back-end/apps/api/src/transactions/approvers/approvers.service.ts
+++ b/back-end/apps/api/src/transactions/approvers/approvers.service.ts
@@ -128,15 +128,7 @@ export class ApproversService {
       this.dataSource.manager,
     );
 
-    if (
-      [
-        TransactionStatus.EXECUTED,
-        TransactionStatus.EXPIRED,
-        TransactionStatus.FAILED,
-        TransactionStatus.CANCELED,
-        TransactionStatus.ARCHIVED,
-      ].includes(transaction.status)
-    )
+    if ([TransactionStatus.EXECUTED, TransactionStatus.FAILED].includes(transaction.status))
       return approvers;
 
     if (

--- a/back-end/apps/api/src/transactions/nodes/transaction-nodes.service.spec.ts
+++ b/back-end/apps/api/src/transactions/nodes/transaction-nodes.service.spec.ts
@@ -278,22 +278,6 @@ describe('TransactionNodesService', () => {
       (attachKeys as jest.Mock).mockImplementation((user) => user.keys.push(userKey));
     });
 
-    it('returns empty array when user has no keys', async () => {
-      // attachKeys leaves user.keys empty
-      (attachKeys as jest.Mock).mockImplementationOnce(() => { /* no-op */ });
-
-      const result = await service.getTransactionNodes(
-        user,
-        TransactionNodeCollection.READY_FOR_REVIEW,
-        TEST_NETWORK,
-        [],
-        [],
-      );
-
-      expect(result).toEqual([]);
-      expect(entityManager.query).not.toHaveBeenCalled();
-    });
-
     it('TransactionNodeCollection.READY_FOR_REVIEW => getTransactionsToApprove()', async () => {
       const mockQuery = makeMockQuery('SELECT * FROM transactions_ready_for_review');
 
@@ -471,7 +455,9 @@ describe('TransactionNodesService', () => {
           statuses: TRANSACTION_STATUS_COLLECTIONS.HISTORY,
           types: null,
           mirrorNetwork: TEST_NETWORK,
-        }
+        },
+        user,
+        { signer: true, creator: true, observer: true, approver: true },
       );
 
       expect(entityManager.query).toHaveBeenCalledWith(mockQuery.text, mockQuery.values);
@@ -499,7 +485,9 @@ describe('TransactionNodesService', () => {
           statuses: [TransactionStatus.EXPIRED],
           types: null,
           mirrorNetwork: TEST_NETWORK,
-        }
+        },
+        user,
+        { signer: true, creator: true, observer: true, approver: true },
       );
 
       expect(entityManager.query).toHaveBeenCalledWith(mockQuery.text, mockQuery.values);
@@ -527,7 +515,9 @@ describe('TransactionNodesService', () => {
           statuses: TRANSACTION_STATUS_COLLECTIONS.HISTORY,
           types: [TransactionType.FILE_APPEND],
           mirrorNetwork: TEST_NETWORK,
-        }
+        },
+        user,
+        { signer: true, creator: true, observer: true, approver: true },
       );
 
       expect(entityManager.query).toHaveBeenCalledWith(mockQuery.text, mockQuery.values);

--- a/back-end/apps/api/src/transactions/nodes/transaction-nodes.service.ts
+++ b/back-end/apps/api/src/transactions/nodes/transaction-nodes.service.ts
@@ -29,9 +29,6 @@ export class TransactionNodesService {
 
     //this should already be done, imo, in the validation stuff
     await attachKeys(user, this.entityManager);
-    if (user.keys.length === 0) {
-      return [];
-    }
 
     switch (collection) {
       case TransactionNodeCollection.READY_FOR_REVIEW: {
@@ -109,6 +106,13 @@ export class TransactionNodesService {
             statuses: statusFilter,
             types: transactionTypeFilter,
             mirrorNetwork: network,
+          },
+          user,
+          {
+            signer: true,
+            creator: true,
+            observer: true,
+            approver: true,
           }
         );
 

--- a/back-end/apps/api/src/transactions/observers/observers.service.ts
+++ b/back-end/apps/api/src/transactions/observers/observers.service.ts
@@ -89,15 +89,7 @@ export class ObserversService {
 
     const approvers = await this.approversService.getApproversByTransactionId(transaction.id);
 
-    if (
-      [
-        TransactionStatus.EXECUTED,
-        TransactionStatus.EXPIRED,
-        TransactionStatus.FAILED,
-        TransactionStatus.CANCELED,
-        TransactionStatus.ARCHIVED,
-      ].includes(transaction.status)
-    )
+    if ([TransactionStatus.EXECUTED, TransactionStatus.FAILED].includes(transaction.status))
       return transaction.observers;
 
     if (

--- a/back-end/apps/api/src/transactions/transactions.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.controller.spec.ts
@@ -247,7 +247,7 @@ describe('TransactionsController', () => {
 
       transactionService.getHistoryTransactions.mockResolvedValue(result);
 
-      expect(await controller.getHistoryTransactions(pagination)).toBe(result);
+      expect(await controller.getHistoryTransactions(user, pagination)).toBe(result);
     });
 
     it('should return an empty array if no transactions exist', async () => {
@@ -260,7 +260,7 @@ describe('TransactionsController', () => {
 
       transactionService.getHistoryTransactions.mockResolvedValue(result);
 
-      expect(await controller.getHistoryTransactions(pagination)).toEqual(result);
+      expect(await controller.getHistoryTransactions(user, pagination)).toEqual(result);
     });
   });
 

--- a/back-end/apps/api/src/transactions/transactions.controller.ts
+++ b/back-end/apps/api/src/transactions/transactions.controller.ts
@@ -142,6 +142,7 @@ export class TransactionsController {
   @Get('/history')
   @Serialize(withPaginatedResponse(TransactionDto))
   getHistoryTransactions(
+    @GetUser() user: User,
     @PaginationParams() paginationParams: Pagination,
     @SortingParams(transactionProperties) sort?: Sorting[],
     @FilteringParams({
@@ -150,7 +151,7 @@ export class TransactionsController {
     })
     filter?: Filtering[],
   ): Promise<PaginatedResourceDto<Transaction>> {
-    return this.transactionsService.getHistoryTransactions(paginationParams, filter, sort);
+    return this.transactionsService.getHistoryTransactions(user, paginationParams, filter, sort);
   }
 
   /* Get all transactions to be signed by the user */

--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -2,7 +2,16 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { mock, mockDeep } from 'jest-mock-extended';
 import { BadRequestException, ConflictException } from '@nestjs/common';
-import { Brackets, DataSource, DeepPartial, EntityManager, In, Not, Repository, SelectQueryBuilder } from 'typeorm';
+import {
+  Brackets,
+  DataSource,
+  DeepPartial,
+  EntityManager,
+  FindOptionsWhere,
+  In,
+  Repository,
+  SelectQueryBuilder,
+} from 'typeorm';
 import {
   AccountCreateTransaction,
   AccountId,
@@ -343,19 +352,11 @@ describe('TransactionsService', () => {
       const transactions = [];
       const count = 0;
 
-      const queryBuilder = {
-        setFindOptions: jest.fn().mockReturnThis(),
-        orWhere: jest.fn().mockImplementation(() => queryBuilder),
-        getManyAndCount: jest.fn().mockResolvedValue([transactions, count]),
-      };
-      transactionsRepo.createQueryBuilder.mockReturnValue(
-        queryBuilder as unknown as SelectQueryBuilder<Transaction>,
-      );
+      transactionsRepo.findAndCount.mockResolvedValue([transactions, count]);
 
-      const result = await service.getHistoryTransactions(defaultPagination);
+      const result = await service.getHistoryTransactions(user as User, defaultPagination);
 
-      expect(transactionsRepo.createQueryBuilder).toHaveBeenCalled();
-      expect(queryBuilder.setFindOptions).toHaveBeenCalledWith(
+      expect(transactionsRepo.findAndCount).toHaveBeenCalledWith(
         expect.objectContaining({
           relations: ['groupItem', 'groupItem.group'],
           skip: defaultPagination.offset,
@@ -1860,6 +1861,7 @@ describe('TransactionsService', () => {
       await sdkTransaction.sign(privateKey);
 
       entityManager.find.mockImplementation(makeFindDispatcher([transaction]) as any);
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([1]);
 
       const result = await service.importSignatures(
         [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
@@ -2023,8 +2025,40 @@ describe('TransactionsService', () => {
       await expect(service.verifyAccess(null, user as User)).rejects.toThrow(ErrorCodes.TNF);
     });
 
-    it('should return true for history/executed statuses', async () => {
+    it('should return true for EXECUTED status without user association check', async () => {
       const tx = { status: TransactionStatus.EXECUTED } as Transaction;
+      await expect(service.verifyAccess(tx, user as User)).resolves.toBe(true);
+    });
+
+    it('should return true for FAILED status without user association check', async () => {
+      const tx = { status: TransactionStatus.FAILED } as Transaction;
+      await expect(service.verifyAccess(tx, user as User)).resolves.toBe(true);
+    });
+
+    it('should require user association for EXPIRED transactions', async () => {
+      const tx = { status: TransactionStatus.EXPIRED } as Transaction;
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
+      await expect(service.verifyAccess(tx, user as User)).resolves.toBe(false);
+    });
+
+    it('should require user association for CANCELED transactions', async () => {
+      const tx = { status: TransactionStatus.CANCELED } as Transaction;
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
+      await expect(service.verifyAccess(tx, user as User)).resolves.toBe(false);
+    });
+
+    it('should require user association for ARCHIVED transactions', async () => {
+      const tx = { status: TransactionStatus.ARCHIVED } as Transaction;
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
+      await expect(service.verifyAccess(tx, user as User)).resolves.toBe(false);
+    });
+
+    it('should return true for EXPIRED if user is creator', async () => {
+      const tx = {
+        status: TransactionStatus.EXPIRED,
+        creatorKey: { userId: user.id },
+      } as Transaction;
+      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
       await expect(service.verifyAccess(tx, user as User)).resolves.toBe(true);
     });
 
@@ -2808,214 +2842,156 @@ describe('TransactionsService', () => {
     });
   });
 
-  describe('getHistoryWhere', () => {
+  describe('getHistoryStatusBuckets (via getHistoryTransactions)', () => {
     beforeEach(() => {
       jest.resetAllMocks();
+      transactionsRepo.findAndCount.mockResolvedValue([[], 0]);
     });
 
-    const allowedStatuses = [
-      TransactionStatus.EXECUTED,
-      TransactionStatus.FAILED,
-      TransactionStatus.EXPIRED,
-      TransactionStatus.CANCELED,
-      TransactionStatus.ARCHIVED,
-    ];
-    const forbiddenStatuses = Object.values(TransactionStatus).filter(
-      s => !allowedStatuses.includes(s),
-    );
+    const bypassStatuses = [TransactionStatus.EXECUTED, TransactionStatus.FAILED];
+    const nonBypassStatuses = [TransactionStatus.EXPIRED, TransactionStatus.CANCELED, TransactionStatus.ARCHIVED];
 
-    const mockQueryBuilder = () => {
-      const queryBuilder = {
-        setFindOptions: jest.fn().mockReturnThis(),
-        orWhere: jest.fn().mockImplementation(() => queryBuilder),
-        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
-      };
-      transactionsRepo.createQueryBuilder.mockReturnValue(
-        queryBuilder as unknown as SelectQueryBuilder<Transaction>,
+    const expectBypassBranch = (where: FindOptionsWhere<Transaction>[]) =>
+      expect(where).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ status: In(bypassStatuses) }),
+        ]),
       );
 
-      return queryBuilder;
-    };
-
-    it('should return where only with allowed statuses if not filter provided', async () => {
-      const queryBuilder = mockQueryBuilder();
-
-      await service.getHistoryTransactions(defaultPagination);
-
-      expect(queryBuilder.setFindOptions).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            status: Not(In(forbiddenStatuses)),
-          }),
-        }),
+    const expectNonBypassBranches = (where: FindOptionsWhere<Transaction>[]) =>
+      expect(where).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ status: In(nonBypassStatuses), creatorKey: { userId: user.id } }),
+          expect.objectContaining({ status: In(nonBypassStatuses), observers: { userId: user.id } }),
+          expect.objectContaining({ status: In(nonBypassStatuses), signers: { userId: user.id } }),
+        ]),
       );
+
+    it('should include all history statuses if no filter provided', async () => {
+      await service.getHistoryTransactions(user as User, defaultPagination);
+      const [{ where }] = transactionsRepo.findAndCount.mock.calls[0];
+      expectBypassBranch(where as FindOptionsWhere<Transaction>[]);
+      expectNonBypassBranches(where as FindOptionsWhere<Transaction>[]);
     });
 
-    it('should return where only with with allowed status if EQ filter provided', async () => {
-      const queryBuilder = mockQueryBuilder();
-
-      await service.getHistoryTransactions(defaultPagination, [
-        {
-          property: 'status',
-          rule: 'eq',
-          value: 'EXECUTED',
-        },
+    it('should only include bypass branch for EQ=EXECUTED filter', async () => {
+      await service.getHistoryTransactions(user as User, defaultPagination, [
+        { property: 'status', rule: 'eq', value: 'EXECUTED' },
       ]);
+      const [{ where }] = transactionsRepo.findAndCount.mock.calls[0];
+      const whereArr = where as FindOptionsWhere<Transaction>[];
+      expect(whereArr).toEqual(
+        expect.arrayContaining([expect.objectContaining({ status: In([TransactionStatus.EXECUTED]) })]),
+      );
+      expect(whereArr.every(w => !(w as any).creatorKey)).toBe(true);
+    });
 
-      expect(queryBuilder.setFindOptions).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            status: 'EXECUTED',
-          }),
-        }),
+    it('should fall back to all history statuses for invalid EQ filter', async () => {
+      await service.getHistoryTransactions(user as User, defaultPagination, [
+        { property: 'status', rule: 'eq', value: 'WAITING FOR EXECUTION' },
+      ]);
+      const [{ where }] = transactionsRepo.findAndCount.mock.calls[0];
+      expectBypassBranch(where as FindOptionsWhere<Transaction>[]);
+      expectNonBypassBranches(where as FindOptionsWhere<Transaction>[]);
+    });
+
+    it('should include only valid statuses for IN filter', async () => {
+      await service.getHistoryTransactions(user as User, defaultPagination, [
+        { property: 'status', rule: 'in', value: 'EXECUTED, WAITING FOR EXECUTION, WAITING FOR SIGNATURES, FAILED' },
+      ]);
+      const [{ where }] = transactionsRepo.findAndCount.mock.calls[0];
+      expect(where as FindOptionsWhere<Transaction>[]).toEqual(
+        expect.arrayContaining([expect.objectContaining({ status: In([TransactionStatus.EXECUTED, TransactionStatus.FAILED]) })]),
       );
     });
 
-    it('should return where with allowed statuses if malicious EQ filter provided', async () => {
-      const queryBuilder = mockQueryBuilder();
-
-      await service.getHistoryTransactions(defaultPagination, [
-        {
-          property: 'status',
-          rule: 'eq',
-          value: 'WAITING FOR EXECUTION',
-        },
+    it('should return empty result for malicious IN filter with no valid statuses', async () => {
+      const result = await service.getHistoryTransactions(user as User, defaultPagination, [
+        { property: 'status', rule: 'in', value: 'NEW, WAITING FOR EXECUTION, WAITING FOR SIGNATURES, REJECTED' },
       ]);
+      expect(result).toEqual({ totalItems: 0, items: [], page: defaultPagination.page, size: defaultPagination.size });
+      expect(transactionsRepo.findAndCount).not.toHaveBeenCalled();
+    });
 
-      expect(queryBuilder.setFindOptions).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            status: Not(In(forbiddenStatuses)),
-          }),
-        }),
+    it('should exclude the NEQ status from both buckets', async () => {
+      await service.getHistoryTransactions(user as User, defaultPagination, [
+        { property: 'status', rule: 'neq', value: 'EXECUTED' },
+      ]);
+      const [{ where }] = transactionsRepo.findAndCount.mock.calls[0];
+      const whereArr = where as FindOptionsWhere<Transaction>[];
+      // FAILED is still in bypass, EXPIRED/CANCELED/ARCHIVED in non-bypass
+      expect(whereArr).toEqual(
+        expect.arrayContaining([expect.objectContaining({ status: In([TransactionStatus.FAILED]) })]),
+      );
+      expect(whereArr).toEqual(
+        expect.arrayContaining([expect.objectContaining({ status: In(nonBypassStatuses), creatorKey: { userId: user.id } })]),
       );
     });
 
-    it('should return where only with with allowed statuses if IN filter provided', async () => {
-      const queryBuilder = mockQueryBuilder();
-
-      await service.getHistoryTransactions(defaultPagination, [
-        {
-          property: 'status',
-          rule: 'in',
-          value: 'EXECUTED, WAITING FOR EXECUTION, WAITING FOR SIGNATURES, FAILED',
-        },
+    it('should exclude NIN statuses from both buckets', async () => {
+      await service.getHistoryTransactions(user as User, defaultPagination, [
+        { property: 'status', rule: 'nin', value: 'EXECUTED, FAILED, EXPIRED' },
       ]);
-
-      expect(queryBuilder.setFindOptions).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            status: In([TransactionStatus.EXECUTED, TransactionStatus.FAILED]),
-          }),
-        }),
+      const [{ where }] = transactionsRepo.findAndCount.mock.calls[0];
+      const whereArr = where as FindOptionsWhere<Transaction>[];
+      // Only CANCELED and ARCHIVED remain — no bypass, non-bypass is reduced
+      const remaining = [TransactionStatus.CANCELED, TransactionStatus.ARCHIVED];
+      expect(whereArr.some(w => !('creatorKey' in w) && (w as any).status?.value?.includes(TransactionStatus.EXECUTED))).toBe(false);
+      expect(whereArr).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ status: In(remaining), creatorKey: { userId: user.id } }),
+        ]),
       );
     });
 
-    it('should return where only with with allowed statuses if malicious IN filter provided', async () => {
-      const queryBuilder = mockQueryBuilder();
-
-      await service.getHistoryTransactions(defaultPagination, [
-        {
-          property: 'status',
-          rule: 'in',
-          value: 'NEW, WAITING FOR EXECUTION, WAITING FOR SIGNATURES, REJECTED',
-        },
+    it('should include all history statuses for unsupported filter rule', async () => {
+      await service.getHistoryTransactions(user as User, defaultPagination, [
+        { property: 'status', rule: 'geteverythingpossiblerule', value: 'EXECUTED,FAILED,EXPIRED' },
       ]);
+      const [{ where }] = transactionsRepo.findAndCount.mock.calls[0];
+      expectBypassBranch(where as FindOptionsWhere<Transaction>[]);
+      expectNonBypassBranches(where as FindOptionsWhere<Transaction>[]);
+    });
 
-      expect(queryBuilder.setFindOptions).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            status: In([]),
+    it('should include all history statuses when filter has no status property', async () => {
+      await service.getHistoryTransactions(user as User, defaultPagination, [
+        { property: 'name', rule: 'eq', value: 'some transaction name' },
+      ]);
+      const [{ where }] = transactionsRepo.findAndCount.mock.calls[0];
+      expectBypassBranch(where as FindOptionsWhere<Transaction>[]);
+      expectNonBypassBranches(where as FindOptionsWhere<Transaction>[]);
+    });
+
+    it('should include cached account and node branches when user has keys', async () => {
+      jest.mocked(attachKeys).mockImplementationOnce(async (u: User) => {
+        u.keys = [{ id: 1, publicKey: 'pub-key-1' }] as any;
+      });
+
+      await service.getHistoryTransactions(user as User, defaultPagination);
+      const [{ where }] = transactionsRepo.findAndCount.mock.calls[0];
+      const whereArr = where as FindOptionsWhere<Transaction>[];
+      expect(whereArr).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            status: In(nonBypassStatuses),
+            transactionCachedAccounts: { cachedAccount: { keys: { publicKey: In(['pub-key-1']) } } },
           }),
-        }),
+          expect.objectContaining({
+            status: In(nonBypassStatuses),
+            transactionCachedNodes: { cachedNode: { keys: { publicKey: In(['pub-key-1']) } } },
+          }),
+        ]),
       );
     });
 
-    it('should return where only with with allowed status if NEQ filter provided', async () => {
-      const queryBuilder = mockQueryBuilder();
-
-      await service.getHistoryTransactions(defaultPagination, [
-        {
-          property: 'status',
-          rule: 'neq',
-          value: 'EXECUTED',
-        },
-      ]);
-
-      expect(queryBuilder.setFindOptions).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            status: Not(In([...forbiddenStatuses, TransactionStatus.EXECUTED])),
-          }),
-        }),
-      );
-    });
-
-    it('should return where only with with allowed statuses if NIN filter provided', async () => {
-      const queryBuilder = mockQueryBuilder();
-
-      await service.getHistoryTransactions(defaultPagination, [
-        {
-          property: 'status',
-          rule: 'nin',
-          value: 'EXECUTED, FAILED,EXPIRED',
-        },
-      ]);
-
-      expect(queryBuilder.setFindOptions).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            status: Not(
-              In([
-                ...forbiddenStatuses,
-                TransactionStatus.EXECUTED,
-                TransactionStatus.FAILED,
-                TransactionStatus.EXPIRED,
-              ]),
-            ),
-          }),
-        }),
-      );
-    });
-
-    it('should return where only with with allowed statuses if unsupported filter', async () => {
-      const queryBuilder = mockQueryBuilder();
-
-      await service.getHistoryTransactions(defaultPagination, [
-        {
-          property: 'status',
-          rule: 'geteverythingpossiblerule',
-          value: 'EXECUTED,FAILED,EXPIRED',
-        },
-      ]);
-
-      expect(queryBuilder.setFindOptions).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            status: Not(In([...forbiddenStatuses])),
-          }),
-        }),
-      );
-    });
-
-    it('should return default where if filtering has no status filter', async () => {
-      const queryBuilder = mockQueryBuilder();
-
-      await service.getHistoryTransactions(defaultPagination, [
-        {
-          property: 'name',  // any property that isn't 'status'
-          rule: 'eq',
-          value: 'some transaction name',
-        },
-      ]);
-
-      expect(queryBuilder.setFindOptions).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            status: Not(In(forbiddenStatuses)),
-          }),
-        }),
-      );
+    it('should omit cached branches when user has no keys', async () => {
+      jest.mocked(attachKeys).mockImplementationOnce(async (u: User) => {
+        u.keys = [];
+      });
+      await service.getHistoryTransactions(user as User, defaultPagination);
+      const [{ where }] = transactionsRepo.findAndCount.mock.calls[0];
+      const whereArr = where as FindOptionsWhere<Transaction>[];
+      expect(whereArr.some(w => 'transactionCachedAccounts' in w || 'transactionCachedNodes' in w)).toBe(false);
     });
   });
 

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -15,6 +15,7 @@ import {
 } from '@hiero-ledger/sdk';
 
 import {
+  ArrayOverlap,
   Brackets,
   DataSource,
   EntityManager,
@@ -265,6 +266,12 @@ export class TransactionsService {
             ...baseWhere,
             status: statusClause,
             transactionCachedNodes: { cachedNode: { keys: { publicKey: In(userPublicKeys) } } },
+          },
+          // Branch 3: user's key is directly listed in the transaction's publicKeys array
+          {
+            ...baseWhere,
+            status: statusClause,
+            publicKeys: ArrayOverlap(userPublicKeys),
           },
         );
       }

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -19,7 +19,6 @@ import {
   DataSource,
   EntityManager,
   FindManyOptions,
-  FindOperator,
   FindOptionsWhere,
   In,
   Not,
@@ -32,7 +31,6 @@ import {
   TransactionObserver,
   TransactionSigner,
   TransactionStatus,
-  TransactionType,
   User,
   UserKey,
 } from '@entities';
@@ -224,27 +222,65 @@ export class TransactionsService {
 
   /* Get the transactions visible by the user */
   async getHistoryTransactions(
+    user: User,
     { page, limit, size, offset }: Pagination,
     filter: Filtering[] = [],
     sort: Sorting[] = [],
   ): Promise<PaginatedResourceDto<Transaction>> {
     const order = getOrder(sort);
 
-    const findOptions: FindManyOptions<Transaction> = {
-      where: {
-        ...getWhere<Transaction>(filter),
-        status: this.getHistoryStatusWhere(filter),
-      },
+    await attachKeys(user, this.entityManager);
+
+    const { bypassStatuses, nonBypassStatuses } = this.getHistoryStatusBuckets(filter);
+
+    // Strip status from baseWhere — each branch sets its own status condition.
+    const baseWhere = getWhere<Transaction>(filter.filter(f => f.property !== 'status'));
+
+    const whereArray: FindOptionsWhere<Transaction>[] = [];
+
+    // EXECUTED and FAILED: submitted to the network, visible to everyone.
+    if (bypassStatuses.length > 0) {
+      whereArray.push({ ...baseWhere, status: In(bypassStatuses) });
+    }
+
+    // EXPIRED, CANCELED, ARCHIVED: require user association.
+    if (nonBypassStatuses.length > 0) {
+      const statusClause = In(nonBypassStatuses);
+      const userPublicKeys = user.keys?.map(k => k.publicKey) ?? [];
+
+      whereArray.push(
+        { ...baseWhere, status: statusClause, creatorKey: { userId: user.id } },
+        { ...baseWhere, status: statusClause, observers: { userId: user.id } },
+        { ...baseWhere, status: statusClause, signers: { userId: user.id } },
+      );
+
+      if (userPublicKeys.length > 0) {
+        whereArray.push(
+          {
+            ...baseWhere,
+            status: statusClause,
+            transactionCachedAccounts: { cachedAccount: { keys: { publicKey: In(userPublicKeys) } } },
+          },
+          {
+            ...baseWhere,
+            status: statusClause,
+            transactionCachedNodes: { cachedNode: { keys: { publicKey: In(userPublicKeys) } } },
+          },
+        );
+      }
+    }
+
+    if (whereArray.length === 0) {
+      return { totalItems: 0, items: [], page, size };
+    }
+
+    const [transactions, total] = await this.repo.findAndCount({
+      where: whereArray,
       order,
       relations: ['groupItem', 'groupItem.group'],
       skip: offset,
       take: limit,
-    };
-
-    const [transactions, total] = await this.repo
-      .createQueryBuilder()
-      .setFindOptions(findOptions)
-      .getManyAndCount();
+    });
 
     return {
       totalItems: total,
@@ -966,10 +1002,7 @@ export class TransactionsService {
     if (
       [
         TransactionStatus.EXECUTED,
-        TransactionStatus.EXPIRED,
         TransactionStatus.FAILED,
-        TransactionStatus.CANCELED,
-        TransactionStatus.ARCHIVED,
       ].includes(transaction.status)
     )
       return true;
@@ -1150,46 +1183,44 @@ export class TransactionsService {
     };
   }
 
-  /* Get the status where clause for the history transactions */
-  private getHistoryStatusWhere(
-    filtering: Filtering[],
-  ): TransactionStatus | FindOperator<TransactionStatus> {
-    const allowedStatuses = [
-      TransactionStatus.EXECUTED,
-      TransactionStatus.FAILED,
-      TransactionStatus.EXPIRED,
-      TransactionStatus.CANCELED,
-      TransactionStatus.ARCHIVED,
-    ];
-    const forbiddenStatuses = Object.values(TransactionStatus).filter(
-      s => !allowedStatuses.includes(s),
-    );
+  /* Splits the status filter into bypass (EXECUTED/FAILED) and non-bypass buckets. */
+  private getHistoryStatusBuckets(filtering: Filtering[]): {
+    bypassStatuses: TransactionStatus[];
+    nonBypassStatuses: TransactionStatus[];
+  } {
+    const bypassGroup = [TransactionStatus.EXECUTED, TransactionStatus.FAILED];
+    const nonBypassGroup = [TransactionStatus.EXPIRED, TransactionStatus.CANCELED, TransactionStatus.ARCHIVED];
+    const allHistoryStatuses = [...bypassGroup, ...nonBypassGroup];
 
-    if (!filtering || filtering.length === 0) return Not(In([...forbiddenStatuses]));
+    const statusFilter = filtering?.find(f => f.property === 'status');
 
-    const statusFilter = filtering.find(f => f.property === 'status');
+    let allowed = allHistoryStatuses;
 
-    if (!statusFilter) return Not(In([...forbiddenStatuses]));
+    if (statusFilter) {
+      const values = statusFilter.value.split(',').map(v => v.trim()) as TransactionStatus[];
+      const validValues = values.filter(s => allHistoryStatuses.includes(s));
 
-    const statusFilterValue = statusFilter.value
-      .split(',')
-      .map(v => v.trim()) as TransactionStatus[];
-
-    switch (statusFilter.rule) {
-      case 'eq':
-        return allowedStatuses.includes(statusFilterValue[0])
-          ? statusFilterValue[0]
-          : Not(In([...forbiddenStatuses]));
-      case 'in':
-        return In(statusFilterValue.filter(s => allowedStatuses.includes(s)));
-      case 'neq':
-        return Not(In([...forbiddenStatuses, ...statusFilterValue]));
-      case 'nin':
-        return Not(
-          In([...forbiddenStatuses, ...statusFilterValue.filter(s => allowedStatuses.includes(s))]),
-        );
-      default:
-        return Not(In([...forbiddenStatuses]));
+      switch (statusFilter.rule) {
+        case 'eq':
+          allowed = allHistoryStatuses.includes(values[0]) ? [values[0]] : allHistoryStatuses;
+          break;
+        case 'in':
+          allowed = validValues;
+          break;
+        case 'neq':
+          allowed = allHistoryStatuses.filter(s => !values.includes(s));
+          break;
+        case 'nin':
+          allowed = allHistoryStatuses.filter(s => !validValues.includes(s));
+          break;
+        default:
+          // keep all
+      }
     }
+
+    return {
+      bypassStatuses: allowed.filter(s => bypassGroup.includes(s)),
+      nonBypassStatuses: allowed.filter(s => nonBypassGroup.includes(s)),
+    };
   }
 }

--- a/back-end/libs/common/src/sql/queries/transaction.queries.ts
+++ b/back-end/libs/common/src/sql/queries/transaction.queries.ts
@@ -201,8 +201,7 @@ function buildEligibilityConditions(
  * The resulting clause is structured as:
  * `(filter conditions) AND ((eligibility conditions) OR (bypass status check))`
  *
- * EXECUTED and FAILED bypass the eligibility check and are always visible.
- * EXPIRED, CANCELED, and ARCHIVED require a user association (creator, observer, or signer).
+ * EXPIRED, CANCELED, and ARCHIVED require a user association (creator, observer, signer, or approver).
  *
  * @param sql - The SQL builder service used to resolve table and column names.
  * @param filters - Optional filters to apply, such as status, type, and mirror network.

--- a/back-end/libs/common/src/sql/queries/transaction.queries.ts
+++ b/back-end/libs/common/src/sql/queries/transaction.queries.ts
@@ -40,6 +40,7 @@ interface WhereClauseResult {
 
 // Only EXECUTED and FAILED are world-readable. EXPIRED, CANCELED, and ARCHIVED
 // still require a user association check (creator / observer / signer / approver).
+const BYPASS_STATUSES = [
   TransactionStatus.EXECUTED,
   TransactionStatus.FAILED,
 ];

--- a/back-end/libs/common/src/sql/queries/transaction.queries.ts
+++ b/back-end/libs/common/src/sql/queries/transaction.queries.ts
@@ -39,8 +39,7 @@ interface WhereClauseResult {
 }
 
 // Only EXECUTED and FAILED are world-readable. EXPIRED, CANCELED, and ARCHIVED
-// still require a user association check (creator / observer / signer).
-const BYPASS_STATUSES = [
+// still require a user association check (creator / observer / signer / approver).
   TransactionStatus.EXECUTED,
   TransactionStatus.FAILED,
 ];

--- a/back-end/libs/common/src/sql/queries/transaction.queries.ts
+++ b/back-end/libs/common/src/sql/queries/transaction.queries.ts
@@ -38,13 +38,11 @@ interface WhereClauseResult {
   addParam: (value: any) => string;
 }
 
-const TERMINAL_STATUSES = [
-  TransactionStatus.CANCELED,
-  TransactionStatus.REJECTED,
+// Only EXECUTED and FAILED are world-readable. EXPIRED, CANCELED, and ARCHIVED
+// still require a user association check (creator / observer / signer).
+const BYPASS_STATUSES = [
   TransactionStatus.EXECUTED,
   TransactionStatus.FAILED,
-  TransactionStatus.EXPIRED,
-  TransactionStatus.ARCHIVED,
 ];
 
 function buildFilterConditions(
@@ -202,10 +200,10 @@ function buildEligibilityConditions(
  * Builds a parameterized SQL WHERE clause for filtering and authorizing transaction queries.
  *
  * The resulting clause is structured as:
- * `(filter conditions) AND ((eligibility conditions) OR (terminal status override))`
+ * `(filter conditions) AND ((eligibility conditions) OR (bypass status check))`
  *
- * Terminal statuses (CANCELED, REJECTED, EXECUTED, FAILED, EXPIRED, ARCHIVED) always
- * pass the eligibility check regardless of user or role conditions.
+ * EXECUTED and FAILED bypass the eligibility check and are always visible.
+ * EXPIRED, CANCELED, and ARCHIVED require a user association (creator, observer, or signer).
  *
  * @param sql - The SQL builder service used to resolve table and column names.
  * @param filters - Optional filters to apply, such as status, type, and mirror network.
@@ -237,7 +235,7 @@ function buildWhereClause(
     eligibilityConditions.push(...buildEligibilityConditions(sql, user, roles, addParam));
   }
 
-  const statusParam = addParam(TERMINAL_STATUSES);
+  const statusParam = addParam(BYPASS_STATUSES);
   eligibilityConditions.push(`t.${sql.col(Transaction, 'status')} = ANY(${statusParam})`);
 
   conditions.push(`(${eligibilityConditions.join(' OR ')})`);


### PR DESCRIPTION
**Description**:
This pull request refines the handling of transaction status checks and user association logic. All transactions that are publicly available (`EXECUTED` or `FAILED`) bypass all user check restrictions. All other transaction statuses (i.e. `CANCELED`, `EXPIRED`, etc.) will be filtered based on the user's involvement.

**Related issue(s)**:

Fixes #2879 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
