### PR TITLE
fix: encode special file content before submission for Hedera special file IDs

### DIFF
--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
@@ -59,7 +59,7 @@ import { addDraft, updateDraft } from '@renderer/services/transactionDraftsServi
 /* Props */
 const { createTransaction, preCreateAssert, customRequest } = defineProps<{
   createTransaction: CreateTransactionFunc;
-  preCreateAssert?: () => boolean | void;
+  preCreateAssert?: () => boolean | void | Promise<boolean | void>;
   createDisabled?: boolean;
   customRequest?: CustomRequest;
 }>();
@@ -188,7 +188,7 @@ const handleDraftLoaded = async (transaction: Transaction) => {
 
 const handleCreate = async () => {
   basePreCreateAssert();
-  if (preCreateAssert?.() === false) return;
+  if ((await Promise.resolve(preCreateAssert?.())) === false) return;
 
   const capturedData = { ...data } as TransactionCommonData;
   // Build the initial transaction once so the retry path can anchor on the

--- a/front-end/src/renderer/components/Transaction/Create/FileAppend/FileAppend.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileAppend/FileAppend.vue
@@ -9,9 +9,8 @@ import useUserStore from '@renderer/stores/storeUser';
 
 import { useRoute } from 'vue-router';
 
-import { isLoggedInOrganization } from '@renderer/utils';
+import { isFileId, isLoggedInOrganization } from '@renderer/utils';
 import { createFileAppendTransaction, getFileAppendTransactionData } from '@renderer/utils/sdk';
-import { useFileTransactionAssert } from '@renderer/composables/useFileTransactionAssert';
 
 import BaseTransaction from '@renderer/components/Transaction/Create/BaseTransaction';
 import FileAppendFormData from './FileAppendFormData.vue';
@@ -63,7 +62,15 @@ const handleUpdateData = (newData: FileAppendData) => {
 };
 
 /* Functions */
-const preCreateAssert = useFileTransactionAssert(data, signatureKey);
+const preCreateAssert = () => {
+  if (!isFileId(data.fileId)) {
+    throw Error('Invalid File ID');
+  }
+
+  if (!signatureKey.value && !isLoggedInOrganization(user.selectedOrganization)) {
+    throw Error('Signature key is required');
+  }
+};
 
 /* Hooks */
 onMounted(() => {

--- a/front-end/src/renderer/components/Transaction/Create/FileAppend/FileAppend.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileAppend/FileAppend.vue
@@ -9,8 +9,9 @@ import useUserStore from '@renderer/stores/storeUser';
 
 import { useRoute } from 'vue-router';
 
-import { isFileId, isLoggedInOrganization } from '@renderer/utils';
+import { isLoggedInOrganization } from '@renderer/utils';
 import { createFileAppendTransaction, getFileAppendTransactionData } from '@renderer/utils/sdk';
+import { useFileTransactionAssert } from '@renderer/composables/useFileTransactionAssert';
 
 import BaseTransaction from '@renderer/components/Transaction/Create/BaseTransaction';
 import FileAppendFormData from './FileAppendFormData.vue';
@@ -62,15 +63,7 @@ const handleUpdateData = (newData: FileAppendData) => {
 };
 
 /* Functions */
-const preCreateAssert = () => {
-  if (!isFileId(data.fileId)) {
-    throw Error('Invalid File ID');
-  }
-
-  if (!signatureKey.value && !isLoggedInOrganization(user.selectedOrganization)) {
-    throw Error('Signature key is required');
-  }
-};
+const preCreateAssert = useFileTransactionAssert(data, signatureKey);
 
 /* Hooks */
 onMounted(() => {

--- a/front-end/src/renderer/components/Transaction/Create/FileUpdate/FileUpdate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileUpdate/FileUpdate.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import type { CreateTransactionFunc } from '@renderer/components/Transaction/Create/BaseTransaction';
+import BaseTransaction from '@renderer/components/Transaction/Create/BaseTransaction';
 import type { FileUpdateData } from '@renderer/utils/sdk';
+import { createFileUpdateTransaction, getFileUpdateTransactionData } from '@renderer/utils/sdk';
 
 import { computed, onMounted, reactive, ref, watch } from 'vue';
 import { Key, Transaction } from '@hiero-ledger/sdk';
@@ -9,11 +11,8 @@ import useUserStore from '@renderer/stores/storeUser';
 
 import { useRoute } from 'vue-router';
 
-import { isLoggedInOrganization, isFileId } from '@renderer/utils';
-import { createFileUpdateTransaction, getFileUpdateTransactionData } from '@renderer/utils/sdk';
+import { isLoggedInOrganization } from '@renderer/utils';
 import { useFileTransactionAssert } from '@renderer/composables/useFileTransactionAssert';
-
-import BaseTransaction from '@renderer/components/Transaction/Create/BaseTransaction';
 import FileUpdateFormData from './FileUpdateFormData.vue';
 
 /* Stores */

--- a/front-end/src/renderer/components/Transaction/Create/FileUpdate/FileUpdate.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileUpdate/FileUpdate.vue
@@ -11,6 +11,7 @@ import { useRoute } from 'vue-router';
 
 import { isLoggedInOrganization, isFileId } from '@renderer/utils';
 import { createFileUpdateTransaction, getFileUpdateTransactionData } from '@renderer/utils/sdk';
+import { useFileTransactionAssert } from '@renderer/composables/useFileTransactionAssert';
 
 import BaseTransaction from '@renderer/components/Transaction/Create/BaseTransaction';
 import FileUpdateFormData from './FileUpdateFormData.vue';
@@ -56,15 +57,7 @@ const handleUpdateData = (newData: FileUpdateData) => {
 };
 
 /* Functions */
-const preCreateAssert = () => {
-  if (!isFileId(data.fileId)) {
-    throw Error('Invalid File ID');
-  }
-
-  if (!signatureKey.value && !isLoggedInOrganization(user.selectedOrganization)) {
-    throw Error('Signature key is required');
-  }
-};
+const preCreateAssert = useFileTransactionAssert(data, signatureKey);
 
 /* Hooks */
 onMounted(() => {

--- a/front-end/src/renderer/composables/useFileTransactionAssert.ts
+++ b/front-end/src/renderer/composables/useFileTransactionAssert.ts
@@ -30,19 +30,33 @@ export function useFileTransactionAssert(
           window.electronAPI.local.files.decodeProto(data.fileId, data.contents),
         );
 
-        if (!decodeError && decoded) {
-          const { error: reEncodeError } = await safeAwait(
-            encodeSpecialFileContent(new TextEncoder().encode(decoded), data.fileId),
-          );
-          if (!reEncodeError) {
-            // Round-trip succeeded — already valid protobuf, pass through unchanged
+        if (!decodeError) {
+          if (decoded !== undefined) {
+            const normalized =
+              decoded.startsWith('"') && decoded.endsWith('"')
+                ? decoded
+                : JSON.stringify(decoded);
+            const { error: reEncodeError } = await safeAwait(
+              encodeSpecialFileContent(new TextEncoder().encode(normalized), data.fileId),
+            );
+            if (!reEncodeError) {
+              // Round-trip succeeded — already valid protobuf, pass through unchanged
+              return;
+            }
+          } else {
+            // decodeProto succeeded but returned undefined (e.g. empty ServicesConfigurationList);
+            // treat as already-encoded protobuf to avoid corrupting valid bytes.
             return;
           }
         }
 
         bytes = data.contents;
       } else {
-        bytes = new TextEncoder().encode(data.contents);
+        const normalized =
+          data.contents.startsWith('"') && data.contents.endsWith('"')
+            ? data.contents
+            : JSON.stringify(data.contents);
+        bytes = new TextEncoder().encode(normalized);
       }
 
       // Content is not already protobuf — attempt to encode it

--- a/front-end/src/renderer/composables/useFileTransactionAssert.ts
+++ b/front-end/src/renderer/composables/useFileTransactionAssert.ts
@@ -1,0 +1,60 @@
+import type { Ref } from 'vue';
+import type { Key } from '@hiero-ledger/sdk';
+
+import { isHederaSpecialFileId } from '@shared/hederaSpecialFiles';
+import { isFileId, isLoggedInOrganization, safeAwait } from '@renderer/utils';
+import { encodeSpecialFileContent } from '@renderer/services/transactionService';
+import useUserStore from '@renderer/stores/storeUser';
+
+export function useFileTransactionAssert(
+  data: { fileId: string; contents: Uint8Array | string | null },
+  signatureKey: Ref<Key | null>,
+) {
+  const user = useUserStore();
+
+  return async () => {
+    if (!isFileId(data.fileId)) {
+      throw Error('Invalid File ID');
+    }
+
+    if (!signatureKey.value && !isLoggedInOrganization(user.selectedOrganization)) {
+      throw Error('Signature key is required');
+    }
+
+    if (isHederaSpecialFileId(data.fileId) && data.contents != null && data.contents.length > 0) {
+      let bytes: Uint8Array;
+
+      if (data.contents instanceof Uint8Array) {
+        // Check if content is already valid protobuf via decode + re-encode round-trip
+        const { data: decoded, error: decodeError } = await safeAwait(
+          window.electronAPI.local.files.decodeProto(data.fileId, data.contents),
+        );
+
+        if (!decodeError && decoded) {
+          const { error: reEncodeError } = await safeAwait(
+            encodeSpecialFileContent(new TextEncoder().encode(decoded), data.fileId),
+          );
+          if (!reEncodeError) {
+            // Round-trip succeeded — already valid protobuf, pass through unchanged
+            return;
+          }
+        }
+
+        bytes = data.contents;
+      } else {
+        bytes = new TextEncoder().encode(data.contents);
+      }
+
+      // Content is not already protobuf — attempt to encode it
+      const { data: encoded, error: encodeError } = await safeAwait(
+        encodeSpecialFileContent(bytes, data.fileId),
+      );
+
+      if (encodeError || !encoded) {
+        throw new Error('Failed to encode special file content');
+      }
+
+      data.contents = encoded;
+    }
+  };
+}

--- a/front-end/src/tests/renderer/composables/useFileTransactionAssert.spec.ts
+++ b/front-end/src/tests/renderer/composables/useFileTransactionAssert.spec.ts
@@ -1,0 +1,131 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ref } from 'vue';
+import { type Key } from '@hiero-ledger/sdk';
+
+import { useFileTransactionAssert } from '@renderer/composables/useFileTransactionAssert';
+
+const mocks = vi.hoisted(() => ({
+  decodeProto: vi.fn(),
+  encodeSpecialFileContent: vi.fn(),
+  isFileId: vi.fn(),
+  isHederaSpecialFileId: vi.fn(),
+  isLoggedInOrganization: vi.fn(),
+  safeAwait: vi.fn(),
+}));
+
+vi.mock('@renderer/services/transactionService', () => ({
+  encodeSpecialFileContent: mocks.encodeSpecialFileContent,
+}));
+
+vi.mock('@renderer/stores/storeUser', () => ({
+  default: () => ({
+    selectedOrganization: null,
+  }),
+}));
+
+vi.mock('@renderer/utils', () => ({
+  isFileId: mocks.isFileId,
+  isLoggedInOrganization: mocks.isLoggedInOrganization,
+  safeAwait: mocks.safeAwait,
+}));
+
+vi.mock('@shared/hederaSpecialFiles', () => ({
+  isHederaSpecialFileId: mocks.isHederaSpecialFileId,
+}));
+
+describe('useFileTransactionAssert', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubGlobal('window', {
+      electronAPI: {
+        local: {
+          files: {
+            decodeProto: mocks.decodeProto,
+          },
+        },
+      },
+    });
+    mocks.isFileId.mockReturnValue(true);
+    mocks.isLoggedInOrganization.mockReturnValue(true);
+    mocks.safeAwait.mockImplementation(async (promise: Promise<unknown>) => {
+      try {
+        return { data: await promise, error: null };
+      } catch (error) {
+        return { data: undefined, error };
+      }
+    });
+  });
+
+  test('passes through already-valid protobuf Uint8Array content unchanged', async () => {
+    const contents = Uint8Array.from([1, 2, 3]);
+    const data = {
+      fileId: '0.0.111',
+      contents,
+    };
+
+    mocks.isHederaSpecialFileId.mockReturnValue(true);
+    mocks.decodeProto.mockResolvedValue('{"currentFeeSchedule":{}}');
+    mocks.encodeSpecialFileContent.mockResolvedValue(Uint8Array.from([9, 9, 9]));
+
+    await useFileTransactionAssert(data, ref({} as Key))();
+
+    expect(mocks.decodeProto).toHaveBeenCalledWith('0.0.111', contents);
+    expect(mocks.encodeSpecialFileContent).toHaveBeenCalledTimes(1);
+    expect(data.contents).toBe(contents);
+  });
+
+  test('encodes decoded text content before submission', async () => {
+    const contents = '{"throttleBuckets":[] }';
+    const data = {
+      fileId: '0.0.123',
+      contents,
+    };
+
+    mocks.isHederaSpecialFileId.mockReturnValue(true);
+    mocks.encodeSpecialFileContent.mockResolvedValue(Uint8Array.from([4, 5, 6]));
+
+    await useFileTransactionAssert(data, ref({} as Key))();
+
+    expect(mocks.decodeProto).not.toHaveBeenCalled();
+    expect(mocks.encodeSpecialFileContent).toHaveBeenCalledWith(
+      new TextEncoder().encode(JSON.stringify(contents)),
+      '0.0.123',
+    );
+    expect(data.contents).toEqual(Uint8Array.from([4, 5, 6]));
+  });
+
+  test('surfaces an error when decode and encode both fail', async () => {
+    const contents = Uint8Array.from([7, 8, 9]);
+    const data = {
+      fileId: '0.0.121',
+      contents,
+    };
+
+    mocks.isHederaSpecialFileId.mockReturnValue(true);
+    mocks.decodeProto.mockRejectedValue(new Error('decode failed'));
+    mocks.encodeSpecialFileContent.mockRejectedValue(new Error('encode failed'));
+
+    await expect(useFileTransactionAssert(data, ref({} as Key))()).rejects.toThrow(
+      'Failed to encode special file content',
+    );
+
+    expect(data.contents).toBe(contents);
+  });
+
+  test('does nothing for non-special file IDs', async () => {
+    const contents = '{"anything":true}';
+    const data = {
+      fileId: '0.0.200',
+      contents,
+    };
+
+    mocks.isHederaSpecialFileId.mockReturnValue(false);
+
+    await useFileTransactionAssert(data, ref({} as Key))();
+
+    expect(mocks.decodeProto).not.toHaveBeenCalled();
+    expect(mocks.encodeSpecialFileContent).not.toHaveBeenCalled();
+    expect(data.contents).toBe(contents);
+  });
+});

--- a/front-end/src/tests/renderer/composables/useFileTransactionAssert.spec.ts
+++ b/front-end/src/tests/renderer/composables/useFileTransactionAssert.spec.ts
@@ -128,4 +128,53 @@ describe('useFileTransactionAssert', () => {
     expect(mocks.encodeSpecialFileContent).not.toHaveBeenCalled();
     expect(data.contents).toBe(contents);
   });
+
+  test('throws when file ID is invalid', async () => {
+    mocks.isFileId.mockReturnValue(false);
+    const data = { fileId: 'not-a-file-id', contents: null };
+
+    await expect(useFileTransactionAssert(data, ref({} as Key))()).rejects.toThrow(
+      'Invalid File ID',
+    );
+  });
+
+  test('throws when signature key is missing and user is not in an organization', async () => {
+    mocks.isLoggedInOrganization.mockReturnValue(false);
+    const data = { fileId: '0.0.111', contents: null };
+
+    await expect(useFileTransactionAssert(data, ref(null))()).rejects.toThrow(
+      'Signature key is required',
+    );
+  });
+
+  test('passes through Uint8Array unchanged when decode returns undefined', async () => {
+    const contents = Uint8Array.from([1, 2, 3]);
+    const data = { fileId: '0.0.121', contents };
+
+    mocks.isHederaSpecialFileId.mockReturnValue(true);
+    mocks.decodeProto.mockResolvedValue(undefined);
+
+    await useFileTransactionAssert(data, ref({} as Key))();
+
+    expect(mocks.encodeSpecialFileContent).not.toHaveBeenCalled();
+    expect(data.contents).toBe(contents);
+  });
+
+  test('encodes Uint8Array content when round-trip re-encode fails', async () => {
+    const contents = Uint8Array.from([7, 8, 9]);
+    const encoded = Uint8Array.from([4, 5, 6]);
+    const data = { fileId: '0.0.112', contents };
+
+    mocks.isHederaSpecialFileId.mockReturnValue(true);
+    mocks.decodeProto.mockResolvedValue('garbage decoded from json bytes');
+    mocks.encodeSpecialFileContent
+      .mockRejectedValueOnce(new Error('re-encode failed'))
+      .mockResolvedValueOnce(encoded);
+
+    await useFileTransactionAssert(data, ref({} as Key))();
+
+    expect(mocks.encodeSpecialFileContent).toHaveBeenCalledTimes(2);
+    expect(mocks.encodeSpecialFileContent).toHaveBeenLastCalledWith(contents, '0.0.112');
+    expect(data.contents).toEqual(encoded);
+  });
 });


### PR DESCRIPTION
**Description**:

  Add shared pre-submit validation for _File Update_ transaction so Hedera special file (0.0.101, 102, 111, 112, 121, 122, 123) content is protobuf-encoded before `setContents()` is used.

**Related issue(s)**:

Fixes #2976 

**Notes for reviewer**:
 - Introduce `useFileTransactionAssert` composable for  pre-create checks.
 - _FileUpdate_  create flow now use the shared composable.
 - Update `BaseTransaction` to support `async preCreateAssert`
 - Add unit tests for `useFileTransactionAssert`
