### PR TITLE
feat: show active credentials for personal and organization accounts

### DIFF
--- a/automation/tests/organization-basic/organizationSettingsGeneralTests.test.ts
+++ b/automation/tests/organization-basic/organizationSettingsGeneralTests.test.ts
@@ -8,12 +8,13 @@ test.describe('Organization Settings (General) navigation tests @organization-ba
     // Organization selector should list all connected orgs (plus personal mode).
     await suite.organizationPage.clickOnSelectModeDropdown();
     const modeItemCount = await suite.organizationPage.countModeSelectionItems();
+    // At least one personal item and one org item must be present.
+    expect(modeItemCount).toBeGreaterThanOrEqual(2);
     const modeItemTexts: string[] = [];
     for (let i = 0; i < modeItemCount; i++) {
       modeItemTexts.push((await suite.organizationPage.getModeSelectionItemText(i)) ?? '');
     }
     const modeMenuText = modeItemTexts.join(' ');
-    expect(modeMenuText).toContain('Personal');
     expect(modeMenuText).toContain(suite.organizationNickname);
 
     // Switch to personal mode.

--- a/front-end/src/renderer/components/UserModeSelect.vue
+++ b/front-end/src/renderer/components/UserModeSelect.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import type { Organization } from '@prisma/client';
+import type { ConnectedOrganization } from '@renderer/types/userStore';
 
-import { onMounted, ref, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 
 import useUserStore from '@renderer/stores/storeUser';
 
@@ -9,7 +10,7 @@ import useLoader from '@renderer/composables/useLoader';
 import useRecoveryPhraseHashMigrate from '@renderer/composables/useRecoveryPhraseHashMigrate';
 import useDefaultOrganization from '@renderer/composables/user/useDefaultOrganization';
 
-import { isOrganizationActive } from '@renderer/utils';
+import { isOrganizationActive, isUserLoggedIn } from '@renderer/utils';
 
 import AddOrganizationModal from '@renderer/components/Organization/AddOrganizationModal.vue';
 import AppButton from '@renderer/components/ui/AppButton.vue';
@@ -28,24 +29,34 @@ const { setLast } = useDefaultOrganization();
 /* State */
 const selectedMode = ref<string>('personal');
 const addOrganizationModalShown = ref(false);
-const dropDownValue = ref<string>(personalModeText);
+
+/* Computed */
+const dropDownValue = computed(() => {
+  if (user.selectedOrganization) {
+    return (
+      user.organizations.find(o => o.id === user.selectedOrganization!.id)?.nickname ??
+      user.selectedOrganization.nickname
+    );
+  }
+  return personalModeText;
+});
 
 /* Handlers */
 const handleUserModeChange = async (e: Event) => {
   const selectEl = e.currentTarget as HTMLSelectElement;
   const newValue = selectEl.getAttribute('data-value');
+
+  if (newValue === selectedMode.value) return;
+
   const org = user.organizations.find(org => org.id === newValue);
 
   if (newValue === 'personal') {
     selectedMode.value = 'personal';
-    dropDownValue.value = personalModeText;
     await user.selectOrganization(null);
     await redirectIfRequiredKeysToMigrate();
     await setLast(null);
   } else {
     selectedMode.value = org ? org.id : 'personal';
-    const organizationNickname =
-      user.organizations.find(org => org.id === newValue)?.nickname || '';
 
     await user.selectOrganization(
       org
@@ -59,7 +70,6 @@ const handleUserModeChange = async (e: Event) => {
     );
 
     if (isOrganizationActive(user.selectedOrganization)) {
-      dropDownValue.value = organizationNickname;
       await setLast(user.selectedOrganization?.id || null);
     }
 
@@ -77,23 +87,20 @@ const handleAddOrganization = async (organization: Organization) => {
 
   if (isOrganizationActive(user.selectedOrganization)) {
     selectedMode.value = organization.id;
-
-    dropDownValue.value =
-      user.organizations.find(org => org.id === organization.id)?.nickname || '';
-
     await setLast(organization.id);
   }
 };
 
 /* Functions */
 const initialize = () => {
-  if (user.selectedOrganization) {
-    selectedMode.value = user.selectedOrganization.id;
-    dropDownValue.value = user.selectedOrganization.nickname;
-  } else {
-    selectedMode.value = 'personal';
-    dropDownValue.value = personalModeText;
+  selectedMode.value = user.selectedOrganization?.id ?? 'personal';
+};
+
+const getOrgEmail = (org: ConnectedOrganization): string | undefined => {
+  if (!org.isLoading && org.isServerActive && !org.loginRequired) {
+    return org.email;
   }
+  return undefined;
 };
 
 /* Hooks */
@@ -102,22 +109,8 @@ onMounted(initialize);
 watch(
   () => user.organizations,
   (current, prev) => {
-    const lastAddedOrganization = user.organizations[user.organizations.length - 1];
-
-    if (isOrganizationActive(user.selectedOrganization)) {
-      // Check if organization was added or removed
-      if (current.length > prev.length) {
-        selectedMode.value = lastAddedOrganization.id;
-
-        dropDownValue.value =
-          user.organizations.find(org => org.id === lastAddedOrganization.id)?.nickname || '';
-      } else {
-        selectedMode.value = user.selectedOrganization.id;
-
-        dropDownValue.value = user.selectedOrganization.nickname;
-      }
-    } else {
-      dropDownValue.value = personalModeText;
+    if (isOrganizationActive(user.selectedOrganization) && current.length > prev.length) {
+      selectedMode.value = user.organizations[user.organizations.length - 1].id;
     }
   },
 );
@@ -142,33 +135,49 @@ watch(() => user.selectedOrganization, initialize);
         </div>
         <i class="bi bi-chevron-down ms-3"></i>
       </AppButton>
-      <ul class="dropdown-menu w-100 mt-3">
-        <li class="dropdown-header text-muted pe-none bg-light border-bottom">Organizations</li>
+      <ul class="dropdown-menu dropdown-menu-sectioned mt-3" style="min-width: 280px">
+        <li class="dropdown-header text-muted pe-none">Local</li>
         <li
           data-testid="dropdown-item-0"
           data-value="personal"
-          class="dropdown-item"
+          class="dropdown-item py-2"
+          :class="{ active: selectedMode === 'personal' }"
           @click="withLoader(handleUserModeChange.bind(null, $event), 'Failed to select user mode')"
         >
-          <span class="text-small">{{ personalModeText }}</span>
+          <div class="text-truncate">
+            {{
+              isUserLoggedIn(user.personal) && !user.personal.useKeychain
+                ? user.personal.email
+                : personalModeText
+            }}
+          </div>
         </li>
-        <template v-for="(organization, index) in user.organizations" :key="organization.id">
-          <li
-            :data-testid="'dropdown-item-' + (index + 1)"
-            class="dropdown-item flex-between-centered gap-3 mt-3"
-            @click="
-              withLoader(handleUserModeChange.bind(null, $event), 'Failed to select user mode')
-            "
-            :data-value="organization.id"
-          >
-            <div class="position-relative flex-1 col-10">
-              <div class="text-small text-truncate">{{ organization.nickname }}</div>
-            </div>
-
-            <div v-if="organization.isLoading" class="flex-centered col-2">
-              <span class="text-primary spinner-border spinner-border-sm"></span>
-            </div>
-          </li>
+        <template v-if="user.organizations.length">
+          <li><hr class="dropdown-divider" /></li>
+          <li class="dropdown-header text-muted pe-none">Organizations</li>
+          <template v-for="(organization, index) in user.organizations" :key="organization.id">
+            <li
+              :data-testid="'dropdown-item-' + (index + 1)"
+              class="dropdown-item py-2"
+              :class="{ active: selectedMode === organization.id }"
+              @click="
+                withLoader(handleUserModeChange.bind(null, $event), 'Failed to select user mode')
+              "
+              :data-value="organization.id"
+            >
+              <div class="d-flex align-items-center gap-2">
+                <div class="flex-grow-1" style="min-width: 0">
+                  <div class="text-truncate">{{ organization.nickname }}</div>
+                  <div v-if="getOrgEmail(organization)" class="text-muted small text-truncate ps-2">
+                    {{ getOrgEmail(organization) }}
+                  </div>
+                </div>
+                <div v-if="organization.isLoading" class="flex-centered">
+                  <span class="text-primary spinner-border spinner-border-sm"></span>
+                </div>
+              </div>
+            </li>
+          </template>
         </template>
       </ul>
     </div>

--- a/front-end/src/renderer/components/UserModeSelect.vue
+++ b/front-end/src/renderer/components/UserModeSelect.vue
@@ -43,10 +43,10 @@ const dropDownValue = computed(() => {
 
 /* Handlers */
 const handleUserModeChange = async (e: Event) => {
-  const selectEl = e.currentTarget as HTMLSelectElement;
-  const newValue = selectEl.getAttribute('data-value');
+  const el = e.currentTarget as HTMLElement;
+  const newValue = el.getAttribute('data-value');
 
-  if (newValue === selectedMode.value) return;
+  if (newValue === null || newValue === selectedMode.value) return;
 
   const org = user.organizations.find(org => org.id === newValue);
 

--- a/front-end/src/renderer/pages/OrganizationLogin/OrganizationLogin.vue
+++ b/front-end/src/renderer/pages/OrganizationLogin/OrganizationLogin.vue
@@ -79,8 +79,6 @@ const handleLogin = async () => {
       inputPassword.value,
     );
 
-    toggleAuthTokenInSessionStorage(user.selectedOrganization.serverUrl, jwtToken);
-
     await addOrganizationCredentials(
       inputEmail.value.toLocaleLowerCase().trim(),
       inputPassword.value,
@@ -90,6 +88,8 @@ const handleLogin = async () => {
       personalPassword,
       true,
     );
+
+    toggleAuthTokenInSessionStorage(user.selectedOrganization.serverUrl, jwtToken);
     await user.refetchOrganizations();
 
     toastManager.success('Successfully signed in');

--- a/front-end/src/renderer/pages/OrganizationLogin/OrganizationLogin.vue
+++ b/front-end/src/renderer/pages/OrganizationLogin/OrganizationLogin.vue
@@ -21,6 +21,7 @@ import {
   isLoggedOutOrganization,
   isOrganizationActive,
   redirectToPrevious,
+  toggleAuthTokenInSessionStorage,
 } from '@renderer/utils';
 
 import AppButton from '@renderer/components/ui/AppButton.vue';
@@ -78,6 +79,8 @@ const handleLogin = async () => {
       inputPassword.value,
     );
 
+    toggleAuthTokenInSessionStorage(user.selectedOrganization.serverUrl, jwtToken);
+
     await addOrganizationCredentials(
       inputEmail.value.toLocaleLowerCase().trim(),
       inputPassword.value,
@@ -87,7 +90,7 @@ const handleLogin = async () => {
       personalPassword,
       true,
     );
-    await user.refetchOrganizationTokens();
+    await user.refetchOrganizations();
 
     toastManager.success('Successfully signed in');
 

--- a/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
@@ -172,6 +172,12 @@ watch(newPassword, pass => {
       (isUserLoggedIn(user.personal) && !user.personal.useKeychain) || user.selectedOrganization
     "
   >
+    <div class="w-50 p-4 border rounded mb-4">
+      <div class="d-flex align-items-center gap-3">
+        <span class="form-label mb-0">Email</span>
+        <span>{{ user.selectedOrganization?.email ?? user.personal?.email }}</span>
+      </div>
+    </div>
     <form class="w-50 p-4 border rounded" @submit.prevent="isConfirmModalShown = true">
       <h3 class="text-main">Password</h3>
       <div class="form-group mt-4">

--- a/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
@@ -181,36 +181,50 @@ watch(newPassword, pass => {
       (isUserLoggedIn(user.personal) && !user.personal.useKeychain) || user.selectedOrganization
     "
   >
-    <div class="w-50 p-4 border rounded mb-4">
-      <div class="d-flex align-items-center gap-3">
-        <span class="form-label mb-0">Email</span>
-        <span>{{ displayEmail }}</span>
+    <div class="p-4 border border-2 rounded-3">
+      <p>User Info</p>
+      <div class="mt-4">
+        <h4 class="text-micro text-semi-bold text-dark-blue">Email</h4>
+        <p class="text-small overflow-hidden mt-1 mb-0">{{ displayEmail }}</p>
       </div>
+      <AppButton
+        v-if="
+          (isUserLoggedIn(user.personal) && !user.personal.useKeychain && !user.selectedOrganization) ||
+          isLoggedInOrganization(user.selectedOrganization)
+        "
+        color="primary"
+        data-testid="button-logout"
+        class="mt-4"
+        @click="withLoader(handleLogout)"
+        >Log Out</AppButton
+      >
     </div>
-    <form class="w-50 p-4 border rounded" @submit.prevent="isConfirmModalShown = true">
+    <form class="p-4 border border-2 rounded-3 mt-5" @submit.prevent="isConfirmModalShown = true">
       <h3 class="text-main">Password</h3>
-      <div class="form-group mt-4">
-        <label class="form-label">Current Password <span class="text-danger">*</span></label>
-        <AppPasswordInput
-          v-model="currentPassword"
-          data-testid="input-current-password"
-          placeholder="Enter Current Password"
-          :filled="true"
-        />
+      <div class="col-sm-5 col-lg-4">
+        <div class="form-group mt-4">
+          <label class="form-label">Current Password <span class="text-danger">*</span></label>
+          <AppPasswordInput
+            v-model="currentPassword"
+            data-testid="input-current-password"
+            placeholder="Enter Current Password"
+            :filled="true"
+          />
+        </div>
+        <div class="mt-4 form-group">
+          <label class="form-label">New Password <span class="text-danger">*</span></label>
+          <AppPasswordInput
+            v-model="newPassword"
+            :filled="true"
+            :class="{ 'is-invalid': newPasswordInvalid }"
+            data-testid="input-new-password"
+            placeholder="Enter New Password"
+            @blur="handleBlur('newPassword', $event.target.value)"
+          />
+          <div v-if="newPasswordInvalid" class="invalid-feedback">Invalid password</div>
+        </div>
       </div>
-      <div class="mt-4 form-group">
-        <label class="form-label">New Password <span class="text-danger">*</span></label>
-        <AppPasswordInput
-          v-model="newPassword"
-          :filled="true"
-          :class="{ 'is-invalid': newPasswordInvalid }"
-          data-testid="input-new-password"
-          placeholder="Enter New Password"
-          @blur="handleBlur('newPassword', $event.target.value)"
-        />
-        <div v-if="newPasswordInvalid" class="invalid-feedback">Invalid password</div>
-      </div>
-      <div class="d-grid mt-4">
+      <div class="mt-4">
         <AppButton
           color="primary"
           data-testid="button-change-password"
@@ -281,15 +295,4 @@ watch(newPassword, pass => {
     <ResetDataModal v-model:show="isResetDataModalShown" @data:reset="handleResetData" />
   </div>
 
-  <div
-    v-if="
-      (isUserLoggedIn(user.personal) && !user.personal.useKeychain && !user.selectedOrganization) ||
-      isLoggedInOrganization(user.selectedOrganization)
-    "
-    class="mt-6"
-  >
-    <AppButton color="primary" data-testid="button-logout" @click="withLoader(handleLogout)">
-      Log Out
-    </AppButton>
-  </div>
 </template>

--- a/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
@@ -58,7 +58,10 @@ const isResetDataModalShown = ref(false);
 
 /* Computed */
 const displayEmail = computed(() => {
-  if (isLoggedInOrganization(user.selectedOrganization)) return user.selectedOrganization.email;
+  const orgEmail = isLoggedInOrganization(user.selectedOrganization)
+    ? user.selectedOrganization.email
+    : null;
+  if (orgEmail) return orgEmail;
   if (isUserLoggedIn(user.personal)) return user.personal.email;
   return '';
 });

--- a/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
@@ -57,6 +57,12 @@ const isChangingPassword = ref(false);
 const isResetDataModalShown = ref(false);
 
 /* Computed */
+const displayEmail = computed(() => {
+  if (isLoggedInOrganization(user.selectedOrganization)) return user.selectedOrganization.email;
+  if (isUserLoggedIn(user.personal)) return user.personal.email;
+  return '';
+});
+
 const isPrimaryButtonDisabled = computed(() => {
   return (
     currentPassword.value.length === 0 ||
@@ -175,7 +181,7 @@ watch(newPassword, pass => {
     <div class="w-50 p-4 border rounded mb-4">
       <div class="d-flex align-items-center gap-3">
         <span class="form-label mb-0">Email</span>
-        <span>{{ user.selectedOrganization?.email ?? user.personal?.email }}</span>
+        <span>{{ displayEmail }}</span>
       </div>
     </div>
     <form class="w-50 p-4 border rounded" @submit.prevent="isConfirmModalShown = true">

--- a/front-end/src/renderer/styles/_ui-elements.scss
+++ b/front-end/src/renderer/styles/_ui-elements.scss
@@ -812,6 +812,41 @@ td .btn {
     &:not(:first-child) {
       margin-top: $spacer * 0.25;
     }
+
+    &.active {
+      &:hover,
+      &:focus {
+        background-color: var(--bs-dropdown-link-active-bg) !important;
+        color: var(--bs-dropdown-link-active-color) !important;
+      }
+
+      .text-muted {
+        color: rgba(255, 255, 255, 0.7) !important;
+      }
+    }
+
+    &:not(.active):active {
+      color: var(--bs-dropdown-link-hover-color) !important;
+      background-color: var(--bs-dropdown-link-hover-bg) !important;
+    }
+  }
+
+  &.dropdown-menu-sectioned {
+    padding-top: 0.75rem;
+
+    .dropdown-header {
+      padding-left: 0.5rem;
+      padding-top: 0.25rem;
+      padding-bottom: 0.25rem;
+    }
+
+    li:has(.dropdown-divider) + li {
+      padding-top: 0.5rem;
+    }
+
+    .dropdown-item {
+      padding-left: 1rem;
+    }
   }
 }
 

--- a/front-end/src/tests/renderer/components/UserModeSelect.spec.ts
+++ b/front-end/src/tests/renderer/components/UserModeSelect.spec.ts
@@ -1,0 +1,293 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import UserModeSelect from '@renderer/components/UserModeSelect.vue';
+
+const makeOrg = (overrides: Record<string, unknown> = {}) => ({
+  id: 'org-1',
+  nickname: 'Acme Corp',
+  serverUrl: 'https://acme.example',
+  key: 'org-key',
+  isLoading: false,
+  isServerActive: true,
+  loginRequired: false,
+  email: 'user@acme.example',
+  ...overrides,
+});
+
+const mocks = vi.hoisted(() => ({
+  userStore: {
+    personal: { id: 'local-user-id', useKeychain: false, email: 'local@example.com' } as Record<string, unknown> | null,
+    selectedOrganization: null as Record<string, unknown> | null,
+    organizations: [] as Record<string, unknown>[],
+    selectOrganization: vi.fn(),
+    refetchOrganizations: vi.fn(),
+  },
+  isOrganizationActive: vi.fn((org: unknown) => org !== null),
+  isUserLoggedIn: vi.fn((user: unknown) => user !== null),
+  redirectIfRequiredKeysToMigrate: vi.fn(),
+  setLast: vi.fn(),
+}));
+
+vi.mock('@renderer/stores/storeUser', () => ({
+  default: vi.fn(() => mocks.userStore),
+}));
+
+vi.mock('@renderer/composables/useLoader', () => ({
+  default: vi.fn(() => async (callback: () => Promise<void>) => callback()),
+}));
+
+vi.mock('@renderer/composables/useRecoveryPhraseHashMigrate', () => ({
+  default: vi.fn(() => ({
+    redirectIfRequiredKeysToMigrate: mocks.redirectIfRequiredKeysToMigrate,
+  })),
+}));
+
+vi.mock('@renderer/composables/user/useDefaultOrganization', () => ({
+  default: vi.fn(() => ({
+    setLast: mocks.setLast,
+  })),
+}));
+
+vi.mock('@renderer/utils', () => ({
+  isOrganizationActive: mocks.isOrganizationActive,
+  isUserLoggedIn: mocks.isUserLoggedIn,
+}));
+
+const stubs = {
+  AppButton: {
+    props: ['color', 'size'],
+    template: '<button v-bind="$attrs"><slot /></button>',
+  },
+  AddOrganizationModal: {
+    props: ['show'],
+    emits: ['update:show', 'added'],
+    template: '<div />',
+  },
+};
+
+function mountSelect() {
+  return mount(UserModeSelect, { global: { stubs } });
+}
+
+describe('UserModeSelect.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.userStore.personal = { id: 'local-user-id', useKeychain: false, email: 'local@example.com' };
+    mocks.userStore.selectedOrganization = null;
+    mocks.userStore.organizations = [];
+    mocks.isOrganizationActive.mockImplementation((org: unknown) => org !== null);
+    mocks.isUserLoggedIn.mockImplementation((user: unknown) => user !== null);
+  });
+
+  describe('dropdown button label (dropDownValue)', () => {
+    test('shows "Personal" when no org is selected', () => {
+      const wrapper = mountSelect();
+
+      expect(wrapper.find('[data-testid="dropdown-selected-mode"]').text()).toBe('Personal');
+    });
+
+    test('shows org nickname from organizations list when an org is selected', () => {
+      const org = makeOrg({ nickname: 'Acme Corp' });
+      mocks.userStore.selectedOrganization = org;
+      mocks.userStore.organizations = [org];
+
+      const wrapper = mountSelect();
+
+      expect(wrapper.find('[data-testid="dropdown-selected-mode"]').text()).toBe('Acme Corp');
+    });
+
+    test('reflects updated nickname from organizations list (not stale selectedOrganization)', () => {
+      const org = makeOrg({ nickname: 'Old Name' });
+      mocks.userStore.selectedOrganization = { ...org, nickname: 'Old Name' };
+      mocks.userStore.organizations = [{ ...org, nickname: 'New Name' }];
+
+      const wrapper = mountSelect();
+
+      expect(wrapper.find('[data-testid="dropdown-selected-mode"]').text()).toBe('New Name');
+    });
+  });
+
+  describe('Local section', () => {
+    test('always renders the Local section header', () => {
+      const wrapper = mountSelect();
+
+      expect(wrapper.text()).toContain('Local');
+    });
+
+    test('shows personal email in personal item for non-keychain user', () => {
+      const wrapper = mountSelect();
+
+      expect(wrapper.find('[data-testid="dropdown-item-0"]').text()).toContain('local@example.com');
+    });
+
+    test('shows "Personal" text in personal item for keychain user', () => {
+      mocks.userStore.personal = { id: 'local-user-id', useKeychain: true };
+      mocks.isUserLoggedIn.mockReturnValue(true);
+
+      const wrapper = mountSelect();
+
+      expect(wrapper.find('[data-testid="dropdown-item-0"]').text()).toBe('Personal');
+    });
+
+    test('personal item has active class when personal mode is selected', () => {
+      mocks.userStore.selectedOrganization = null;
+
+      const wrapper = mountSelect();
+
+      expect(wrapper.find('[data-testid="dropdown-item-0"]').classes()).toContain('active');
+    });
+
+    test('personal item does not have active class when an org is selected', async () => {
+      const org = makeOrg();
+      mocks.userStore.selectedOrganization = org;
+      mocks.userStore.organizations = [org];
+
+      const wrapper = mountSelect();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="dropdown-item-0"]').classes()).not.toContain('active');
+    });
+  });
+
+  describe('Organizations section', () => {
+    test('hides org section when there are no organizations', () => {
+      mocks.userStore.organizations = [];
+
+      const wrapper = mountSelect();
+
+      expect(wrapper.text()).not.toContain('Organizations');
+      expect(wrapper.find('[data-testid="dropdown-item-1"]').exists()).toBe(false);
+    });
+
+    test('shows org section header and divider when organizations exist', () => {
+      mocks.userStore.organizations = [makeOrg()];
+
+      const wrapper = mountSelect();
+
+      expect(wrapper.text()).toContain('Organizations');
+      expect(wrapper.find('.dropdown-divider').exists()).toBe(true);
+    });
+
+    test('renders an item for each organization', () => {
+      mocks.userStore.organizations = [
+        makeOrg({ id: 'org-1', nickname: 'Acme' }),
+        makeOrg({ id: 'org-2', nickname: 'Globex' }),
+      ];
+
+      const wrapper = mountSelect();
+
+      expect(wrapper.find('[data-testid="dropdown-item-1"]').text()).toContain('Acme');
+      expect(wrapper.find('[data-testid="dropdown-item-2"]').text()).toContain('Globex');
+    });
+
+    test('shows email subtitle when org is loaded and active', () => {
+      mocks.userStore.organizations = [makeOrg({ email: 'user@acme.example' })];
+
+      const wrapper = mountSelect();
+
+      expect(wrapper.find('[data-testid="dropdown-item-1"]').text()).toContain('user@acme.example');
+    });
+
+    test('hides email subtitle when org is still loading', () => {
+      mocks.userStore.organizations = [makeOrg({ isLoading: true })];
+
+      const wrapper = mountSelect();
+
+      expect(wrapper.find('[data-testid="dropdown-item-1"]').text()).not.toContain('user@acme.example');
+    });
+
+    test('hides email subtitle when loginRequired is true', () => {
+      mocks.userStore.organizations = [makeOrg({ loginRequired: true })];
+
+      const wrapper = mountSelect();
+
+      expect(wrapper.find('[data-testid="dropdown-item-1"]').text()).not.toContain('user@acme.example');
+    });
+
+    test('shows loading spinner when org isLoading', () => {
+      mocks.userStore.organizations = [makeOrg({ isLoading: true })];
+
+      const wrapper = mountSelect();
+
+      expect(wrapper.find('[data-testid="dropdown-item-1"]').find('.spinner-border').exists()).toBe(true);
+    });
+
+    test('org item has active class when that org is selected', async () => {
+      const org = makeOrg({ id: 'org-1' });
+      mocks.userStore.selectedOrganization = org;
+      mocks.userStore.organizations = [org];
+
+      const wrapper = mountSelect();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="dropdown-item-1"]').classes()).toContain('active');
+    });
+
+    test('org item does not have active class when a different org is selected', async () => {
+      const org1 = makeOrg({ id: 'org-1' });
+      const org2 = makeOrg({ id: 'org-2' });
+      mocks.userStore.selectedOrganization = org1;
+      mocks.userStore.organizations = [org1, org2];
+
+      const wrapper = mountSelect();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="dropdown-item-2"]').classes()).not.toContain('active');
+    });
+  });
+
+  describe('mode switching', () => {
+    test('does not call selectOrganization when clicking the already-selected personal item', async () => {
+      mocks.userStore.selectedOrganization = null;
+
+      const wrapper = mountSelect();
+      await wrapper.find('[data-testid="dropdown-item-0"]').trigger('click');
+      await flushPromises();
+
+      expect(mocks.userStore.selectOrganization).not.toHaveBeenCalled();
+    });
+
+    test('does not call selectOrganization when clicking the already-selected org item', async () => {
+      const org = makeOrg({ id: 'org-1' });
+      mocks.userStore.selectedOrganization = org;
+      mocks.userStore.organizations = [org];
+
+      const wrapper = mountSelect();
+      await wrapper.find('[data-testid="dropdown-item-1"]').trigger('click');
+      await flushPromises();
+
+      expect(mocks.userStore.selectOrganization).not.toHaveBeenCalled();
+    });
+
+    test('switches to personal by calling selectOrganization(null)', async () => {
+      const org = makeOrg({ id: 'org-1' });
+      mocks.userStore.selectedOrganization = org;
+      mocks.userStore.organizations = [org];
+
+      const wrapper = mountSelect();
+      await wrapper.find('[data-testid="dropdown-item-0"]').trigger('click');
+      await flushPromises();
+
+      expect(mocks.userStore.selectOrganization).toHaveBeenCalledWith(null);
+    });
+
+    test('switches to an org by calling selectOrganization with the org shape', async () => {
+      const org = makeOrg({ id: 'org-1', nickname: 'Acme', serverUrl: 'https://acme.example', key: 'k' });
+      mocks.userStore.selectedOrganization = null;
+      mocks.userStore.organizations = [org];
+
+      const wrapper = mountSelect();
+      await wrapper.find('[data-testid="dropdown-item-1"]').trigger('click');
+      await flushPromises();
+
+      expect(mocks.userStore.selectOrganization).toHaveBeenCalledWith({
+        id: 'org-1',
+        nickname: 'Acme',
+        serverUrl: 'https://acme.example',
+        key: 'k',
+      });
+    });
+  });
+});

--- a/front-end/src/tests/renderer/pages/OrganizationLogin/OrganizationLogin.spec.ts
+++ b/front-end/src/tests/renderer/pages/OrganizationLogin/OrganizationLogin.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 
 import OrganizationLogin from '@renderer/pages/OrganizationLogin/OrganizationLogin.vue';
 
@@ -13,7 +13,13 @@ const mocks = vi.hoisted(() => ({
       serverUrl: 'https://org.example.com',
       loginRequired: true,
     },
+    refetchOrganizations: vi.fn(),
+    selectOrganization: vi.fn(),
   },
+  login: vi.fn(),
+  addOrganizationCredentials: vi.fn(),
+  toggleAuthTokenInSessionStorage: vi.fn(),
+  setLast: vi.fn(),
 }));
 
 vi.mock('vue-router', () => ({
@@ -51,16 +57,16 @@ vi.mock('@renderer/composables/useRecoveryPhraseHashMigrate', () => ({
 
 vi.mock('@renderer/composables/user/useDefaultOrganization', () => ({
   default: vi.fn(() => ({
-    setLast: vi.fn(),
+    setLast: mocks.setLast,
   })),
 }));
 
 vi.mock('@renderer/services/organization', () => ({
-  login: vi.fn(),
+  login: mocks.login,
 }));
 
 vi.mock('@renderer/services/organizationCredentials', () => ({
-  addOrganizationCredentials: vi.fn(),
+  addOrganizationCredentials: mocks.addOrganizationCredentials,
 }));
 
 vi.mock('@renderer/utils/ToastManager', () => ({
@@ -81,10 +87,12 @@ vi.mock('@renderer/utils', () => ({
   isLoggedOutOrganization: vi.fn(() => true),
   isOrganizationActive: vi.fn(() => false),
   redirectToPrevious: vi.fn(),
+  toggleAuthTokenInSessionStorage: mocks.toggleAuthTokenInSessionStorage,
 }));
 
 describe('OrganizationLogin.vue', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mocks.userStore.selectedOrganization.nickname = 'Test Organization A';
   });
 
@@ -161,5 +169,84 @@ describe('OrganizationLogin.vue', () => {
     await wrapper.find('.link-primary').trigger('click');
 
     expect(wrapper.find('[data-testid="forgot-password-modal"]').exists()).toBe(true);
+  });
+
+  test('successful login: writes token to session storage immediately, stores credentials, then refreshes organizations', async () => {
+    mocks.login.mockResolvedValueOnce({ jwtToken: 'test-jwt-token' });
+    mocks.addOrganizationCredentials.mockResolvedValueOnce(undefined);
+    mocks.userStore.refetchOrganizations.mockResolvedValueOnce(undefined);
+    mocks.userStore.selectOrganization.mockResolvedValueOnce(undefined);
+
+    const wrapper = mountOrganizationLogin();
+    await wrapper
+      .find('[data-testid="input-login-email-for-organization"]')
+      .setValue('user@example.com');
+    await wrapper
+      .find('[data-testid="input-login-password-for-organization"]')
+      .setValue('password123');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(mocks.toggleAuthTokenInSessionStorage).toHaveBeenCalledWith(
+      'https://org.example.com',
+      'test-jwt-token',
+    );
+    expect(mocks.addOrganizationCredentials).toHaveBeenCalledWith(
+      'user@example.com',
+      'password123',
+      'org-id',
+      'local-user-id',
+      'test-jwt-token',
+      'personal-password',
+      true,
+    );
+    expect(mocks.userStore.refetchOrganizations).toHaveBeenCalled();
+  });
+
+  test('token is written to session storage before credentials are stored', async () => {
+    const callOrder: string[] = [];
+    mocks.login.mockResolvedValueOnce({ jwtToken: 'test-jwt-token' });
+    mocks.toggleAuthTokenInSessionStorage.mockImplementationOnce(() => {
+      callOrder.push('toggleAuthToken');
+    });
+    mocks.addOrganizationCredentials.mockImplementationOnce(async () => {
+      callOrder.push('addCredentials');
+    });
+    mocks.userStore.refetchOrganizations.mockResolvedValueOnce(undefined);
+    mocks.userStore.selectOrganization.mockResolvedValueOnce(undefined);
+
+    const wrapper = mountOrganizationLogin();
+    await wrapper
+      .find('[data-testid="input-login-email-for-organization"]')
+      .setValue('user@example.com');
+    await wrapper
+      .find('[data-testid="input-login-password-for-organization"]')
+      .setValue('password123');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(callOrder).toEqual(['toggleAuthToken', 'addCredentials']);
+  });
+
+  test('login failure: shows error toast and marks fields invalid without calling refetchOrganizations', async () => {
+    const toastError = vi.fn();
+    vi.mocked(
+      (await import('@renderer/utils/ToastManager')).ToastManager.inject,
+    ).mockReturnValueOnce({ error: toastError, success: vi.fn() } as any);
+
+    mocks.login.mockRejectedValueOnce(new Error('Invalid credentials'));
+
+    const wrapper = mountOrganizationLogin();
+    await wrapper
+      .find('[data-testid="input-login-email-for-organization"]')
+      .setValue('user@example.com');
+    await wrapper
+      .find('[data-testid="input-login-password-for-organization"]')
+      .setValue('wrongpassword');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(mocks.userStore.refetchOrganizations).not.toHaveBeenCalled();
+    expect(mocks.toggleAuthTokenInSessionStorage).not.toHaveBeenCalled();
   });
 });

--- a/front-end/src/tests/renderer/pages/OrganizationLogin/OrganizationLogin.spec.ts
+++ b/front-end/src/tests/renderer/pages/OrganizationLogin/OrganizationLogin.spec.ts
@@ -171,7 +171,7 @@ describe('OrganizationLogin.vue', () => {
     expect(wrapper.find('[data-testid="forgot-password-modal"]').exists()).toBe(true);
   });
 
-  test('successful login: writes token to session storage immediately, stores credentials, then refreshes organizations', async () => {
+  test('successful login: stores credentials, writes token to session storage, then refreshes organizations', async () => {
     mocks.login.mockResolvedValueOnce({ jwtToken: 'test-jwt-token' });
     mocks.addOrganizationCredentials.mockResolvedValueOnce(undefined);
     mocks.userStore.refetchOrganizations.mockResolvedValueOnce(undefined);
@@ -203,7 +203,7 @@ describe('OrganizationLogin.vue', () => {
     expect(mocks.userStore.refetchOrganizations).toHaveBeenCalled();
   });
 
-  test('token is written to session storage before credentials are stored', async () => {
+  test('credentials are stored before token is written to session storage', async () => {
     const callOrder: string[] = [];
     mocks.login.mockResolvedValueOnce({ jwtToken: 'test-jwt-token' });
     mocks.toggleAuthTokenInSessionStorage.mockImplementationOnce(() => {
@@ -225,7 +225,7 @@ describe('OrganizationLogin.vue', () => {
     await wrapper.find('form').trigger('submit');
     await flushPromises();
 
-    expect(callOrder).toEqual(['toggleAuthToken', 'addCredentials']);
+    expect(callOrder).toEqual(['addCredentials', 'toggleAuthToken']);
   });
 
   test('login failure: shows error toast and marks fields invalid without calling refetchOrganizations', async () => {

--- a/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
+++ b/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
@@ -7,15 +7,17 @@ import ProfileTab from '@renderer/pages/Settings/components/ProfileTab.vue';
 const mocks = vi.hoisted(() => ({
   routerPush: vi.fn(),
   userStore: {
-    personal: { id: 'local-user-id', useKeychain: false } as {
+    personal: { id: 'local-user-id', useKeychain: false, email: 'local@example.com' } as {
       id: string;
       useKeychain: boolean;
+      email?: string;
     } | null,
     selectedOrganization: null as null | {
       id: string;
       nickname: string;
       serverUrl: string;
       key: string;
+      email?: string;
     },
     logout: vi.fn(),
     refetchAccounts: vi.fn(),
@@ -118,6 +120,7 @@ const ORG = {
   nickname: 'Acme',
   serverUrl: 'https://acme.example',
   key: 'org-key',
+  email: 'org@acme.example',
 };
 
 const STRONG_OLD = 'old-password';
@@ -142,7 +145,7 @@ const clickConfirm = async (wrapper: ReturnType<typeof mountProfile>) => {
 describe('settings profile coverage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.userStore.personal = { id: 'local-user-id', useKeychain: false };
+    mocks.userStore.personal = { id: 'local-user-id', useKeychain: false, email: 'local@example.com' };
     mocks.userStore.selectedOrganization = null;
   });
 
@@ -580,6 +583,45 @@ describe('settings profile coverage', () => {
       expect(wrapper.text()).toContain('Reset Application');
       expect(wrapper.find('[data-testid="input-current-password"]').exists()).toBe(false);
       expect(wrapper.find('[data-testid="input-new-password"]').exists()).toBe(false);
+    });
+  });
+
+  describe('email display', () => {
+    test('shows personal email for non-keychain user', () => {
+      mocks.userStore.personal = { id: 'local-user-id', useKeychain: false, email: 'local@example.com' };
+      mocks.userStore.selectedOrganization = null;
+
+      const wrapper = mountProfile();
+
+      expect(wrapper.text()).toContain('Email');
+      expect(wrapper.text()).toContain('local@example.com');
+    });
+
+    test('shows organization email when an org is selected', () => {
+      mocks.userStore.selectedOrganization = { ...ORG };
+
+      const wrapper = mountProfile();
+
+      expect(wrapper.text()).toContain('Email');
+      expect(wrapper.text()).toContain('org@acme.example');
+    });
+
+    test('falls back to personal email when org has no email', () => {
+      mocks.userStore.selectedOrganization = { ...ORG, email: undefined };
+
+      const wrapper = mountProfile();
+
+      expect(wrapper.text()).toContain('Email');
+      expect(wrapper.text()).toContain('local@example.com');
+    });
+
+    test('does not render email section for keychain-only user with no org', () => {
+      mocks.userStore.personal = { id: 'local-user-id', useKeychain: true };
+      mocks.userStore.selectedOrganization = null;
+
+      const wrapper = mountProfile();
+
+      expect(wrapper.text()).not.toContain('Email');
     });
   });
 });


### PR DESCRIPTION
**Description**:
This pull request makes significant improvements to the user mode selection dropdown, organization login flow, and related UI components. The main focus is on enhancing the dropdown's logic and presentation, improving maintainability, and adding comprehensive tests for the `UserModeSelect` component. There are also minor improvements to the organization login flow and styling updates. 

The main goal is to enable the user to see the current username/email in use for each organization.

**Related issue(s)**:

Fixes #2982

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
