### PR TITLE
feat: enhance release automation by adding draft check

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -382,7 +382,7 @@ jobs:
           retention-days: 5
 
   # ----------------------------
-  # Close the milestone, publish the GitHub release, and attach macOS artifacts.
+  # Close the milestone, attach macOS artifacts, and publish the GitHub release.
   # ----------------------------
   github_release:
     name: Publish GitHub Release
@@ -487,6 +487,28 @@ jobs:
             --draft=false \
             --prerelease \
             --repo ${{ github.repository }}
+
+
+  # ----------------------------
+  # Create or update the release tracking issue. Runs in parallel with
+  # create_snapshot_pr so a flaky GitHub API call cannot block the snapshot PR.
+  # ----------------------------
+  create_tracking_issue:
+    name: Create or Update Release Tracking Issue
+    runs-on: transaction-tools-linux-medium
+    needs: [prepare, cut_release, github_release]
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.prepare.outputs.release_branch }}
+          token: ${{ secrets.HEDERA_BOT_TOKEN }}
 
       - name: Create or Update Release Tracking Issue
         env:

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -412,6 +412,7 @@ jobs:
 
       - name: Close the Milestone
         if: ${{ needs.prepare.outputs.prerelease == '' }}
+        continue-on-error: true
         uses: step-security/close-milestone@d6e3b63e31f1f869bd3d0403f8cdc1a68f59ab4a # v2.2.2
         with:
           milestone_name: v${{ needs.prepare.outputs.release }}
@@ -436,12 +437,6 @@ jobs:
           echo "$RELEASE_BODY" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      - name: Download macOS Artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: macos-artifacts-${{ needs.prepare.outputs.version }}
-          path: macos-artifacts
-
       - name: Create GitHub Release
         uses: step-security/release-action@a0d8e0f90f554c15366ca2c9046bf4090d24adbe # v1.21.0
         with:
@@ -454,7 +449,29 @@ jobs:
           tag: ${{ env.RELEASE_TAG }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check Release Is Draft
+        id: release_state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IS_DRAFT=$(gh release view "$RELEASE_TAG" \
+            --repo ${{ github.repository }} \
+            --json isDraft \
+            --jq '.isDraft')
+          echo "is_draft=$IS_DRAFT" >> $GITHUB_OUTPUT
+          if [[ "$IS_DRAFT" != "true" ]]; then
+            echo "Release is already published — skipping artifact upload"
+          fi
+
+      - name: Download macOS Artifacts
+        if: ${{ steps.release_state.outputs.is_draft == 'true' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: macos-artifacts-${{ needs.prepare.outputs.version }}
+          path: macos-artifacts
+
       - name: Upload macOS Artifacts to Release
+        if: ${{ steps.release_state.outputs.is_draft == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
**Description**:
Rerun of failed release job fails if the job already created and published a release. This PR changes the job to check if the release has been published before attempting to add/remove artifacts to the release.