### PR TITLE
feat: enforce SSL in TypeORM configuration for SQL connection

### DIFF
--- a/back-end/libs/common/src/database/database.module.ts
+++ b/back-end/libs/common/src/database/database.module.ts
@@ -18,6 +18,7 @@ import { ConfigService } from '@nestjs/config';
           synchronize: configService.getOrThrow<boolean>('POSTGRES_SYNCHRONIZE', { infer: true }),
           autoLoadEntities: true,
           poolSize: configService.getOrThrow<number>('POSTGRES_MAX_POOL_SIZE', { infer: true }),
+          ssl: { rejectUnauthorized: false },
         }) as TypeOrmModuleAsyncOptions,
       inject: [ConfigService],
     }),
@@ -40,6 +41,7 @@ import { ConfigService } from '@nestjs/config';
           extra: {
             statement_timeout: 15000, // Slightly longer for cache operations
           },
+          ssl: { rejectUnauthorized: false },
         }) as TypeOrmModuleAsyncOptions,
       inject: [ConfigService],
     }),

--- a/back-end/libs/common/src/database/database.module.ts
+++ b/back-end/libs/common/src/database/database.module.ts
@@ -18,7 +18,7 @@ import { ConfigService } from '@nestjs/config';
           synchronize: configService.getOrThrow<boolean>('POSTGRES_SYNCHRONIZE', { infer: true }),
           autoLoadEntities: true,
           poolSize: configService.getOrThrow<number>('POSTGRES_MAX_POOL_SIZE', { infer: true }),
-          ssl: { rejectUnauthorized: false },
+          ssl: configService.get('NODE_ENV') === 'production' ? { rejectUnauthorized: false } : false,
         }) as TypeOrmModuleAsyncOptions,
       inject: [ConfigService],
     }),
@@ -41,7 +41,7 @@ import { ConfigService } from '@nestjs/config';
           extra: {
             statement_timeout: 15000, // Slightly longer for cache operations
           },
-          ssl: { rejectUnauthorized: false },
+          ssl: configService.get('NODE_ENV') === 'production' ? { rejectUnauthorized: false } : false,
         }) as TypeOrmModuleAsyncOptions,
       inject: [ConfigService],
     }),

--- a/back-end/test-utils/postgres-test-db.ts
+++ b/back-end/test-utils/postgres-test-db.ts
@@ -51,6 +51,7 @@ export async function createTestPostgresDataSource() {
       username: container.getUsername(),
       password: container.getPassword(),
       database: container.getDatabase(),
+      ssl: false,
     });
 
     const initStart = Date.now();

--- a/back-end/typeorm/data-source.ts
+++ b/back-end/typeorm/data-source.ts
@@ -14,6 +14,7 @@ export const AppDataSource = new DataSource({
   username: process.env.POSTGRES_USERNAME || 'postgres',
   password: process.env.POSTGRES_PASSWORD || 'postgres',
   database: process.env.POSTGRES_DATABASE || 'postgres',
+  ssl: { rejectUnauthorized: false },
 
   // Entities: .ts in dev, .js in production/Docker
   entities: [

--- a/back-end/typeorm/data-source.ts
+++ b/back-end/typeorm/data-source.ts
@@ -14,7 +14,7 @@ export const AppDataSource = new DataSource({
   username: process.env.POSTGRES_USERNAME || 'postgres',
   password: process.env.POSTGRES_PASSWORD || 'postgres',
   database: process.env.POSTGRES_DATABASE || 'postgres',
-  ssl: { rejectUnauthorized: false },
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
 
   // Entities: .ts in dev, .js in production/Docker
   entities: [

--- a/back-end/typeorm/test/integration/post-migration.test.ts
+++ b/back-end/typeorm/test/integration/post-migration.test.ts
@@ -21,6 +21,7 @@ describe('Post-Migration Database Validation', () => {
       username: container.getUsername(),
       password: container.getPassword(),
       database: container.getDatabase(),
+      ssl: false,
     });
 
     await AppDataSource.initialize();

--- a/back-end/typeorm/test/migrations/schema-sync.test.ts
+++ b/back-end/typeorm/test/migrations/schema-sync.test.ts
@@ -25,6 +25,7 @@ describe('Schema Synchronization', () => {
       username: container.getUsername(),
       password: container.getPassword(),
       database: container.getDatabase(),
+      ssl: false,
     });
 
     // Recreate instance (important if AppDataSource was already initialized)


### PR DESCRIPTION
**Description**:
This pull request adds SSL support to the PostgreSQL database connections across the codebase. The main change is configuring the connections to use SSL with `rejectUnauthorized: false`, which makes SSL required for communication to the database.

**Related issue(s)**:

Fixes #2917 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
