### PR TITLE
feat: email notifications are now disabled by default

### DIFF
--- a/back-end/apps/api/src/notification-preferences/notification-preferences.service.spec.ts
+++ b/back-end/apps/api/src/notification-preferences/notification-preferences.service.spec.ts
@@ -286,7 +286,7 @@ describe('NotificationPreferencesService', () => {
       expect(repo.create).toHaveBeenCalledWith({
         userId: user.id,
         type: NotificationType.TRANSACTION_CREATED,
-        email: true,
+        email: false,
         inApp: true,
       });
       expect(repo.insert).toHaveBeenCalledWith(newPreferences);
@@ -322,7 +322,7 @@ describe('NotificationPreferencesService', () => {
       repo.find.mockResolvedValue([]);
       const newPreferences = {
         userId: user.id,
-        email: true,
+        email: false,
         inApp: true,
       };
       repo.create.mockImplementation(((data: NotificationPreferences) => data) as any);
@@ -339,7 +339,7 @@ describe('NotificationPreferencesService', () => {
         expect(repo.create).toHaveBeenCalledWith({
           userId: user.id,
           type,
-          email: true,
+          email: false,
           inApp: true,
         });
         expect(repo.insert).toHaveBeenCalledWith({ ...newPreferences, type });

--- a/back-end/apps/api/src/notification-preferences/notification-preferences.service.ts
+++ b/back-end/apps/api/src/notification-preferences/notification-preferences.service.ts
@@ -69,7 +69,7 @@ export class NotificationPreferencesService {
     const newPreferences = this.repo.create({
       userId: user.id,
       type,
-      email: true,
+      email: false,
       inApp: true,
     });
 


### PR DESCRIPTION
**Description**:

Changes below update preferences initialization logic for email notifications.
By default, email notifications are now all disabled.

**Related issue(s)**:

Fixes #2989 

**Notes for reviewer**:

1) Deploy a fresh Transaction Tool backend
2) Create an admin user
3) Start and initialize Transaction Tool client
4) Add a new org pointing to your Transaction Tool backend
5) Connect to new org with your admin user
6) `Settings` > `Notifications` 
    => notifications are all unchecked

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
