### PR TITLE
fix: keychain auth breaking migration flow after app reset  

### DIFF
--- a/front-end/src/renderer/pages/Migrate/components/SetupPersonal.vue
+++ b/front-end/src/renderer/pages/Migrate/components/SetupPersonal.vue
@@ -68,7 +68,11 @@ const setupPersonal = async ({
   password,
 }: ModelValue): Promise<PersonalUser> => {
   /* Initialize the use of the keychain */
-  await initializeUseKeychain(useKeychain);
+  try {
+    await initializeUseKeychain(useKeychain);
+  } catch {
+    // Must be ignored in this context
+  }
 
   /* Register the user */
   const personalId = useKeychain


### PR DESCRIPTION
**Description**:
Changes below fix `SetupPersonal` view : it now continues even if keychain has already been initialized.

**Related issue(s)**:

Fixes #2992

**Notes for reviewer**:

See [2992](https://github.com/hashgraph/hedera-transaction-tool/issues/2992#issuecomment-4770560529) for test scenario.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
