### PR TITLE
fix: validate signatures before recording in POST /transactions/:transactionId/signers

### DIFF
--- a/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
@@ -1,4 +1,3 @@
-import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock, mockDeep } from 'jest-mock-extended';
 import { getRepositoryToken } from '@nestjs/typeorm';

--- a/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock, mockDeep } from 'jest-mock-extended';
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -19,6 +20,7 @@ import {
   NatsPublisherService,
   processTransactionStatus,
   TransactionSignatureService,
+  validateSignature,
 } from '@app/common';
 import { isExpired } from '@app/common/utils';
 
@@ -30,6 +32,7 @@ jest.mock('@app/common', () => ({
   emitTransactionStatusUpdate: jest.fn(),
   emitTransactionUpdate: jest.fn(),
   processTransactionStatus: jest.fn(),
+  validateSignature: jest.fn(),
 }));
 
 describe('SignersService', () => {
@@ -56,6 +59,7 @@ describe('SignersService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    jest.mocked(validateSignature).mockReturnValue([]);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -284,6 +288,7 @@ describe('SignersService', () => {
 
       await sdkTransaction.sign(privateKey);
       const signatureMap = sdkTransaction.getSignatures();
+      jest.mocked(validateSignature).mockReturnValue([privateKey.publicKey]);
 
       const result = await service['processTransactionSignatures'](
         transaction,
@@ -314,6 +319,7 @@ describe('SignersService', () => {
 
       await sdkTransaction.sign(privateKey);
       const signatureMap = sdkTransaction.getSignatures();
+      jest.mocked(validateSignature).mockReturnValue([privateKey.publicKey]);
 
       await expect(
         service['processTransactionSignatures'](
@@ -342,6 +348,7 @@ describe('SignersService', () => {
 
       await sdkTransaction.sign(privateKey);
       const signatureMap = sdkTransaction.getSignatures();
+      jest.mocked(validateSignature).mockReturnValue([privateKey.publicKey]);
 
       const existingSignerIds = new Set([3]); // Already signed
 
@@ -382,6 +389,64 @@ describe('SignersService', () => {
       );
 
       expect(result.isSameBytes).toBe(true);
+    });
+
+    it('should throw when validateSignature reports an invalid signature', async () => {
+      jest.mocked(validateSignature).mockImplementation(() => { throw new Error('Invalid signature'); });
+
+      const privateKey = PrivateKey.generateECDSA();
+      const userKeyMap = new Map<string, any>();
+      userKeyMap.set(privateKey.publicKey.toStringRaw(), { id: 3, publicKey: privateKey.publicKey.toStringRaw() });
+
+      const sdkTransaction = new AccountCreateTransaction()
+        .setTransactionId(TransactionId.generate('0.0.2'))
+        .setNodeAccountIds([AccountId.fromString('0.0.3')])
+        .freeze();
+
+      await sdkTransaction.sign(privateKey);
+      const signatureMap = sdkTransaction.getSignatures();
+
+      const transaction = {
+        id: 1,
+        transactionBytes: sdkTransaction.toBytes(),
+      } as Transaction;
+
+      await expect(
+        service['processTransactionSignatures'](transaction, signatureMap, userKeyMap, new Set())
+      ).rejects.toThrow('Invalid signature');
+    });
+  });
+
+  describe('validateAndProcessSignatures', () => {
+    it('should capture invalid signature errors as a result entry without throwing', async () => {
+      jest.mocked(validateSignature).mockImplementation(() => { throw new Error('Invalid signature'); });
+
+      const privateKey = PrivateKey.generateECDSA();
+
+      const sdkTransaction = new AccountCreateTransaction()
+        .setTransactionId(TransactionId.generate('0.0.2'))
+        .setNodeAccountIds([AccountId.fromString('0.0.3')])
+        .freeze();
+
+      await sdkTransaction.sign(privateKey);
+      const signatureMap = sdkTransaction.getSignatures();
+
+      const transaction = {
+        id: 1,
+        transactionBytes: sdkTransaction.toBytes(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+      } as Transaction;
+
+      const dto = [{ id: 1, signatureMap }];
+      const transactionMap = new Map([[1, transaction]]);
+      const signersByTransaction = new Map<number, Set<number>>();
+
+      jest.mocked(isExpired).mockReturnValue(false);
+
+      const results = await service['validateAndProcessSignatures'](dto, user, transactionMap, signersByTransaction);
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({ id: 1, error: 'Invalid signature' });
     });
   });
 
@@ -628,6 +693,7 @@ describe('SignersService', () => {
       const statusMap = new Map<number, TransactionStatus>();
       statusMap.set(transactionId, TransactionStatus.WAITING_FOR_EXECUTION);
       jest.mocked(processTransactionStatus).mockResolvedValue(statusMap);
+      jest.mocked(validateSignature).mockReturnValue([privateKey.publicKey]);
 
       const result = await service.uploadSignatureMaps(
         [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
@@ -698,6 +764,7 @@ describe('SignersService', () => {
       statusMap.set(transactionId1, TransactionStatus.WAITING_FOR_EXECUTION);
       statusMap.set(transactionId2, TransactionStatus.WAITING_FOR_EXECUTION);
       jest.mocked(processTransactionStatus).mockResolvedValue(statusMap);
+      jest.mocked(validateSignature).mockReturnValue([privateKey.publicKey]);
 
       const result = await service.uploadSignatureMaps(
         [
@@ -814,6 +881,7 @@ describe('SignersService', () => {
       });
 
       jest.mocked(processTransactionStatus).mockResolvedValue(new Map());
+      jest.mocked(validateSignature).mockReturnValue([privateKey.publicKey]);
 
       const result = await service.uploadSignatureMaps(
         [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],

--- a/back-end/apps/api/src/transactions/signers/signers.service.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.service.ts
@@ -15,6 +15,7 @@ import {
   Pagination,
   processTransactionStatus,
   TransactionSignatureService,
+  validateSignature,
 } from '@app/common';
 import { Transaction, TransactionSigner, TransactionStatus, User, UserKey } from '@entities';
 
@@ -222,43 +223,32 @@ export class SignersService {
   ) {
     let sdkTransaction = SDKTransaction.fromBytes(transaction.transactionBytes);
 
+    // Verify all signatures; returns only keys not already on the transaction.
+    // Throws if any signature is invalid.
+    const validPublicKeys = validateSignature(sdkTransaction, map);
+
+    if (validPublicKeys.length === 0) {
+      return { sdkTransaction, userKeys: [], isSameBytes: true };
+    }
+
     const userKeys: UserKey[] = [];
-    const processedRawKeys = new Set<string>();
 
-    // To explain what is going on here, we need to understand how sdkTransaction.addSignature works.
-    // The addSignature method will go through each inner transaction, then go through the map
-    // and pull the signatures for the supplied public key belonging to that inner transaction
-    // (denoted by the node and transaction id), add the signatures to the inner transactions.
-    // So we need to go through the map and get each unique publicKey and call addSignature one time
-    // per key.
-    for (const nodeMap of map.values()) {
-      for (const txMap of nodeMap.values()) {
-        for (const publicKey of txMap.keys()) {
-          const raw = publicKey.toStringRaw();
+    for (const publicKey of validPublicKeys) {
+      const raw = publicKey.toStringRaw();
 
-          // Skip duplicates across node/tx maps, and already-processed keys
-          if (processedRawKeys.has(raw)) continue;
-          processedRawKeys.add(raw);
+      let userKey = userKeyMap.get(raw);
+      if (!userKey) {
+        userKey = userKeyMap.get(publicKey.toStringDer());
+      }
+      if (!userKey) throw new Error(ErrorCodes.PNY);
 
-          // Look up key (raw first, then DER)
-          let userKey = userKeyMap.get(raw);
-          if (!userKey) {
-            userKey = userKeyMap.get(publicKey.toStringDer());
-          }
-          if (!userKey) throw new Error(ErrorCodes.PNY);
+      sdkTransaction = sdkTransaction.addSignature(publicKey, map);
 
-          // Only add the signature once per unique key
-          sdkTransaction = sdkTransaction.addSignature(publicKey, map);
-
-          // Only return "new" signers (not already persisted)
-          if (!existingSignerIds.has(userKey.id)) {
-            userKeys.push(userKey);
-          }
-        }
+      if (!existingSignerIds.has(userKey.id)) {
+        userKeys.push(userKey);
       }
     }
 
-    // Finally, compare the resulting transaction bytes to see if any signatures were actually added
     const isSameBytes = Buffer.from(sdkTransaction.toBytes()).equals(
       transaction.transactionBytes
     );

--- a/back-end/apps/api/src/transactions/signers/signers.service.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.service.ts
@@ -223,14 +223,17 @@ export class SignersService {
   ) {
     let sdkTransaction = SDKTransaction.fromBytes(transaction.transactionBytes);
 
-    // Verify ALL signatures (including already-signed keys); returns only (deduped) keys
-    // not already on the transaction. Throws if any signature is invalid.
-    const validNewKeys = validateSignature(sdkTransaction, map);
+    // Verify ALL signatures (including already-signed keys)
+    // Returns the list of new keys (those not already in the transaction) and the list of all keys.
+    // Throws if any signature is invalid.
+    const { newPublicKeys: validNewKeys, allPublicKeys: validKeys } = validateSignature(
+      sdkTransaction,
+      map,
+    );
 
     const userKeys: UserKey[] = [];
 
-    // For new keys: add to transaction bytes + record as signer
-    for (const publicKey of validNewKeys) {
+    for (const publicKey of validKeys) {
       const raw = publicKey.toStringRaw();
 
       let userKey = userKeyMap.get(raw);
@@ -239,8 +242,12 @@ export class SignersService {
       }
       if (!userKey) throw new Error(ErrorCodes.PNY);
 
-      sdkTransaction = sdkTransaction.addSignature(publicKey, map);
+      // Add new key to transaction bytes
+      if (validNewKeys.includes(publicKey)) {
+        sdkTransaction = sdkTransaction.addSignature(publicKey, map);
+      }
 
+      // Record "new" signer (not already persisted)
       if (!existingSignerIds.has(userKey.id)) {
         userKeys.push(userKey);
       }

--- a/back-end/apps/api/src/transactions/signers/signers.service.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.service.ts
@@ -223,17 +223,14 @@ export class SignersService {
   ) {
     let sdkTransaction = SDKTransaction.fromBytes(transaction.transactionBytes);
 
-    // Verify all signatures; returns only keys not already on the transaction.
-    // Throws if any signature is invalid.
-    const validPublicKeys = validateSignature(sdkTransaction, map);
-
-    if (validPublicKeys.length === 0) {
-      return { sdkTransaction, userKeys: [], isSameBytes: true };
-    }
+    // Verify ALL signatures (including already-signed keys); returns only (deduped) keys
+    // not already on the transaction. Throws if any signature is invalid.
+    const validNewKeys = validateSignature(sdkTransaction, map);
 
     const userKeys: UserKey[] = [];
 
-    for (const publicKey of validPublicKeys) {
+    // For new keys: add to transaction bytes + record as signer
+    for (const publicKey of validNewKeys) {
       const raw = publicKey.toStringRaw();
 
       let userKey = userKeyMap.get(raw);

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -618,12 +618,14 @@ export class TransactionsService {
         const sdkTransaction = SDKTransaction.fromBytes(transaction.transactionBytes);
         if (isExpired(sdkTransaction)) throw new BadRequestException(ErrorCodes.TE);
 
-        const { data: publicKeys, error } = safe<PublicKey[]>(
+        // Verify ALL signatures (including already-signed keys); returns only (deduped) keys
+        // not already on the transaction. Throws if any signature is invalid.
+        const { data: validNewKeys, error } = safe<PublicKey[]>(
           validateSignature.bind(this, sdkTransaction, map),
         );
         if (error) throw new BadRequestException(ErrorCodes.ISNMPN);
 
-        for (const publicKey of publicKeys) {
+        for (const publicKey of validNewKeys) {
           sdkTransaction.addSignature(publicKey, map);
         }
 
@@ -631,12 +633,12 @@ export class TransactionsService {
         const newBytes = Buffer.from(sdkTransaction.toBytes());
         const isSameBytes = newBytes.equals(originalBytes);
 
-        for (const pk of publicKeys) {
+        for (const pk of validNewKeys) {
           allPubKeyStrings.add(pk.toStringRaw());
           allPubKeyStrings.add(pk.toStringDer());
         }
 
-        intermediate.set(id, { transaction, publicKeys, newBytes, isSameBytes });
+        intermediate.set(id, { transaction, publicKeys:validNewKeys, newBytes, isSameBytes });
       } catch (error) {
         results.set(id, {
           id,

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -638,7 +638,7 @@ export class TransactionsService {
           allPubKeyStrings.add(pk.toStringDer());
         }
 
-        intermediate.set(id, { transaction, publicKeys:validNewKeys, newBytes, isSameBytes });
+        intermediate.set(id, { transaction, publicKeys: validNewKeys, newBytes, isSameBytes });
       } catch (error) {
         results.set(id, {
           id,

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -620,9 +620,10 @@ export class TransactionsService {
 
         // Verify ALL signatures (including already-signed keys); returns only (deduped) keys
         // not already on the transaction. Throws if any signature is invalid.
-        const { data: validNewKeys, error } = safe<PublicKey[]>(
+        const { data: validResult, error } = safe<ReturnType<typeof validateSignature>>(
           validateSignature.bind(this, sdkTransaction, map),
         );
+        const validNewKeys = validResult?.newPublicKeys ?? [];
         if (error) throw new BadRequestException(ErrorCodes.ISNMPN);
 
         for (const publicKey of validNewKeys) {

--- a/back-end/libs/common/src/utils/sdk/transaction.ts
+++ b/back-end/libs/common/src/utils/sdk/transaction.ts
@@ -227,6 +227,7 @@ const getSignedTransactionsDimensions = (transaction: SDKTransaction) => {
 
 export const validateSignature = (transaction: SDKTransaction, signatureMap: SignatureMap) => {
   const signerPublicKeys: PublicKey[] = [];
+  const seenPublicKeys = new Set<string>();
 
   const { rowLength, nodeAccountIdRow, transactionIdCol } =
     getSignedTransactionsDimensions(transaction);
@@ -241,19 +242,18 @@ export const validateSignature = (transaction: SDKTransaction, signatureMap: Sig
           transaction._signerPublicKeys.has(publicKeyHex) ||
           transaction._signerPublicKeys.has(publicKeyDer);
 
-        if (!alreadySigned) {
-          const row = nodeAccountIdRow[nodeAccountId];
-          const col = transactionIdCol[transactionId];
+        const row = nodeAccountIdRow[nodeAccountId];
+        const col = transactionIdCol[transactionId];
+        const bodyBytes = transaction._signedTransactions.get(col * rowLength + row).bodyBytes;
+        const signatureValid = publicKey.verify(bodyBytes, signature);
 
-          const bodyBytes = transaction._signedTransactions.get(col * rowLength + row).bodyBytes;
+        if (!signatureValid) {
+          throw new Error('Invalid signature');
+        }
 
-          const signatureValid = publicKey.verify(bodyBytes, signature);
-
-          if (signatureValid) {
-            signerPublicKeys.push(publicKey);
-          } else {
-            throw new Error('Invalid signature');
-          }
+        if (!alreadySigned && !seenPublicKeys.has(publicKeyHex)) {
+          seenPublicKeys.add(publicKeyHex);
+          signerPublicKeys.push(publicKey);
         }
       }
     }

--- a/back-end/libs/common/src/utils/sdk/transaction.ts
+++ b/back-end/libs/common/src/utils/sdk/transaction.ts
@@ -244,6 +244,10 @@ export const validateSignature = (transaction: SDKTransaction, signatureMap: Sig
 
         const row = nodeAccountIdRow[nodeAccountId];
         const col = transactionIdCol[transactionId];
+        if (row === undefined || col === undefined) {
+          throw new Error('Invalid signature');
+        }
+
         const bodyBytes = transaction._signedTransactions.get(col * rowLength + row).bodyBytes;
         const signatureValid = publicKey.verify(bodyBytes, signature);
 

--- a/back-end/libs/common/src/utils/sdk/transaction.ts
+++ b/back-end/libs/common/src/utils/sdk/transaction.ts
@@ -226,7 +226,8 @@ const getSignedTransactionsDimensions = (transaction: SDKTransaction) => {
 };
 
 export const validateSignature = (transaction: SDKTransaction, signatureMap: SignatureMap) => {
-  const signerPublicKeys: PublicKey[] = [];
+  const allPublicKeys: PublicKey[] = [];
+  const newPublicKeys: PublicKey[] = [];
   const seenPublicKeys = new Set<string>();
 
   const { rowLength, nodeAccountIdRow, transactionIdCol } =
@@ -255,15 +256,18 @@ export const validateSignature = (transaction: SDKTransaction, signatureMap: Sig
           throw new Error('Invalid signature');
         }
 
-        if (!alreadySigned && !seenPublicKeys.has(publicKeyHex)) {
+        if ( !seenPublicKeys.has(publicKeyHex)) {
           seenPublicKeys.add(publicKeyHex);
-          signerPublicKeys.push(publicKey);
+          allPublicKeys.push(publicKey);
+          if (!alreadySigned) {
+            newPublicKeys.push(publicKey);
+          }
         }
       }
     }
   }
 
-  return signerPublicKeys;
+  return { newPublicKeys, allPublicKeys };
 };
 
 export const getStatusCodeFromMessage = (message: string) => {


### PR DESCRIPTION
**Description**:

With these changes, we make sure that the logic behind the `POST /transactions/:transactionId/signers` endpoint validates the submitted signature bytes before they are recorded in the DB:
- `processTransactionSignatures()` now calls `validateSignature()` before calling `sdkTransaction.addSignature()`. The returned list of new and verified public keys replaces the previous nested map iteration which simplifies the loop. When the returned list is empty, we short-circuit the loop.
- validation errors are logged and skipped, so a bad signature on one entry does not abort a batch upload (consistent with what is done for `importSignatures()`)
 
 Tests added for both `processTransactionSignatures()` (throws on invalid signature) and `validateAndProcessSignatures()` (captures the error without re-throwing).
 
**Related issue(s)**:

Fixes #2929 
