### PR TITLE
feat: add cleanup step to delete build artifacts cache after tests

### DIFF
--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -475,9 +475,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api --method DELETE \
-            "/repos/${{ github.repository }}/actions/caches?key=build-artifacts-${{ github.sha }}" \
-            || true
+          if ! gh api --method DELETE \
+            "/repos/${{ github.repository }}/actions/caches?key=build-artifacts-${{ github.sha }}&ref=${{ github.ref }}"; then
+            echo "::warning::Failed to delete Actions cache build-artifacts-${{ github.sha }}"
+          fi
 
   unit-test:
     name: Unit Tests | ${{ matrix.test-suite.name }}

--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -457,6 +457,28 @@ jobs:
         run: docker compose -f "${BACKEND_COMPOSE_FILE}" down --volumes --remove-orphans || true
         working-directory: back-end
 
+  cleanup:
+    name: Cleanup | Build Cache
+    runs-on: transaction-tools-linux-medium
+    needs: [test]
+    if: always()
+    permissions:
+      actions: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Delete Build Artifacts Cache
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method DELETE \
+            "/repos/${{ github.repository }}/actions/caches?key=build-artifacts-${{ github.sha }}" \
+            || true
+
   unit-test:
     name: Unit Tests | ${{ matrix.test-suite.name }}
     runs-on: transaction-tools-linux-medium


### PR DESCRIPTION
**Description**:
This pull request adds a new cleanup job to the frontend test workflow to improve cache management and runner security. 

**Notes for reviewer**:
The repo cache was constantly full. We seem to be having issues with pulling cached images during builds and tests. Hopefully, removing the caches at the end will help.

