### PR TITLE
fix: registered node update transactions show service endpoints with commas

### DIFF
--- a/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
@@ -137,11 +137,7 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
             <tr v-for="(endpoint, index) of transaction.serviceEndpoints" :key="index">
               <td class="col text-start">{{ typeLabel[endpoint.type] ?? endpoint.type }}</td>
               <td class="col text-start">
-                {{
-                  endpoint.ipAddress
-                    ? stringifyIpAddressBytes(endpoint.ipAddress)
-                    : (endpoint.domainName ?? '')
-                }}
+                {{ stringifyIpAddressBytes(endpoint.ipAddress) || (endpoint.domainName ?? '') }}
               </td>
               <td class="col text-start">{{ endpoint.port }}</td>
               <td class="col text-start">{{ endpoint.requiresTls ? 'Yes' : 'No' }}</td>

--- a/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
+++ b/front-end/src/renderer/components/Transaction/Details/RegisteredNodeDetails.vue
@@ -9,13 +9,14 @@ import {
   KeyList,
   PublicKey,
   RegisteredNodeCreateTransaction,
-  RegisteredNodeUpdateTransaction,
   RegisteredNodeDeleteTransaction,
+  RegisteredNodeUpdateTransaction,
   Transaction,
 } from '@hiero-ledger/sdk';
 
 import KeyStructureModal from '@renderer/components/KeyStructureModal.vue';
 import { labelForBlockNodeApi } from '@renderer/components/Transaction/Create/RegisteredNodeCreate/BlockNodeApiLabel.ts';
+import { stringifyIpAddressBytes } from '@renderer/utils';
 
 /* Props */
 const props = defineProps<{
@@ -135,7 +136,13 @@ const commonColClass = 'col-6 col-lg-5 col-xl-4 col-xxl-3 overflow-hidden py-3';
         -->
             <tr v-for="(endpoint, index) of transaction.serviceEndpoints" :key="index">
               <td class="col text-start">{{ typeLabel[endpoint.type] ?? endpoint.type }}</td>
-              <td class="col text-start">{{ endpoint.ipAddress ?? endpoint.domainName ?? '' }}</td>
+              <td class="col text-start">
+                {{
+                  endpoint.ipAddress
+                    ? stringifyIpAddressBytes(endpoint.ipAddress)
+                    : (endpoint.domainName ?? '')
+                }}
+              </td>
               <td class="col text-start">{{ endpoint.port }}</td>
               <td class="col text-start">{{ endpoint.requiresTls ? 'Yes' : 'No' }}</td>
               <td class="col text-start">

--- a/front-end/src/renderer/utils/sdk/getData.ts
+++ b/front-end/src/renderer/utils/sdk/getData.ts
@@ -314,6 +314,10 @@ const getRegisteredEndpointType = (
   return endpoint.type;
 };
 
+export function stringifyIpAddressBytes(ipBytes: Uint8Array | null | undefined): string {
+  return ipBytes && ipBytes.length === 4 ? Array.from(ipBytes).join('.') : '';
+}
+
 /**
  * Extract an endpoint from a decoded SDK transaction back into the FE-facing
  * shape. Deliberately does NOT populate `uiId` — that field is a render-side
@@ -325,9 +329,7 @@ const getRegisteredEndpointType = (
 export const getComponentRegisteredEndpoint = (
   endpoint: RegisteredServiceEndpoint,
 ): ComponentRegisteredServiceEndpoint => {
-  const ipBytes = endpoint.ipAddress;
-  const ipAddressV4 =
-    ipBytes && ipBytes.length === 4 ? Array.from(ipBytes).join('.') : '';
+  const ipAddressV4 = stringifyIpAddressBytes(endpoint.ipAddress);
   const base: ComponentRegisteredServiceEndpoint = {
     ipAddressV4,
     port: endpoint.port != null ? endpoint.port.toString() : '',

--- a/front-end/src/renderer/utils/sdk/getData.ts
+++ b/front-end/src/renderer/utils/sdk/getData.ts
@@ -314,8 +314,52 @@ const getRegisteredEndpointType = (
   return endpoint.type;
 };
 
+/**
+ * Converts an IP (v4 or v6) address represented as a Uint8Array into a string.
+ * In the case of an IPv6 address, this returns the (compressed) canonical text representation
+ * defined in RFC 5952 §4.
+ * For instance: 2001:0db8:0000:0000:0000:ff00:0042:8329
+ * becomes:      2001:db8::ff00:42:8329
+ */
 export function stringifyIpAddressBytes(ipBytes: Uint8Array | null | undefined): string {
-  return ipBytes && ipBytes.length === 4 ? Array.from(ipBytes).join('.') : '';
+  if (!ipBytes) return '';
+  if (ipBytes.length === 4) return Array.from(ipBytes).join('.');
+  if (ipBytes.length === 16) {
+    const groups: string[] = [];
+    for (let i = 0; i < 16; i += 2) {
+      groups.push(((ipBytes[i] << 8) | ipBytes[i + 1]).toString(16));
+    }
+
+    // Find the longest run of consecutive groups of only zeros for '::'.
+    // Choose the first run in case of multiple runs of the same length.
+    let bestStart = -1;
+    let bestLen = 0;
+    let runStart = -1;
+    let runLen = 0;
+    for (let i = 0; i < groups.length; i++) {
+      if (groups[i] === '0') {
+        if (runStart === -1) {
+          runStart = i;
+          runLen = 0;
+        }
+        runLen++;
+        if (runLen > bestLen) {
+          bestLen = runLen;
+          bestStart = runStart;
+        }
+      } else {
+        runStart = -1;
+      }
+    }
+
+    // Minimal length to compress groups of only zeros is 2 groups.
+    if (bestLen < 2) return groups.join(':');
+
+    const before = groups.slice(0, bestStart).join(':');
+    const after = groups.slice(bestStart + bestLen).join(':');
+    return `${before}::${after}`;
+  }
+  return '';
 }
 
 /**

--- a/front-end/src/tests/renderer/components/Transaction/Details/RegisteredNodeDetails.spec.ts
+++ b/front-end/src/tests/renderer/components/Transaction/Details/RegisteredNodeDetails.spec.ts
@@ -1,0 +1,356 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import {
+  AccountId,
+  BlockNodeApi,
+  BlockNodeServiceEndpoint,
+  GeneralServiceEndpoint,
+  KeyList,
+  MirrorNodeServiceEndpoint,
+  PrivateKey,
+  RegisteredNodeCreateTransaction,
+  RegisteredNodeDeleteTransaction,
+  RegisteredNodeUpdateTransaction,
+  RpcRelayServiceEndpoint,
+  Timestamp,
+  Transaction,
+  TransactionId,
+} from '@hiero-ledger/sdk';
+import Long from 'long';
+
+import RegisteredNodeDetails from '@renderer/components/Transaction/Details/RegisteredNodeDetails.vue';
+
+// Key reused across tests
+const adminPrivKey = PrivateKey.generateED25519();
+const adminPubKey = adminPrivKey.publicKey;
+
+const payerAccount = new AccountId(0, 0, 2);
+const validStart = Timestamp.fromDate(new Date('2026-01-01T00:00:00Z'));
+const txId = () => TransactionId.withValidStart(payerAccount, validStart);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const roundTripCreate = (
+  configure: (tx: RegisteredNodeCreateTransaction) => RegisteredNodeCreateTransaction,
+): RegisteredNodeCreateTransaction => {
+  const frozen = configure(
+    new RegisteredNodeCreateTransaction().setTransactionId(txId()),
+  ).freeze();
+  const parsed = Transaction.fromBytes(frozen.toBytes());
+  if (!(parsed instanceof RegisteredNodeCreateTransaction)) {
+    throw new Error('round-trip did not produce a RegisteredNodeCreateTransaction');
+  }
+  return parsed;
+};
+
+const roundTripUpdate = (
+  configure: (tx: RegisteredNodeUpdateTransaction) => RegisteredNodeUpdateTransaction,
+): RegisteredNodeUpdateTransaction => {
+  const frozen = configure(
+    new RegisteredNodeUpdateTransaction()
+      .setRegisteredNodeId(Long.fromNumber(42))
+      .setTransactionId(txId()),
+  ).freeze();
+  const parsed = Transaction.fromBytes(frozen.toBytes());
+  if (!(parsed instanceof RegisteredNodeUpdateTransaction)) {
+    throw new Error('round-trip did not produce a RegisteredNodeUpdateTransaction');
+  }
+  return parsed;
+};
+
+const roundTripDelete = (
+  configure: (tx: RegisteredNodeDeleteTransaction) => RegisteredNodeDeleteTransaction,
+): RegisteredNodeDeleteTransaction => {
+  const frozen = configure(
+    new RegisteredNodeDeleteTransaction()
+      .setRegisteredNodeId(Long.fromNumber(7))
+      .setTransactionId(txId()),
+  ).freeze();
+  const parsed = Transaction.fromBytes(frozen.toBytes());
+  if (!(parsed instanceof RegisteredNodeDeleteTransaction)) {
+    throw new Error('round-trip did not produce a RegisteredNodeDeleteTransaction');
+  }
+  return parsed;
+};
+
+const mountDetails = (transaction: Transaction) =>
+  mount(RegisteredNodeDetails, {
+    props: { transaction, organizationTransaction: null },
+    global: { stubs: { KeyStructureModal: true } },
+  });
+
+/** Find the container div whose h4 matches `label`. */
+const findSection = (wrapper: ReturnType<typeof mountDetails>, label: string) =>
+  wrapper.findAll('h4').find(h => h.text() === label)?.element.parentElement ?? null;
+
+/** Return all <tr> elements inside the service-endpoints table body. */
+const endpointRows = (wrapper: ReturnType<typeof mountDetails>) =>
+  wrapper.findAll('tbody tr');
+
+/** Return the text of each <td> in a given row. */
+const rowCells = (row: ReturnType<typeof endpointRows>[number]) =>
+  row.findAll('td').map(td => td.text().trim());
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RegisteredNodeDetails.vue', () => {
+  // -------------------------------------------------------------------------
+  describe('RegisteredNodeCreateTransaction', () => {
+    it('does not show a Registered Node ID section', () => {
+      const tx = roundTripCreate(t => t);
+      const wrapper = mountDetails(tx);
+      expect(findSection(wrapper, 'Registered Node ID')).toBeNull();
+      expect(wrapper.find('[data-testid="p-node-details-node-id"]').exists()).toBe(false);
+    });
+
+    // -----------------------------------------------------------------------
+    describe('description', () => {
+      it('shows the description when one is set', () => {
+        const tx = roundTripCreate(t => t.setDescription('My test node'));
+        const wrapper = mountDetails(tx);
+        const el = wrapper.find('[data-testid="p-registered-node-details-description"]');
+        expect(el.exists()).toBe(true);
+        expect(el.text()).toBe('My test node');
+      });
+
+      it('hides the description section when none is set', () => {
+        const tx = roundTripCreate(t => t);
+        const wrapper = mountDetails(tx);
+        expect(findSection(wrapper, 'Description')).toBeNull();
+        expect(
+          wrapper.find('[data-testid="p-registered-node-details-description"]').exists(),
+        ).toBe(false);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    describe('admin key', () => {
+      it('hides the admin key section when no key is set', () => {
+        const tx = roundTripCreate(t => t);
+        const wrapper = mountDetails(tx);
+        expect(findSection(wrapper, 'Admin Key')).toBeNull();
+        expect(
+          wrapper.find('[data-testid="p-registered-node-details-admin-key"]').exists(),
+        ).toBe(false);
+      });
+
+      it('shows the raw public key value for a PublicKey admin key', () => {
+        const tx = roundTripCreate(t => t.setAdminKey(adminPubKey));
+        const wrapper = mountDetails(tx);
+        const el = wrapper.find('[data-testid="p-registered-node-details-admin-key"]');
+        expect(el.exists()).toBe(true);
+        // toStringRaw() returns the hex-encoded public key bytes
+        expect(el.text()).toContain(adminPubKey.toStringRaw());
+        expect(el.text()).not.toContain('None');
+        expect(el.text()).not.toContain('See details');
+      });
+
+      it('shows "See details" for a KeyList admin key', () => {
+        const keyList = new KeyList([adminPubKey]);
+        const tx = roundTripCreate(t => t.setAdminKey(keyList));
+        const wrapper = mountDetails(tx);
+        const el = wrapper.find('[data-testid="p-registered-node-details-admin-key"]');
+        expect(el.exists()).toBe(true);
+        expect(el.text()).toContain('See details');
+        expect(el.text()).not.toContain('None');
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    describe('service endpoints', () => {
+      it('hides the service endpoints section when the list is empty', () => {
+        const tx = roundTripCreate(t => t);
+        const wrapper = mountDetails(tx);
+        expect(findSection(wrapper, 'Service Endpoints')).toBeNull();
+        expect(endpointRows(wrapper)).toHaveLength(0);
+      });
+
+      it('renders the correct type labels for all four endpoint types', () => {
+        const tx = roundTripCreate(t =>
+          t.setServiceEndpoints([
+            new BlockNodeServiceEndpoint().setIpAddress(new Uint8Array([1, 1, 1, 1])).setPort(50211).setRequiresTls(false),
+            new MirrorNodeServiceEndpoint().setIpAddress(new Uint8Array([1, 1, 1, 2])).setPort(5600).setRequiresTls(false),
+            new RpcRelayServiceEndpoint().setIpAddress(new Uint8Array([1, 1, 1, 3])).setPort(7546).setRequiresTls(false),
+            new GeneralServiceEndpoint().setIpAddress(new Uint8Array([1, 1, 1, 4])).setPort(443).setRequiresTls(true),
+          ]),
+        );
+        const wrapper = mountDetails(tx);
+        const rows = endpointRows(wrapper);
+        expect(rows).toHaveLength(4);
+        expect(rowCells(rows[0])[0]).toBe('Block Node');
+        expect(rowCells(rows[1])[0]).toBe('Mirror Node');
+        expect(rowCells(rows[2])[0]).toBe('RPC Relay');
+        expect(rowCells(rows[3])[0]).toBe('General Service');
+      });
+
+      it('renders IPv4 bytes as a dot-separated address (regression: not comma-separated)', () => {
+        const tx = roundTripCreate(t =>
+          t.setServiceEndpoints([
+            new BlockNodeServiceEndpoint()
+              .setIpAddress(new Uint8Array([192, 168, 1, 100]))
+              .setPort(50211)
+              .setRequiresTls(false),
+          ]),
+        );
+        const wrapper = mountDetails(tx);
+        const cells = wrapper.findAll('td');
+        const ipCell = cells.find(td => /^\d+\.\d+\.\d+\.\d+$/.test(td.text().trim()));
+        expect(ipCell).toBeDefined();
+        expect(ipCell!.text().trim()).toBe('192.168.1.100');
+        expect(ipCell!.text()).not.toContain(',');
+      });
+
+      it('renders the domain name when no IP address is set', () => {
+        const tx = roundTripCreate(t =>
+          t.setServiceEndpoints([
+            new GeneralServiceEndpoint()
+              .setDomainName('node.example.com')
+              .setPort(443)
+              .setRequiresTls(true),
+          ]),
+        );
+        const wrapper = mountDetails(tx);
+        expect(rowCells(endpointRows(wrapper)[0])[1]).toBe('node.example.com');
+      });
+
+      it('renders the port number', () => {
+        const tx = roundTripCreate(t =>
+          t.setServiceEndpoints([
+            new MirrorNodeServiceEndpoint()
+              .setIpAddress(new Uint8Array([10, 0, 0, 1]))
+              .setPort(5600)
+              .setRequiresTls(false),
+          ]),
+        );
+        const wrapper = mountDetails(tx);
+        expect(rowCells(endpointRows(wrapper)[0])[2]).toBe('5600');
+      });
+
+      it('renders TLS as "Yes" when requiresTls is true', () => {
+        const tx = roundTripCreate(t =>
+          t.setServiceEndpoints([
+            new RpcRelayServiceEndpoint()
+              .setIpAddress(new Uint8Array([10, 0, 0, 2]))
+              .setPort(443)
+              .setRequiresTls(true),
+          ]),
+        );
+        const wrapper = mountDetails(tx);
+        expect(rowCells(endpointRows(wrapper)[0])[3]).toBe('Yes');
+      });
+
+      it('renders TLS as "No" when requiresTls is false', () => {
+        const tx = roundTripCreate(t =>
+          t.setServiceEndpoints([
+            new MirrorNodeServiceEndpoint()
+              .setIpAddress(new Uint8Array([10, 0, 0, 3]))
+              .setPort(5600)
+              .setRequiresTls(false),
+          ]),
+        );
+        const wrapper = mountDetails(tx);
+        expect(rowCells(endpointRows(wrapper)[0])[3]).toBe('No');
+      });
+
+      it('renders BlockNodeServiceEndpoint API labels in the last column', () => {
+        const tx = roundTripCreate(t =>
+          t.setServiceEndpoints([
+            new BlockNodeServiceEndpoint()
+              .setIpAddress(new Uint8Array([10, 0, 0, 4]))
+              .setPort(50211)
+              .setRequiresTls(false)
+              .setEndpointApis([BlockNodeApi.Status, BlockNodeApi.SubscribeStream]),
+          ]),
+        );
+        const wrapper = mountDetails(tx);
+        const apisCell = rowCells(endpointRows(wrapper)[0])[4];
+        expect(apisCell).toContain('Status');
+        expect(apisCell).toContain('Sub. Stream');
+      });
+
+      it('renders GeneralServiceEndpoint description in the last column', () => {
+        const tx = roundTripCreate(t =>
+          t.setServiceEndpoints([
+            new GeneralServiceEndpoint()
+              .setDomainName('gw.example.com')
+              .setPort(443)
+              .setRequiresTls(true)
+              .setDescription('Public gateway'),
+          ]),
+        );
+        const wrapper = mountDetails(tx);
+        expect(rowCells(endpointRows(wrapper)[0])[4]).toBe('Public gateway');
+      });
+
+      it('leaves the last column empty for MirrorNode and RpcRelay endpoints', () => {
+        const tx = roundTripCreate(t =>
+          t.setServiceEndpoints([
+            new MirrorNodeServiceEndpoint().setIpAddress(new Uint8Array([1, 2, 3, 4])).setPort(443).setRequiresTls(false),
+            new RpcRelayServiceEndpoint().setIpAddress(new Uint8Array([1, 2, 3, 5])).setPort(7546).setRequiresTls(false),
+          ]),
+        );
+        const wrapper = mountDetails(tx);
+        const rows = endpointRows(wrapper);
+        expect(rowCells(rows[0])[4]).toBe('');
+        expect(rowCells(rows[1])[4]).toBe('');
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('RegisteredNodeUpdateTransaction', () => {
+    it('shows the Registered Node ID', () => {
+      const tx = roundTripUpdate(t => t);
+      const wrapper = mountDetails(tx);
+      const el = wrapper.find('[data-testid="p-node-details-node-id"]');
+      expect(el.exists()).toBe(true);
+      expect(el.text()).toBe('42');
+    });
+
+    it('shows description when set', () => {
+      const tx = roundTripUpdate(t => t.setDescription('Updated description'));
+      const wrapper = mountDetails(tx);
+      const el = wrapper.find('[data-testid="p-registered-node-details-description"]');
+      expect(el.exists()).toBe(true);
+      expect(el.text()).toBe('Updated description');
+    });
+
+    it('shows service endpoints when set', () => {
+      const tx = roundTripUpdate(t =>
+        t.setServiceEndpoints([
+          new GeneralServiceEndpoint()
+            .setIpAddress(new Uint8Array([10, 0, 0, 5]))
+            .setPort(8080)
+            .setRequiresTls(false),
+        ]),
+      );
+      const wrapper = mountDetails(tx);
+      expect(endpointRows(wrapper)).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('RegisteredNodeDeleteTransaction', () => {
+    it('shows the Registered Node ID', () => {
+      const tx = roundTripDelete(t => t);
+      const wrapper = mountDetails(tx);
+      const el = wrapper.find('[data-testid="p-node-details-node-id"]');
+      expect(el.exists()).toBe(true);
+      expect(el.text()).toBe('7');
+    });
+
+    it('does not show description, admin key, or service endpoints sections', () => {
+      const tx = roundTripDelete(t => t);
+      const wrapper = mountDetails(tx);
+      expect(findSection(wrapper, 'Description')).toBeNull();
+      expect(findSection(wrapper, 'Admin Key')).toBeNull();
+      expect(findSection(wrapper, 'Service Endpoints')).toBeNull();
+    });
+  });
+});

--- a/front-end/src/tests/renderer/utils/sdk/getData.spec.ts
+++ b/front-end/src/tests/renderer/utils/sdk/getData.spec.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+import { describe, test, expect } from 'vitest';
+
+import { stringifyIpAddressBytes } from '@renderer/utils/sdk/getData';
+
+describe('stringifyIpAddressBytes', () => {
+  test('returns empty string for null', () => {
+    expect(stringifyIpAddressBytes(null)).toBe('');
+  });
+
+  test('returns empty string for undefined', () => {
+    expect(stringifyIpAddressBytes(undefined)).toBe('');
+  });
+
+  test('returns empty string for unrecognized byte length', () => {
+    expect(stringifyIpAddressBytes(new Uint8Array([1, 2, 3]))).toBe('');
+    expect(stringifyIpAddressBytes(new Uint8Array([1, 2, 3, 4, 5]))).toBe('');
+  });
+
+  describe('IPv4 (4 bytes)', () => {
+    test('formats a standard IPv4 address', () => {
+      expect(stringifyIpAddressBytes(new Uint8Array([192, 168, 1, 1]))).toBe('192.168.1.1');
+    });
+
+    test('formats all-zero IPv4 address', () => {
+      expect(stringifyIpAddressBytes(new Uint8Array([0, 0, 0, 0]))).toBe('0.0.0.0');
+    });
+
+    test('formats all-max IPv4 address', () => {
+      expect(stringifyIpAddressBytes(new Uint8Array([255, 255, 255, 255]))).toBe(
+        '255.255.255.255',
+      );
+    });
+  });
+
+  describe('IPv6 (16 bytes) — RFC 5952 canonical form', () => {
+    test('formats a full IPv6 address without any groups of only zeros', () => {
+      // 2001:0db8:85a3:0001:0001:8a2e:0370:7334
+      const bytes = new Uint8Array([
+        0x20, 0x01, 0x0d, 0xb8, 0x85, 0xa3, 0x00, 0x01, 0x00, 0x01, 0x8a, 0x2e, 0x03, 0x70, 0x73,
+        0x34,
+      ]);
+      expect(stringifyIpAddressBytes(bytes)).toBe('2001:db8:85a3:1:1:8a2e:370:7334');
+    });
+
+    test('compresses the longest run of consecutive groups of only zeros with ::', () => {
+      // RFC 5952 §4 example: 2001:db8:0:0:0:ff00:42:8329 → 2001:db8::ff00:42:8329
+      const bytes = new Uint8Array([
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x00, 0x00, 0x42, 0x83,
+        0x29,
+      ]);
+      expect(stringifyIpAddressBytes(bytes)).toBe('2001:db8::ff00:42:8329');
+    });
+
+    test('compresses loopback address ::1', () => {
+      const bytes = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+      expect(stringifyIpAddressBytes(bytes)).toBe('::1');
+    });
+
+    test('compresses all-zero address ::', () => {
+      const bytes = new Uint8Array(16);
+      expect(stringifyIpAddressBytes(bytes)).toBe('::');
+    });
+
+    test('does not compress a single group of only zeros', () => {
+      // fe80:0:1:2:3:4:5:6 — the single zero group must not be replaced by ::
+      const bytes = new Uint8Array([
+        0xfe, 0x80, 0x00, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x04, 0x00, 0x05, 0x00,
+        0x06,
+      ]);
+      expect(stringifyIpAddressBytes(bytes)).toBe('fe80:0:1:2:3:4:5:6');
+    });
+
+    test('chooses the first run when two runs have equal length', () => {
+      // 2001:db8:0:0:1:0:0:1 — two runs of two zeros; first wins → 2001:db8::1:0:0:1
+      const bytes = new Uint8Array([
+        0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x01,
+      ]);
+      expect(stringifyIpAddressBytes(bytes)).toBe('2001:db8::1:0:0:1');
+    });
+
+    test('omits leading zeros in each group', () => {
+      // 0001:0002:0003:0004:0005:0006:0007:0008 → 1:2:3:4:5:6:7:8
+      const bytes = new Uint8Array([
+        0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07,
+        0x00, 0x08,
+      ]);
+      expect(stringifyIpAddressBytes(bytes)).toBe('1:2:3:4:5:6:7:8');
+    });
+  });
+});


### PR DESCRIPTION
**Description**:

Fixes: #3014 

When displaying the details of a `RegisteredNodeCreate` or `RegisteredNodeUpdate` transaction, the `RegisteredNodeDetails` view needs to treat `endpoint.ipAddress` as `Uint8Array` and not as a `string` in order to display `1.2.3.4 `instead of `1,2,3,4.`

Add some unit tests for RegisteredNodeDetails.vue