### PR TITLE
fix: consistent access checks across transaction sub-resources endpoints

### DIFF
--- a/back-end/apps/api/src/guards/transaction-access.guard.spec.ts
+++ b/back-end/apps/api/src/guards/transaction-access.guard.spec.ts
@@ -56,13 +56,20 @@ describe('TransactionAccessGuard', () => {
     expect(transactionsService.getTransactionWithVerifiedAccess).not.toHaveBeenCalled();
   });
 
+  it('should deny access when transactionId is not a valid integer', async () => {
+    const user = { id: 1 } as User;
+    const context = mockExecutionContext(user, { transactionId: 'not-a-number' });
+    expect(await guard.canActivate(context)).toBe(false);
+    expect(transactionsService.getTransactionWithVerifiedAccess).not.toHaveBeenCalled();
+  });
+
   it('should read transactionId from request.params.transactionId', async () => {
     const user = { id: 1 } as User;
     transactionsService.getTransactionWithVerifiedAccess.mockResolvedValue(undefined);
     const context = mockExecutionContext(user, { transactionId: '42' });
 
     expect(await guard.canActivate(context)).toBe(true);
-    expect(transactionsService.getTransactionWithVerifiedAccess).toHaveBeenCalledWith('42', user);
+    expect(transactionsService.getTransactionWithVerifiedAccess).toHaveBeenCalledWith(42, user);
   });
 
   it('should allow access when the user has a relationship with the transaction', async () => {

--- a/back-end/apps/api/src/guards/transaction-access.guard.spec.ts
+++ b/back-end/apps/api/src/guards/transaction-access.guard.spec.ts
@@ -1,0 +1,85 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+
+import { User } from '@entities';
+
+import { TransactionsService } from '../transactions/transactions.service';
+
+import { TransactionAccessGuard } from './transaction-access.guard';
+
+describe('TransactionAccessGuard', () => {
+  let guard: TransactionAccessGuard;
+  let transactionsService: jest.Mocked<
+    Pick<TransactionsService, 'getTransactionWithVerifiedAccess'>
+  >;
+
+  const mockExecutionContext = (
+    user: Partial<User> | undefined,
+    params: Record<string, unknown> = {},
+  ): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({ user, params }),
+      }),
+    }) as ExecutionContext;
+
+  beforeEach(async () => {
+    transactionsService = {
+      getTransactionWithVerifiedAccess: jest.fn(),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        TransactionAccessGuard,
+        {
+          provide: TransactionsService,
+          useValue: transactionsService,
+        },
+      ],
+    }).compile();
+
+    guard = moduleRef.get(TransactionAccessGuard);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should deny access when no user is in the request', async () => {
+    const context = mockExecutionContext(undefined, { transactionId: '1' });
+    expect(await guard.canActivate(context)).toBe(false);
+    expect(transactionsService.getTransactionWithVerifiedAccess).not.toHaveBeenCalled();
+  });
+
+  it('should deny access when no transactionId is in the params', async () => {
+    const user = { id: 1 } as User;
+    const context = mockExecutionContext(user, {});
+    expect(await guard.canActivate(context)).toBe(false);
+    expect(transactionsService.getTransactionWithVerifiedAccess).not.toHaveBeenCalled();
+  });
+
+  it('should read transactionId from request.params.transactionId', async () => {
+    const user = { id: 1 } as User;
+    transactionsService.getTransactionWithVerifiedAccess.mockResolvedValue(undefined);
+    const context = mockExecutionContext(user, { transactionId: '42' });
+
+    expect(await guard.canActivate(context)).toBe(true);
+    expect(transactionsService.getTransactionWithVerifiedAccess).toHaveBeenCalledWith('42', user);
+  });
+
+  it('should allow access when the user has a relationship with the transaction', async () => {
+    const user = { id: 1 } as User;
+    transactionsService.getTransactionWithVerifiedAccess.mockResolvedValue(undefined);
+    const context = mockExecutionContext(user, { transactionId: '1' });
+
+    expect(await guard.canActivate(context)).toBe(true);
+  });
+
+  it('should propagate UnauthorizedException when the user has no relationship with the transaction', async () => {
+    const user = { id: 99 } as User;
+    transactionsService.getTransactionWithVerifiedAccess.mockRejectedValue(
+      new UnauthorizedException("You don't have permission to view this transaction"),
+    );
+    const context = mockExecutionContext(user, { transactionId: '1' });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(UnauthorizedException);
+  });
+});

--- a/back-end/apps/api/src/guards/transaction-access.guard.ts
+++ b/back-end/apps/api/src/guards/transaction-access.guard.ts
@@ -1,0 +1,23 @@
+import { CanActivate, ExecutionContext, Inject } from '@nestjs/common';
+import { TransactionsService } from '../transactions/transactions.service';
+
+export class TransactionAccessGuard implements CanActivate {
+  constructor(
+    @Inject(TransactionsService) private readonly transactionsService: TransactionsService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    const transactionId = request.params.transactionId;
+
+    if (!user || !transactionId) {
+      return false;
+    }
+
+    // This will throw UnauthorizedException if access is denied
+    await this.transactionsService.getTransactionWithVerifiedAccess(transactionId, user);
+
+    return true;
+  }
+}

--- a/back-end/apps/api/src/guards/transaction-access.guard.ts
+++ b/back-end/apps/api/src/guards/transaction-access.guard.ts
@@ -9,9 +9,9 @@ export class TransactionAccessGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
     const user = request.user;
-    const transactionId = request.params.transactionId;
+    const transactionId = parseInt(request.params.transactionId, 10);
 
-    if (!user || !transactionId) {
+    if (!user || isNaN(transactionId)) {
       return false;
     }
 

--- a/back-end/apps/api/src/transactions/comments/comments.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/comments/comments.controller.spec.ts
@@ -1,10 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { mockDeep } from 'jest-mock-extended';
+import { plainToInstance } from 'class-transformer';
 
 import { BlacklistService, guardMock } from '@app/common';
 import { User } from '@entities';
 
+import { TransactionCommentDto } from '../dto';
+
 import { VerifiedUserGuard } from '../../guards';
+import { TransactionAccessGuard } from '../../guards/transaction-access.guard';
 
 import { CommentsController } from './comments.controller';
 import { CommentsService } from './comments.service';
@@ -37,6 +41,8 @@ describe('CommentsController', () => {
     })
       .overrideGuard(VerifiedUserGuard)
       .useValue(guardMock())
+      .overrideGuard(TransactionAccessGuard)
+      .useValue(guardMock())
       .compile();
 
     controller = module.get<CommentsController>(CommentsController);
@@ -62,11 +68,28 @@ describe('CommentsController', () => {
 
   describe('getCommentById', () => {
     it('should return a comment', async () => {
+      const tid = 10;
       const id = 1;
 
-      await controller.getCommentById(id);
+      await controller.getCommentById(tid, id);
 
-      expect(commentsService.getTransactionCommentById).toHaveBeenCalledWith(id);
+      expect(commentsService.getTransactionCommentById).toHaveBeenCalledWith(tid, id);
+    });
+  });
+
+  describe('TransactionCommentDto serialization', () => {
+    it('should transform nested user using UserCoreDto', () => {
+      const raw = {
+        id: 1,
+        message: 'hello',
+        createdAt: new Date(),
+        user: { id: 2, email: 'user@test.com', password: 'secret' },
+      };
+
+      const dto = plainToInstance(TransactionCommentDto, raw, { excludeExtraneousValues: true });
+
+      expect(dto.user).toEqual({ id: 2, email: 'user@test.com' });
+      expect((dto.user as any).password).toBeUndefined();
     });
   });
 });

--- a/back-end/apps/api/src/transactions/comments/comments.controller.ts
+++ b/back-end/apps/api/src/transactions/comments/comments.controller.ts
@@ -10,7 +10,8 @@ import { GetUser } from '../../decorators';
 
 import { CommentsService } from './comments.service';
 
-import { CreateCommentDto } from '../dto';
+import { CreateCommentDto, TransactionCommentDto } from '../dto';
+import { Serialize } from '@app/common';
 
 @ApiTags('Transaction Comments')
 @Controller('transactions/:transactionId/comments')
@@ -19,6 +20,7 @@ export class CommentsController {
   constructor(private commentsService: CommentsService) {}
 
   @Post()
+  @Serialize(TransactionCommentDto)
   createComment(
     @GetUser() user: User,
     @Param('transactionId', ParseIntPipe) transactionId: number,
@@ -28,11 +30,13 @@ export class CommentsController {
   }
 
   @Get()
+  @Serialize(TransactionCommentDto)
   getComments(@Param('transactionId', ParseIntPipe) transactionId: number) {
     return this.commentsService.getTransactionComments(transactionId);
   }
 
   @Get('/:id')
+  @Serialize(TransactionCommentDto)
   getCommentById(
     @Param('transactionId', ParseIntPipe) transactionId: number,
     @Param('id', ParseIntPipe) id: number,

--- a/back-end/apps/api/src/transactions/comments/comments.controller.ts
+++ b/back-end/apps/api/src/transactions/comments/comments.controller.ts
@@ -4,22 +4,21 @@ import { ApiTags } from '@nestjs/swagger';
 import { User } from '@entities';
 
 import { JwtAuthGuard, JwtBlackListAuthGuard, VerifiedUserGuard } from '../../guards';
+import { TransactionAccessGuard } from '../../guards/transaction-access.guard';
 
-import { GetUser } from '../../decorators/get-user.decorator';
+import { GetUser } from '../../decorators';
 
 import { CommentsService } from './comments.service';
 
-import { CreateCommentDto } from '../dto/create-comment.dto';
+import { CreateCommentDto } from '../dto';
 
 @ApiTags('Transaction Comments')
-@Controller('transactions{/:transactionId}/comments')
-@UseGuards(JwtBlackListAuthGuard, JwtAuthGuard, VerifiedUserGuard)
-//TODO add serializer
+@Controller('transactions/:transactionId/comments')
+@UseGuards(JwtBlackListAuthGuard, JwtAuthGuard, VerifiedUserGuard, TransactionAccessGuard)
 export class CommentsController {
   constructor(private commentsService: CommentsService) {}
 
   @Post()
-  //TODO need some sort of guard or check to ensure user can comment here
   createComment(
     @GetUser() user: User,
     @Param('transactionId', ParseIntPipe) transactionId: number,
@@ -34,8 +33,11 @@ export class CommentsController {
   }
 
   @Get('/:id')
-  getCommentById(@Param('id', ParseIntPipe) id: number) {
-    return this.commentsService.getTransactionCommentById(id);
+  getCommentById(
+    @Param('transactionId', ParseIntPipe) transactionId: number,
+    @Param('id', ParseIntPipe) id: number,
+  ) {
+    return this.commentsService.getTransactionCommentById(transactionId, id);
   }
 
   //TODO add update and remove routes

--- a/back-end/apps/api/src/transactions/comments/comments.service.spec.ts
+++ b/back-end/apps/api/src/transactions/comments/comments.service.spec.ts
@@ -81,13 +81,16 @@ describe('CommentsService', () => {
   });
 
   describe('getTransactionCommentById', () => {
-    it('should return a transaction comment by id', async () => {
+    it('should return a transaction comment by id scoped to the transaction', async () => {
       const mockComment = { id: 1, message: 'Test comment' } as TransactionComment;
-      repo.findOneBy.mockResolvedValue(mockComment);
+      repo.findOne.mockResolvedValue(mockComment);
 
-      const result = await service.getTransactionCommentById(1);
+      const result = await service.getTransactionCommentById(10, 1);
 
-      expect(repo.findOneBy).toHaveBeenCalledWith({ id: 1 });
+      expect(repo.findOne).toHaveBeenCalledWith({
+        where: { id: 1, transaction: { id: 10 } },
+        relations: ['user'],
+      });
       expect(result).toEqual(mockComment);
     });
   });
@@ -101,6 +104,7 @@ describe('CommentsService', () => {
       ] as TransactionComment[];
 
       repo.createQueryBuilder.mockReturnValue({
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         getMany: jest.fn().mockResolvedValue(mockComments),
       } as unknown as SelectQueryBuilder<TransactionComment>);

--- a/back-end/apps/api/src/transactions/comments/comments.service.ts
+++ b/back-end/apps/api/src/transactions/comments/comments.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { TransactionComment, User } from '@entities';
 import { Repository } from 'typeorm';
 import { ErrorCodes } from '@app/common';
-import { CreateCommentDto } from '../dto/create-comment.dto';
+import { CreateCommentDto } from '../dto';
 
 @Injectable()
 export class CommentsService {
@@ -31,15 +31,16 @@ export class CommentsService {
     }
   }
 
-  // Get the transaction comment for the given id.
-  getTransactionCommentById(id: number) {
-    return this.repo.findOneBy({ id });
+  // Get the transaction comment for the given id, scoped to the transaction.
+  getTransactionCommentById(transactionId: number, id: number) {
+    return this.repo.findOne({ where: { id, transaction: { id: transactionId } }, relations: ['user'] });
   }
 
   // Get the transaction comments for the given transaction id.
   getTransactionComments(transactionId: number) {
     return this.repo
       .createQueryBuilder('comment')
+      .leftJoinAndSelect('comment.user', 'user')
       .where('comment.transactionId = :transactionId', { transactionId })
       .getMany();
   }

--- a/back-end/apps/api/src/transactions/dto/index.ts
+++ b/back-end/apps/api/src/transactions/dto/index.ts
@@ -8,6 +8,7 @@ export * from './create-transaction-observers.dto';
 export * from './signature-import-result.dto';
 export * from './transaction.dto';
 export * from './transaction-approver.dto';
+export * from './transaction-comment.dto';
 export * from './transaction-group.dto';
 export * from './transaction-observer.dto';
 export * from './transaction-signer.dto';

--- a/back-end/apps/api/src/transactions/dto/transaction-comment.dto.ts
+++ b/back-end/apps/api/src/transactions/dto/transaction-comment.dto.ts
@@ -1,0 +1,17 @@
+import { Expose, Type } from 'class-transformer';
+import { UserCoreDto } from '../../users/dtos';
+
+export class TransactionCommentDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  @Type(() => UserCoreDto)
+  user: UserCoreDto;
+
+  @Expose()
+  message: string;
+
+  @Expose()
+  createdAt: Date;
+}

--- a/back-end/apps/api/src/transactions/observers/observers.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/observers/observers.controller.spec.ts
@@ -5,6 +5,7 @@ import { BlacklistService, guardMock } from '@app/common';
 import { Role, TransactionObserver, User, UserStatus } from '@entities';
 
 import { VerifiedUserGuard } from '../../guards';
+import { TransactionAccessGuard } from '../../guards/transaction-access.guard';
 
 import { ObserversController } from './observers.controller';
 import { ObserversService } from './observers.service';
@@ -32,6 +33,8 @@ describe('ObserversController', () => {
       ],
     })
       .overrideGuard(VerifiedUserGuard)
+      .useValue(guardMock())
+      .overrideGuard(TransactionAccessGuard)
       .useValue(guardMock())
       .compile();
 

--- a/back-end/apps/api/src/transactions/observers/observers.controller.ts
+++ b/back-end/apps/api/src/transactions/observers/observers.controller.ts
@@ -15,18 +15,19 @@ import { Serialize } from '@app/common';
 import { TransactionObserver, User } from '@entities';
 
 import { JwtAuthGuard, JwtBlackListAuthGuard, VerifiedUserGuard } from '../../guards';
+import { TransactionAccessGuard } from '../../guards/transaction-access.guard';
 import { GetUser } from '../../decorators';
 import {
-  TransactionObserverDto,
   CreateTransactionObserversDto,
+  TransactionObserverDto,
   UpdateTransactionObserverDto,
 } from '../dto/';
 
 import { ObserversService } from './observers.service';
 
 @ApiTags('Transaction Observers')
-@Controller('transactions{/:transactionId}/observers')
-@UseGuards(JwtBlackListAuthGuard, JwtAuthGuard, VerifiedUserGuard)
+@Controller('transactions/:transactionId/observers')
+@UseGuards(JwtBlackListAuthGuard, JwtAuthGuard, VerifiedUserGuard, TransactionAccessGuard)
 @Serialize(TransactionObserverDto)
 export class ObserversController {
   constructor(private observersService: ObserversService) {}

--- a/back-end/apps/api/src/transactions/observers/observers.controller.ts
+++ b/back-end/apps/api/src/transactions/observers/observers.controller.ts
@@ -26,8 +26,8 @@ import {
 import { ObserversService } from './observers.service';
 
 @ApiTags('Transaction Observers')
-@Controller('transactions/:transactionId/observers')
-@UseGuards(JwtBlackListAuthGuard, JwtAuthGuard, VerifiedUserGuard, TransactionAccessGuard)
+@Controller('transactions{/:transactionId}/observers')
+@UseGuards(JwtBlackListAuthGuard, JwtAuthGuard, VerifiedUserGuard)
 @Serialize(TransactionObserverDto)
 export class ObserversController {
   constructor(private observersService: ObserversService) {}
@@ -42,6 +42,7 @@ export class ObserversController {
     type: TransactionObserverDto,
   })
   @Post()
+  @UseGuards(TransactionAccessGuard)
   createTransactionObserver(
     @GetUser() user: User,
     @Param('transactionId', ParseIntPipe) transactionId: number,
@@ -60,6 +61,7 @@ export class ObserversController {
     type: [TransactionObserverDto],
   })
   @Get()
+  @UseGuards(TransactionAccessGuard)
   getTransactionObserversByTransactionId(
     @GetUser() user: User,
     @Param('transactionId', ParseIntPipe) id: number,

--- a/back-end/apps/api/src/transactions/signers/signers.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.controller.spec.ts
@@ -1,12 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { mockDeep } from 'jest-mock-extended';
-import { EntityManager } from 'typeorm';
 import { SignatureMap } from '@hiero-ledger/sdk';
 
 import { BlacklistService, guardMock } from '@app/common';
 import { TransactionSigner, User, UserStatus } from '@entities';
 
 import { VerifiedUserGuard } from '../../guards';
+import { TransactionAccessGuard } from '../../guards/transaction-access.guard';
 
 import { SignersController } from './signers.controller';
 import { SignersService } from './signers.service';
@@ -35,7 +35,6 @@ describe('SignaturesController', () => {
   let signer: TransactionSigner;
 
   const signersService = mockDeep<SignersService>();
-  const entityManager = mockDeep<EntityManager>();
   const blacklistService = mockDeep<BlacklistService>();
 
   beforeEach(async () => {
@@ -47,16 +46,14 @@ describe('SignaturesController', () => {
           useValue: signersService,
         },
         {
-          provide: EntityManager,
-          useValue: entityManager,
-        },
-        {
           provide: BlacklistService,
           useValue: blacklistService,
         },
       ],
     })
       .overrideGuard(VerifiedUserGuard)
+      .useValue(guardMock())
+      .overrideGuard(TransactionAccessGuard)
       .useValue(guardMock())
       .compile();
 

--- a/back-end/apps/api/src/transactions/signers/signers.controller.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.controller.ts
@@ -53,6 +53,7 @@ export class SignersController {
   @Get()
   @HttpCode(200)
   @UseGuards(TransactionAccessGuard)
+  @Serialize(TransactionSignerUserKeyDto)
   getSignaturesByTransactionId(
     @Param('transactionId', ParseIntPipe) transactionId: number,
   ): Promise<TransactionSigner[]> {

--- a/back-end/apps/api/src/transactions/signers/signers.controller.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.controller.ts
@@ -22,14 +22,15 @@ import {
 import { TransactionSigner, User } from '@entities';
 
 import { JwtAuthGuard, JwtBlackListAuthGuard, VerifiedUserGuard } from '../../guards';
+import { TransactionAccessGuard } from '../../guards/transaction-access.guard';
 import { GetUser } from '../../decorators';
 
 import {
+  TransactionSignerDto,
+  TransactionSignerFullDto,
+  TransactionSignerUserKeyDto,
   UploadSignatureMapDto,
   UploadSignatureMapResponseDto,
-  TransactionSignerDto,
-  TransactionSignerUserKeyDto,
-  TransactionSignerFullDto,
 } from '../dto';
 
 import { SignersService } from './signers.service';
@@ -51,17 +52,17 @@ export class SignersController {
   })
   @Get()
   @HttpCode(200)
+  @UseGuards(TransactionAccessGuard)
   getSignaturesByTransactionId(
     @Param('transactionId', ParseIntPipe) transactionId: number,
   ): Promise<TransactionSigner[]> {
     return this.signaturesService.getSignaturesByTransactionId(transactionId, true);
   }
 
-  /* Returns all signatures for a particular user for the transaction */
+  /* Returns all signatures for a particular user */
   @ApiOperation({
     summary: 'Get signatures for user',
-    description:
-      'Get all transaction signatures for the current user for the transaction with the given id.',
+    description: 'Get all transaction signatures for the current user.',
   })
   @ApiResponse({
     status: 200,
@@ -77,7 +78,6 @@ export class SignersController {
     return this.signaturesService.getSignaturesByUser(user, pagination, true);
   }
 
-
   /* Upload one or more signature maps for one or more transactions */
   @ApiOperation({
     summary: 'Upload one or more signature maps for one or more transactions',
@@ -90,12 +90,12 @@ export class SignersController {
   @ApiResponse({
     status: 201,
     type: [TransactionSignerFullDto],
-    description: 'Deprecated: use ?includeNotifications=true for full response'
+    description: 'Deprecated: use ?includeNotifications=true for full response',
   })
   @ApiResponse({
     status: 201,
     type: UploadSignatureMapResponseDto,
-    description: 'Returned when includeNotifications=true'
+    description: 'Returned when includeNotifications=true',
   })
   @Post()
   @HttpCode(201)

--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -2612,7 +2612,6 @@ describe('TransactionsService', () => {
     it('should throw if transaction is not found', async () => {
       transactionsRepo.find.mockResolvedValue([]);
 
-      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
       await expect(service.getTransactionWithVerifiedAccess(123, user as User)).rejects.toThrow(
         ErrorCodes.TNF,
       );
@@ -2737,28 +2736,34 @@ describe('TransactionsService', () => {
       );
     });
 
-    it('should return history transaction, even if the user does not have verified access', async () => {
+    it('should return EXECUTED transaction without checking user association', async () => {
       const transaction = {
         id: 123,
-        creatorKey: {
-          id: 1,
-          userId: 1,
-          user: {
-            id: 1,
-            email: 'test@email.com',
-          },
-        },
+        creatorKey: { id: 1, userId: 99, user: { id: 99, email: 'other@email.com' } },
         status: TransactionStatus.EXECUTED,
       };
 
-      (userKeysRequiredToSign as jest.Mock).mockResolvedValueOnce([]);
       jest.spyOn(approversService, 'getApproversByTransactionId').mockResolvedValueOnce([]);
       jest.spyOn(approversService, 'getTreeStructure').mockReturnValue([]);
       transactionsRepo.find.mockResolvedValue([transaction as Transaction]);
 
-      await expect(service.getTransactionWithVerifiedAccess(123, user as User)).resolves.toEqual(
-        transaction,
-      );
+      await expect(service.getTransactionWithVerifiedAccess(123, user as User)).resolves.toEqual(transaction);
+      expect(userKeysRequiredToSign).not.toHaveBeenCalled();
+    });
+
+    it('should return FAILED transaction without checking user association', async () => {
+      const transaction = {
+        id: 456,
+        creatorKey: { id: 1, userId: 99, user: { id: 99, email: 'other@email.com' } },
+        status: TransactionStatus.FAILED,
+      };
+
+      jest.spyOn(approversService, 'getApproversByTransactionId').mockResolvedValueOnce([]);
+      jest.spyOn(approversService, 'getTreeStructure').mockReturnValue([]);
+      transactionsRepo.find.mockResolvedValue([transaction as Transaction]);
+
+      await expect(service.getTransactionWithVerifiedAccess(456, user as User)).resolves.toEqual(transaction);
+      expect(userKeysRequiredToSign).not.toHaveBeenCalled();
     });
   });
 

--- a/back-end/apps/api/src/user-keys/dtos/user-key-core.dto.ts
+++ b/back-end/apps/api/src/user-keys/dtos/user-key-core.dto.ts
@@ -5,11 +5,5 @@ export class UserKeyCoreDto {
   id: number;
 
   @Expose()
-  mnemonicHash?: string;
-
-  @Expose()
-  index?: number;
-
-  @Expose()
   publicKey: string;
 }

--- a/back-end/apps/api/src/users/dtos/user.dto.ts
+++ b/back-end/apps/api/src/users/dtos/user.dto.ts
@@ -5,6 +5,14 @@ import { UserStatus } from '@entities';
 
 import { UserKeyDto } from '../../user-keys/dtos';
 
+export class UserCoreDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  email: string;
+}
+
 export class UserDto {
   @Expose()
   id: number;


### PR DESCRIPTION
**Description**:

Adds a `TransactionAccessGuard` that verifies a user has an explicit relationship with a transaction (as its creator, observer, approver, or required signer) before allowing access to its sub-resources. The guard is applied to the `CommentsController`, `ObserversController`, and `SignersController` endpoints.

**Related issue(s)**:

Fixes #2931

**Notes for reviewer**:

- the added guard  is based on `getTransactionWithVerifiedAccess` (itself based on `verifyAccess`) from the transaction service, which means that EXECUTED and FAILED transactions bypass the access check, consistent with the behavior of the `GET /transactions/:id` endpoint.
- when this access check fails, an `UnauthorizedException` is raised which will cause the endpoint to return 401 (_not 403 as specified in the issue_) to remain consistent with the current behavior of `GET /transactions/:id`.
- a `TransactionCommentDto` serializer is applied to the comments controller (previously had a TODO).
- `mnemonicHash` and `index` are removed from `UserKeyCoreDto` to avoid leaking sensitive key fields
- `transactionId` is now mandatory in the routes defined by the comments and observers controllers
- the signers controller has a mix of routes scoped and not scoped by `transactionId`, which hence remains optional in the main route, but the added guard will check that it is provided -- this is for simplicity, we might as well have split this controller in 2.
- in the endpoint `GET /transactions/:transactionId/comments/:id` the lookup is now also scoped by `transactionId`