### PR TITLE
feat: add executedAt timestamp to transaction status updates

### DIFF
--- a/automation/tests/organization-advanced/organizationTransactionTests.test.ts
+++ b/automation/tests/organization-advanced/organizationTransactionTests.test.ts
@@ -317,7 +317,7 @@ test.describe('Organization Transaction status/signing tests @organization-advan
       const historyDetails = await organizationPage.getHistoryTransactionDetails(txId ?? '');
       expect(historyDetails?.transactionId).toBe(txId);
       expect(historyDetails?.transactionType).toBe('Account Update');
-      expect(historyDetails?.validStart).toBe('N/A');
+      expect(historyDetails?.validStart).toMatch(/^\d{2}\/\d{2}\/\d{4}/);
       expect(historyDetails?.status).toBe('CANCELED');
       expect(historyDetails?.detailsButton).toBe(true);
       await organizationPage.clickOnHistoryDetailsButtonByTransactionId(txId ?? '');

--- a/back-end/apps/api/src/transactions/groups/transaction-groups.service.ts
+++ b/back-end/apps/api/src/transactions/groups/transaction-groups.service.ts
@@ -251,7 +251,7 @@ export class TransactionGroupsService {
       const updateResult = await this.dataSource.getRepository(Transaction)
         .createQueryBuilder()
         .update(Transaction)
-        .set({ status: TransactionStatus.CANCELED })
+        .set({ status: TransactionStatus.CANCELED, executedAt: new Date() })
         .where('id IN (:...ids)', { ids: cancelableIds })
         .andWhere('status IN (:...statuses)', { statuses: cancelableStatuses })
         .execute();

--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -2247,6 +2247,10 @@ describe('TransactionsService', () => {
 
     it('should soft remove the transaction', async () => {
       await service.removeTransaction(123, user as User, true);
+      expect(transactionsRepo.update).toHaveBeenCalledWith(
+        transaction.id,
+        expect.objectContaining({ status: TransactionStatus.CANCELED, executedAt: expect.any(Date) }),
+      );
       expect(transactionsRepo.softRemove).toHaveBeenCalledWith(transaction);
     });
 
@@ -2309,7 +2313,7 @@ describe('TransactionsService', () => {
       const result = await service.cancelTransaction(123, { id: 1 } as User);
 
       expect(queryBuilder.update).toHaveBeenCalledWith(Transaction);
-      expect(queryBuilder.set).toHaveBeenCalledWith(expect.objectContaining({ status: TransactionStatus.CANCELED }));
+      expect(queryBuilder.set).toHaveBeenCalledWith(expect.objectContaining({ status: TransactionStatus.CANCELED, executedAt: expect.any(Date) }));
       expect(queryBuilder.where).toHaveBeenCalledWith('id = :id', { id: 123 });
       expect(result).toBe(true);
       expect(emitTransactionStatusUpdate).toHaveBeenCalledWith(
@@ -2497,7 +2501,7 @@ describe('TransactionsService', () => {
 
       expect(transactionsRepo.update).toHaveBeenCalledWith(
         { id: 123 },
-        expect.objectContaining({ status: TransactionStatus.ARCHIVED }),
+        expect.objectContaining({ status: TransactionStatus.ARCHIVED, executedAt: expect.any(Date) }),
       );
       expect(result).toBe(true);
       expect(emitTransactionStatusUpdate).toHaveBeenCalledWith(

--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -2309,7 +2309,7 @@ describe('TransactionsService', () => {
       const result = await service.cancelTransaction(123, { id: 1 } as User);
 
       expect(queryBuilder.update).toHaveBeenCalledWith(Transaction);
-      expect(queryBuilder.set).toHaveBeenCalledWith({ status: TransactionStatus.CANCELED });
+      expect(queryBuilder.set).toHaveBeenCalledWith(expect.objectContaining({ status: TransactionStatus.CANCELED }));
       expect(queryBuilder.where).toHaveBeenCalledWith('id = :id', { id: 123 });
       expect(result).toBe(true);
       expect(emitTransactionStatusUpdate).toHaveBeenCalledWith(
@@ -2497,7 +2497,7 @@ describe('TransactionsService', () => {
 
       expect(transactionsRepo.update).toHaveBeenCalledWith(
         { id: 123 },
-        { status: TransactionStatus.ARCHIVED },
+        expect.objectContaining({ status: TransactionStatus.ARCHIVED }),
       );
       expect(result).toBe(true);
       expect(emitTransactionStatusUpdate).toHaveBeenCalledWith(

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -851,7 +851,7 @@ export class TransactionsService {
     const transaction = await this.getTransactionForCreator(id, user);
 
     if (softRemove) {
-      await this.repo.update(transaction.id, { status: TransactionStatus.CANCELED });
+      await this.repo.update(transaction.id, { status: TransactionStatus.CANCELED, executedAt: new Date() });
       await this.repo.softRemove(transaction);
     } else {
       await this.repo.remove(transaction);
@@ -894,7 +894,7 @@ export class TransactionsService {
     const updateResult = await this.repo
       .createQueryBuilder()
       .update(Transaction)
-      .set({ status: TransactionStatus.CANCELED })
+      .set({ status: TransactionStatus.CANCELED, executedAt: new Date() })
       .where('id = :id', { id })
       .andWhere('status IN (:...statuses)', { statuses: this.cancelableStatuses })
       .execute();
@@ -938,7 +938,7 @@ export class TransactionsService {
       throw new BadRequestException(ErrorCodes.OMTIP);
     }
 
-    await this.repo.update({ id }, { status: TransactionStatus.ARCHIVED });
+    await this.repo.update({ id }, { status: TransactionStatus.ARCHIVED, executedAt: new Date() });
     emitTransactionStatusUpdate(
       this.notificationsPublisher,
       [{

--- a/back-end/apps/chain/src/transaction-scheduler/transaction-scheduler.service.spec.ts
+++ b/back-end/apps/chain/src/transaction-scheduler/transaction-scheduler.service.spec.ts
@@ -276,7 +276,7 @@ describe('TransactionStatusService', () => {
 
     expect(transactionRepo.createQueryBuilder).toHaveBeenCalled();
     expect(mockQueryBuilder.update).toHaveBeenCalled();
-    expect(mockQueryBuilder.set).toHaveBeenCalledWith({ status: TransactionStatus.EXPIRED });
+    expect(mockQueryBuilder.set).toHaveBeenCalledWith(expect.objectContaining({ status: TransactionStatus.EXPIRED }));
     expect(mockQueryBuilder.returning).toHaveBeenCalled();
     expect(mockQueryBuilder.execute).toHaveBeenCalled();
 

--- a/back-end/apps/chain/src/transaction-scheduler/transaction-scheduler.service.spec.ts
+++ b/back-end/apps/chain/src/transaction-scheduler/transaction-scheduler.service.spec.ts
@@ -276,7 +276,7 @@ describe('TransactionStatusService', () => {
 
     expect(transactionRepo.createQueryBuilder).toHaveBeenCalled();
     expect(mockQueryBuilder.update).toHaveBeenCalled();
-    expect(mockQueryBuilder.set).toHaveBeenCalledWith(expect.objectContaining({ status: TransactionStatus.EXPIRED }));
+    expect(mockQueryBuilder.set).toHaveBeenCalledWith(expect.objectContaining({ status: TransactionStatus.EXPIRED, executedAt: expect.any(Date) }));
     expect(mockQueryBuilder.returning).toHaveBeenCalled();
     expect(mockQueryBuilder.execute).toHaveBeenCalled();
 

--- a/back-end/apps/chain/src/transaction-scheduler/transaction-scheduler.service.ts
+++ b/back-end/apps/chain/src/transaction-scheduler/transaction-scheduler.service.ts
@@ -104,7 +104,7 @@ export class TransactionSchedulerService {
     const result = await this.transactionRepo
       .createQueryBuilder()
       .update(Transaction)
-      .set({ status: TransactionStatus.EXPIRED })
+      .set({ status: TransactionStatus.EXPIRED, executedAt: new Date() })
       .where('status IN (:...statuses) AND validStart < :before', {
         statuses: [
           TransactionStatus.NEW,

--- a/back-end/typeorm/migrations/1781285892089-ExecutedAtBackfillForTerminalStates.ts
+++ b/back-end/typeorm/migrations/1781285892089-ExecutedAtBackfillForTerminalStates.ts
@@ -8,7 +8,7 @@ export class ExecutedAtBackfillForTerminalStates1781285892089 implements Migrati
             UPDATE "transaction"
             SET "executedAt" = "updatedAt"
             WHERE "executedAt" IS NULL
-              AND status IN ('CANCELED', 'REJECTED', 'FAILED', 'EXPIRED', 'ARCHIVED')
+              AND "status" IN ('CANCELED', 'REJECTED', 'FAILED', 'EXPIRED', 'ARCHIVED')
         `);
     }
 
@@ -19,7 +19,7 @@ export class ExecutedAtBackfillForTerminalStates1781285892089 implements Migrati
         await queryRunner.query(`
             UPDATE "transaction"
             SET "executedAt" = NULL
-            WHERE status IN ('CANCELED', 'REJECTED', 'EXPIRED', 'ARCHIVED')
+            WHERE "status" IN ('CANCELED', 'REJECTED', 'EXPIRED', 'ARCHIVED')
         `);
     }
 }

--- a/back-end/typeorm/migrations/1781285892089-ExecutedAtBackfillForTerminalStates.ts
+++ b/back-end/typeorm/migrations/1781285892089-ExecutedAtBackfillForTerminalStates.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ExecutedAtBackfillForTerminalStates1781285892089 implements MigrationInterface {
+    name = 'ExecutedAtBackfillForTerminalStates1781285892089'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE "transaction"
+            SET "executedAt" = "updatedAt"
+            WHERE "executedAt" IS NULL
+              AND status IN ('CANCELED', 'REJECTED', 'FAILED', 'EXPIRED', 'ARCHIVED')
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // FAILED is excluded: code has always set executedAt on FAILED rows, so any value present
+        // is legitimate and should not be cleared. The up backfills the rare historical rows that
+        // were missing it due to an old bug, but there is no safe way to reverse that for FAILED.
+        await queryRunner.query(`
+            UPDATE "transaction"
+            SET "executedAt" = NULL
+            WHERE status IN ('CANCELED', 'REJECTED', 'EXPIRED', 'ARCHIVED')
+        `);
+    }
+}


### PR DESCRIPTION
**Description**:
This pull request ensures that the `executedAt` timestamp is consistently set whenever a transaction status transitions to a terminal state (such as `CANCELED`, `ARCHIVED`, or `EXPIRED`). It also introduces a database migration to backfill missing `executedAt` values for historical data. Additionally, related tests have been updated to accommodate these changes.

**Related issue(s)**:

Fixes #2971

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
