### PR TITLE
feat: add signing report endpoint with controller and service

### DIFF
--- a/back-end/apps/api/src/api.module.ts
+++ b/back-end/apps/api/src/api.module.ts
@@ -26,6 +26,7 @@ import { UserKeysModule } from './user-keys/user-keys.module';
 import { UsersModule } from './users/users.module';
 import { NotificationPreferencesModule } from './notification-preferences/notification-preferences.module';
 import { NotificationReceiverModule } from './notification-receiver/notification-receiver.module';
+import { ReportsModule } from './reports/reports.module';
 
 export const config = ConfigModule.forRoot({
   envFilePath: getEnvFilePaths(),
@@ -64,6 +65,7 @@ export const config = ConfigModule.forRoot({
     NatsModule.forRoot(),
     NotificationPreferencesModule,
     NotificationReceiverModule,
+    ReportsModule,
     HealthModule,
     IpThrottlerModule,
     EmailThrottlerModule,

--- a/back-end/apps/api/src/decorators/index.ts
+++ b/back-end/apps/api/src/decorators/index.ts
@@ -1,3 +1,4 @@
 export * from './get-user.decorator';
 export * from './ignore-controller-guard.decorator';
 export * from './allow-non-verified-user.decorator';
+export * from './to-boolean.decorator';

--- a/back-end/apps/api/src/decorators/to-boolean.decorator.ts
+++ b/back-end/apps/api/src/decorators/to-boolean.decorator.ts
@@ -10,8 +10,12 @@ import { Transform } from 'class-transformer';
  * 400 rather than silently treating them as true. Omitted stays undefined.
  */
 export const ToBoolean = (): PropertyDecorator =>
-  Transform(({ value }) => {
-    if (value === true || value === 'true') return true;
-    if (value === false || value === 'false') return false;
-    return value;
-  });
+  Transform(
+    ({ value }) => {
+      if (value === true || value === 'true') return true;
+      if (value === false || value === 'false') return false;
+      return value;
+    },
+    // Inbound coercion only — don't alter values when serializing back to plain.
+    { toClassOnly: true },
+  );

--- a/back-end/apps/api/src/decorators/to-boolean.decorator.ts
+++ b/back-end/apps/api/src/decorators/to-boolean.decorator.ts
@@ -1,0 +1,17 @@
+import { Transform } from 'class-transformer';
+
+/**
+ * Coerces a query/string value into a real boolean for validation.
+ *
+ * Query parameters always arrive as strings, so `@IsBoolean()` alone would
+ * reject them and `@Type(() => Boolean)` is unsafe (`Boolean('false') === true`).
+ * This only maps the recognized tokens and leaves anything else untouched, so a
+ * following `@IsBoolean()` rejects unexpected values (e.g. '0', 'no', '') with a
+ * 400 rather than silently treating them as true. Omitted stays undefined.
+ */
+export const ToBoolean = (): PropertyDecorator =>
+  Transform(({ value }) => {
+    if (value === true || value === 'true') return true;
+    if (value === false || value === 'false') return false;
+    return value;
+  });

--- a/back-end/apps/api/src/reports/dto/signing-report.dto.spec.ts
+++ b/back-end/apps/api/src/reports/dto/signing-report.dto.spec.ts
@@ -1,0 +1,65 @@
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+
+import { SigningReportQueryDto, SigningReportType } from './signing-report.dto';
+
+function toDto(plain: Record<string, unknown>): SigningReportQueryDto {
+  return plainToInstance(SigningReportQueryDto, plain);
+}
+
+describe('SigningReportQueryDto', () => {
+  const base = { type: SigningReportType.ACCOUNT, id: '0.0.100', mirrorNetwork: 'testnet' };
+
+  describe('completedOnly coercion', () => {
+    it.each([
+      ['true', true],
+      [true, true],
+      ['false', false],
+      [false, false],
+    ])('coerces %p to %p', (input, expected) => {
+      const dto = toDto({ ...base, completedOnly: input });
+      expect(dto.completedOnly).toBe(expected);
+      expect(validateSync(dto)).toHaveLength(0);
+    });
+
+    it('defaults to true when omitted', () => {
+      const dto = toDto({ ...base });
+      expect(dto.completedOnly).toBe(true);
+    });
+
+    it.each(['0', 'no', 'off', ''])('rejects the non-boolean token %p', token => {
+      const dto = toDto({ ...base, completedOnly: token });
+      const errors = validateSync(dto);
+      expect(errors.some(e => e.property === 'completedOnly')).toBe(true);
+    });
+  });
+
+  describe('date coercion', () => {
+    it('parses startDate and endDate strings into Date instances', () => {
+      const dto = toDto({ ...base, startDate: '2026-06-01T00:00:00.000Z', endDate: '2026-06-02' });
+      expect(dto.startDate).toBeInstanceOf(Date);
+      expect(dto.endDate).toBeInstanceOf(Date);
+      expect(dto.startDate?.toISOString()).toBe('2026-06-01T00:00:00.000Z');
+      expect(validateSync(dto)).toHaveLength(0);
+    });
+
+    it('rejects an invalid date', () => {
+      const dto = toDto({ ...base, startDate: 'not-a-date' });
+      expect(validateSync(dto).some(e => e.property === 'startDate')).toBe(true);
+    });
+  });
+
+  describe('required fields', () => {
+    it('rejects a missing/empty id', () => {
+      expect(validateSync(toDto({ type: SigningReportType.ACCOUNT })).some(e => e.property === 'id')).toBe(
+        true,
+      );
+    });
+
+    it('rejects an invalid type', () => {
+      expect(
+        validateSync(toDto({ ...base, type: 'bogus' })).some(e => e.property === 'type'),
+      ).toBe(true);
+    });
+  });
+});

--- a/back-end/apps/api/src/reports/dto/signing-report.dto.spec.ts
+++ b/back-end/apps/api/src/reports/dto/signing-report.dto.spec.ts
@@ -1,4 +1,4 @@
-import { plainToInstance } from 'class-transformer';
+import { instanceToPlain, plainToInstance } from 'class-transformer';
 import { validateSync } from 'class-validator';
 
 import { SigningReportQueryDto, SigningReportType } from './signing-report.dto';
@@ -31,6 +31,13 @@ describe('SigningReportQueryDto', () => {
       const dto = toDto({ ...base, completedOnly: token });
       const errors = validateSync(dto);
       expect(errors.some(e => e.property === 'completedOnly')).toBe(true);
+    });
+
+    it('does not re-coerce on serialization back to plain (toClassOnly)', () => {
+      const dto = toDto({ ...base });
+      // A value the inbound transform would coerce; outbound must leave it as-is.
+      (dto as unknown as { completedOnly: unknown }).completedOnly = 'false';
+      expect(instanceToPlain(dto).completedOnly).toBe('false');
     });
   });
 

--- a/back-end/apps/api/src/reports/dto/signing-report.dto.ts
+++ b/back-end/apps/api/src/reports/dto/signing-report.dto.ts
@@ -21,6 +21,11 @@ export enum SigningEntityType {
   NODE = 'NODE',
 }
 
+export enum SigningReportFormat {
+  CSV = 'csv',
+  JSON = 'json',
+}
+
 export class SigningReportQueryDto {
   @ApiProperty({ enum: SigningReportType })
   @IsEnum(SigningReportType)
@@ -70,11 +75,21 @@ export class SigningReportQueryDto {
   @IsBoolean()
   @IsOptional()
   completedOnly?: boolean = true;
+
+  @ApiProperty({
+    enum: SigningReportFormat,
+    required: false,
+    default: SigningReportFormat.CSV,
+    description: 'Response format. Defaults to CSV; pass json for the structured JSON array.',
+  })
+  @IsEnum(SigningReportFormat)
+  @IsOptional()
+  format?: SigningReportFormat = SigningReportFormat.CSV;
 }
 
 export class SigningReportItemDto {
-  @ApiProperty()
-  transactionId: number;
+  @ApiProperty({ description: 'The Hedera transaction ID (e.g. 0.0.1001@1700000000.000000000)' })
+  transactionId: string;
 
   @ApiProperty()
   createdAt: string;

--- a/back-end/apps/api/src/reports/dto/signing-report.dto.ts
+++ b/back-end/apps/api/src/reports/dto/signing-report.dto.ts
@@ -117,6 +117,12 @@ export class SigningReportItemDto {
   @ApiProperty({ nullable: true, description: 'Null when no UserKey matches the public key' })
   userEmail: string | null;
 
+  @ApiProperty({
+    nullable: true,
+    description: 'When the key signed the transaction (from the signer record); null if not signed',
+  })
+  signedAt: string | null;
+
   @ApiProperty({ enum: SigningStatus })
   signingStatus: SigningStatus;
 }

--- a/back-end/apps/api/src/reports/dto/signing-report.dto.ts
+++ b/back-end/apps/api/src/reports/dto/signing-report.dto.ts
@@ -1,0 +1,107 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsBoolean, IsDate, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+import { ToBoolean } from '../../decorators';
+
+export enum SigningReportType {
+  ACCOUNT = 'account',
+  TRANSACTION = 'transaction',
+  GROUP = 'group',
+  USER = 'user',
+}
+
+export enum SigningStatus {
+  SIGNED = 'SIGNED',
+  NOT_SIGNED = 'NOT_SIGNED',
+}
+
+export enum SigningEntityType {
+  ACCOUNT = 'ACCOUNT',
+  NODE = 'NODE',
+}
+
+export class SigningReportQueryDto {
+  @ApiProperty({ enum: SigningReportType })
+  @IsEnum(SigningReportType)
+  type: SigningReportType;
+
+  @ApiProperty({
+    description:
+      'Hedera account ID (e.g. 0.0.55) for the account type; numeric entity ID for all other types',
+  })
+  @IsString()
+  @IsNotEmpty()
+  id: string;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Mirror network the report is scoped to (e.g. testnet, mainnet). Required for the account ' +
+      'and user types, whose identifiers are network-relative. Ignored for the transaction and ' +
+      'group types, which are looked up by (globally unique) database id.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  mirrorNetwork?: string;
+
+  @ApiProperty({ required: false, description: 'Required for the account and user types' })
+  @Type(() => Date)
+  @IsDate()
+  @IsOptional()
+  startDate?: Date;
+
+  @ApiProperty({ required: false, description: 'Defaults to today when omitted' })
+  @Type(() => Date)
+  @IsDate()
+  @IsOptional()
+  endDate?: Date;
+
+  @ApiProperty({
+    required: false,
+    default: true,
+    description:
+      'When true (default) only completed (terminal) transactions are reported, using their ' +
+      'historical key snapshots. When false, all transactions are included — transactions that ' +
+      'are not yet complete have their keys read from the live account/node cache.',
+  })
+  @ToBoolean()
+  @IsBoolean()
+  @IsOptional()
+  completedOnly?: boolean = true;
+}
+
+export class SigningReportItemDto {
+  @ApiProperty()
+  transactionId: number;
+
+  @ApiProperty()
+  createdAt: string;
+
+  @ApiProperty()
+  validStart: string;
+
+  @ApiProperty({ nullable: true })
+  executedAt: string | null;
+
+  @ApiProperty({ enum: SigningEntityType, description: 'Whether the key belongs to an account or a node' })
+  entityType: SigningEntityType;
+
+  @ApiProperty({ description: 'The account ID (e.g. 0.0.55) or node ID the key belongs to' })
+  entityId: string;
+
+  @ApiProperty({
+    description: 'A public key from the account/node key active when the transaction ran',
+  })
+  publicKey: string;
+
+  @ApiProperty({ nullable: true, description: 'Null when no UserKey matches the public key' })
+  userId: number | null;
+
+  @ApiProperty({ nullable: true, description: 'Null when no UserKey matches the public key' })
+  userEmail: string | null;
+
+  @ApiProperty({ enum: SigningStatus })
+  signingStatus: SigningStatus;
+}

--- a/back-end/apps/api/src/reports/reports.module.ts
+++ b/back-end/apps/api/src/reports/reports.module.ts
@@ -1,0 +1,41 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import {
+  Transaction,
+  TransactionAccountSnapshot,
+  TransactionCachedAccount,
+  TransactionCachedNode,
+  TransactionGroup,
+  TransactionGroupItem,
+  TransactionNodeSnapshot,
+  TransactionSigner,
+  UserKey,
+} from '@entities';
+
+import { SigningReportController } from './signing-report.controller';
+import { SigningReportService } from './signing-report.service';
+
+@Module({
+  imports: [
+    // Only the entities whose repositories SigningReportService injects. The
+    // related entities loaded via relations (AccountSnapshot, NodeSnapshot,
+    // CachedAccount/Key, CachedNode/AdminKey) are registered on the default
+    // connection by TransactionSnapshotModule and TransactionsModule, so they
+    // don't need to be listed here.
+    TypeOrmModule.forFeature([
+      Transaction,
+      TransactionAccountSnapshot,
+      TransactionCachedAccount,
+      TransactionCachedNode,
+      TransactionGroup,
+      TransactionGroupItem,
+      TransactionNodeSnapshot,
+      TransactionSigner,
+      UserKey,
+    ]),
+  ],
+  controllers: [SigningReportController],
+  providers: [SigningReportService],
+})
+export class ReportsModule {}

--- a/back-end/apps/api/src/reports/signing-report.controller.spec.ts
+++ b/back-end/apps/api/src/reports/signing-report.controller.spec.ts
@@ -52,6 +52,7 @@ describe('SigningReportController', () => {
       publicKey: 'pk_alice',
       userId: 7,
       userEmail: 'alice@example.com',
+      signedAt: '2026-01-01T00:00:03.000Z',
       signingStatus: SigningStatus.SIGNED,
     },
   ];

--- a/back-end/apps/api/src/reports/signing-report.controller.spec.ts
+++ b/back-end/apps/api/src/reports/signing-report.controller.spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { mockDeep } from 'jest-mock-extended';
+
+import { guardMock } from '@app/common';
+
+import { AdminGuard, JwtAuthGuard, JwtBlackListAuthGuard, VerifiedUserGuard } from '../guards';
+
+import { SigningReportController } from './signing-report.controller';
+import { SigningReportService } from './signing-report.service';
+import {
+  SigningEntityType,
+  SigningReportQueryDto,
+  SigningReportType,
+  SigningStatus,
+} from './dto/signing-report.dto';
+
+describe('SigningReportController', () => {
+  let controller: SigningReportController;
+
+  const service = mockDeep<SigningReportService>();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SigningReportController],
+      providers: [{ provide: SigningReportService, useValue: service }],
+    })
+      .overrideGuard(JwtBlackListAuthGuard)
+      .useValue(guardMock())
+      .overrideGuard(JwtAuthGuard)
+      .useValue(guardMock())
+      .overrideGuard(VerifiedUserGuard)
+      .useValue(guardMock())
+      .overrideGuard(AdminGuard)
+      .useValue(guardMock())
+      .compile();
+
+    controller = module.get(SigningReportController);
+    jest.resetAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('delegates to the service and returns the result', async () => {
+    const query: SigningReportQueryDto = {
+      type: SigningReportType.TRANSACTION,
+      id: '42',
+      mirrorNetwork: 'testnet',
+    };
+    const expected = [
+      {
+        transactionId: 42,
+        createdAt: '2025-12-31T00:00:00.000Z',
+        validStart: '2026-01-01T00:00:00.000Z',
+        executedAt: '2026-01-01T00:00:01.000Z',
+        entityType: SigningEntityType.ACCOUNT,
+        entityId: '0.0.55',
+        publicKey: 'pk_alice',
+        userId: 7,
+        userEmail: 'alice@example.com',
+        signingStatus: SigningStatus.SIGNED,
+      },
+    ];
+
+    service.getSigningReport.mockResolvedValue(expected);
+
+    const result = await controller.getSigningReport(query);
+
+    expect(service.getSigningReport).toHaveBeenCalledWith(query);
+    expect(result).toBe(expected);
+  });
+});

--- a/back-end/apps/api/src/reports/signing-report.controller.spec.ts
+++ b/back-end/apps/api/src/reports/signing-report.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Response } from 'express';
 import { mockDeep } from 'jest-mock-extended';
 
 import { guardMock } from '@app/common';
@@ -9,6 +10,8 @@ import { SigningReportController } from './signing-report.controller';
 import { SigningReportService } from './signing-report.service';
 import {
   SigningEntityType,
+  SigningReportFormat,
+  SigningReportItemDto,
   SigningReportQueryDto,
   SigningReportType,
   SigningStatus,
@@ -38,36 +41,62 @@ describe('SigningReportController', () => {
     jest.resetAllMocks();
   });
 
+  const rows: SigningReportItemDto[] = [
+    {
+      transactionId: '0.0.1001@1700000000.000000000',
+      createdAt: '2025-12-31T00:00:00.000Z',
+      validStart: '2026-01-01T00:00:00.000Z',
+      executedAt: '2026-01-01T00:00:01.000Z',
+      entityType: SigningEntityType.ACCOUNT,
+      entityId: '0.0.55',
+      publicKey: 'pk_alice',
+      userId: 7,
+      userEmail: 'alice@example.com',
+      signingStatus: SigningStatus.SIGNED,
+    },
+  ];
+
+  const query: SigningReportQueryDto = {
+    type: SigningReportType.TRANSACTION,
+    id: '42',
+    mirrorNetwork: 'testnet',
+  };
+
+  function mockRes() {
+    return { header: jest.fn() } as unknown as Response;
+  }
+
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
 
-  it('delegates to the service and returns the result', async () => {
-    const query: SigningReportQueryDto = {
-      type: SigningReportType.TRANSACTION,
-      id: '42',
-      mirrorNetwork: 'testnet',
-    };
-    const expected = [
-      {
-        transactionId: 42,
-        createdAt: '2025-12-31T00:00:00.000Z',
-        validStart: '2026-01-01T00:00:00.000Z',
-        executedAt: '2026-01-01T00:00:01.000Z',
-        entityType: SigningEntityType.ACCOUNT,
-        entityId: '0.0.55',
-        publicKey: 'pk_alice',
-        userId: 7,
-        userEmail: 'alice@example.com',
-        signingStatus: SigningStatus.SIGNED,
-      },
-    ];
+  it('returns CSV by default and sets the CSV headers', async () => {
+    service.getSigningReport.mockResolvedValue(rows);
+    const res = mockRes();
 
-    service.getSigningReport.mockResolvedValue(expected);
-
-    const result = await controller.getSigningReport(query);
+    const result = await controller.getSigningReport(query, res);
 
     expect(service.getSigningReport).toHaveBeenCalledWith(query);
-    expect(result).toBe(expected);
+    expect(res.header).toHaveBeenCalledWith('Content-Type', 'text/csv; charset=utf-8');
+    expect(res.header).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename="signing-report.csv"',
+    );
+    expect(typeof result).toBe('string');
+    expect(result as string).toContain('transactionId,createdAt');
+    expect(result as string).toContain('0.0.1001@1700000000.000000000');
+  });
+
+  it('returns the JSON array when format=json', async () => {
+    service.getSigningReport.mockResolvedValue(rows);
+    const res = mockRes();
+
+    const result = await controller.getSigningReport(
+      { ...query, format: SigningReportFormat.JSON },
+      res,
+    );
+
+    expect(result).toBe(rows);
+    expect(res.header).not.toHaveBeenCalled();
   });
 });

--- a/back-end/apps/api/src/reports/signing-report.controller.ts
+++ b/back-end/apps/api/src/reports/signing-report.controller.ts
@@ -1,9 +1,15 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Query, Res, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiProduces, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
 
 import { AdminGuard, JwtAuthGuard, JwtBlackListAuthGuard, VerifiedUserGuard } from '../guards';
 
-import { SigningReportItemDto, SigningReportQueryDto } from './dto/signing-report.dto';
+import {
+  SigningReportFormat,
+  SigningReportItemDto,
+  SigningReportQueryDto,
+} from './dto/signing-report.dto';
+import { toCsv } from './signing-report.csv';
 import { SigningReportService } from './signing-report.service';
 
 @ApiTags('Reports')
@@ -16,11 +22,24 @@ export class SigningReportController {
     summary: 'Get signing activity report',
     description:
       'Returns the per-account key signing activity for a given account, transaction, group, ' +
-      'or user, filtered by date range. Admin only.',
+      'or user, filtered by date range. Admin only. Returns CSV by default; pass format=json ' +
+      'for the structured JSON array.',
   })
+  @ApiProduces('text/csv', 'application/json')
   @ApiResponse({ status: 200, type: [SigningReportItemDto] })
   @Get()
-  getSigningReport(@Query() query: SigningReportQueryDto): Promise<SigningReportItemDto[]> {
-    return this.service.getSigningReport(query);
+  async getSigningReport(
+    @Query() query: SigningReportQueryDto,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<SigningReportItemDto[] | string> {
+    const rows = await this.service.getSigningReport(query);
+
+    if (query.format === SigningReportFormat.JSON) {
+      return rows;
+    }
+
+    res.header('Content-Type', 'text/csv; charset=utf-8');
+    res.header('Content-Disposition', 'attachment; filename="signing-report.csv"');
+    return toCsv(rows);
   }
 }

--- a/back-end/apps/api/src/reports/signing-report.controller.ts
+++ b/back-end/apps/api/src/reports/signing-report.controller.ts
@@ -1,5 +1,12 @@
 import { Controller, Get, Query, Res, UseGuards } from '@nestjs/common';
-import { ApiOperation, ApiProduces, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiExtraModels,
+  ApiOperation,
+  ApiProduces,
+  ApiResponse,
+  ApiTags,
+  getSchemaPath,
+} from '@nestjs/swagger';
 import { Response } from 'express';
 
 import { AdminGuard, JwtAuthGuard, JwtBlackListAuthGuard, VerifiedUserGuard } from '../guards';
@@ -25,8 +32,24 @@ export class SigningReportController {
       'or user, filtered by date range. Admin only. Returns CSV by default; pass format=json ' +
       'for the structured JSON array.',
   })
+  @ApiExtraModels(SigningReportItemDto)
   @ApiProduces('text/csv', 'application/json')
-  @ApiResponse({ status: 200, type: [SigningReportItemDto] })
+  @ApiResponse({
+    status: 200,
+    description: 'Signing activity rows — CSV by default (text/csv), or a JSON array when format=json.',
+    content: {
+      'text/csv': {
+        schema: {
+          type: 'string',
+          example:
+            'transactionId,createdAt,validStart,executedAt,entityType,entityId,publicKey,userId,userEmail,signingStatus',
+        },
+      },
+      'application/json': {
+        schema: { type: 'array', items: { $ref: getSchemaPath(SigningReportItemDto) } },
+      },
+    },
+  })
   @Get()
   async getSigningReport(
     @Query() query: SigningReportQueryDto,

--- a/back-end/apps/api/src/reports/signing-report.controller.ts
+++ b/back-end/apps/api/src/reports/signing-report.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { AdminGuard, JwtAuthGuard, JwtBlackListAuthGuard, VerifiedUserGuard } from '../guards';
+
+import { SigningReportItemDto, SigningReportQueryDto } from './dto/signing-report.dto';
+import { SigningReportService } from './signing-report.service';
+
+@ApiTags('Reports')
+@Controller('reports/signing')
+@UseGuards(JwtBlackListAuthGuard, JwtAuthGuard, VerifiedUserGuard, AdminGuard)
+export class SigningReportController {
+  constructor(private readonly service: SigningReportService) {}
+
+  @ApiOperation({
+    summary: 'Get signing activity report',
+    description:
+      'Returns the per-account key signing activity for a given account, transaction, group, ' +
+      'or user, filtered by date range. Admin only.',
+  })
+  @ApiResponse({ status: 200, type: [SigningReportItemDto] })
+  @Get()
+  getSigningReport(@Query() query: SigningReportQueryDto): Promise<SigningReportItemDto[]> {
+    return this.service.getSigningReport(query);
+  }
+}

--- a/back-end/apps/api/src/reports/signing-report.csv.spec.ts
+++ b/back-end/apps/api/src/reports/signing-report.csv.spec.ts
@@ -46,4 +46,17 @@ describe('toCsv', () => {
     const dataLine = csv.trimEnd().split('\r\n')[1];
     expect(dataLine).toContain('"a,b""c\nd"');
   });
+
+  it.each(['=1+2', '+1', '-1', '@cmd', '\tx'])(
+    'prefixes formula-injection values (%p) with a single quote',
+    value => {
+      const dataLine = toCsv([row({ userEmail: value })]).trimEnd().split('\r\n')[1];
+      expect(dataLine).toContain(`,'${value},`);
+    },
+  );
+
+  it('quotes a formula value that also contains a comma', () => {
+    const dataLine = toCsv([row({ userEmail: '=a,b' })]).trimEnd().split('\r\n')[1];
+    expect(dataLine).toContain(`,"'=a,b",`);
+  });
 });

--- a/back-end/apps/api/src/reports/signing-report.csv.spec.ts
+++ b/back-end/apps/api/src/reports/signing-report.csv.spec.ts
@@ -1,0 +1,49 @@
+import { SigningEntityType, SigningReportItemDto, SigningStatus } from './dto/signing-report.dto';
+import { toCsv } from './signing-report.csv';
+
+function row(overrides: Partial<SigningReportItemDto> = {}): SigningReportItemDto {
+  return {
+    transactionId: '0.0.1001@1700000000.000000000',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    validStart: '2026-01-01T00:00:01.000Z',
+    executedAt: '2026-01-01T00:00:02.000Z',
+    entityType: SigningEntityType.ACCOUNT,
+    entityId: '0.0.100',
+    publicKey: 'pk_alice',
+    userId: 7,
+    userEmail: 'alice@example.com',
+    signingStatus: SigningStatus.SIGNED,
+    ...overrides,
+  };
+}
+
+describe('toCsv', () => {
+  it('emits a header row even with no data', () => {
+    expect(toCsv([])).toBe(
+      'transactionId,createdAt,validStart,executedAt,entityType,entityId,publicKey,userId,userEmail,signingStatus\r\n',
+    );
+  });
+
+  it('writes one CRLF-terminated line per row in column order', () => {
+    const csv = toCsv([row()]);
+    const lines = csv.trimEnd().split('\r\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toBe(
+      '0.0.1001@1700000000.000000000,2026-01-01T00:00:00.000Z,2026-01-01T00:00:01.000Z,2026-01-01T00:00:02.000Z,ACCOUNT,0.0.100,pk_alice,7,alice@example.com,SIGNED',
+    );
+  });
+
+  it('renders null/absent user fields as empty', () => {
+    const csv = toCsv([row({ executedAt: null, userId: null, userEmail: null })]);
+    const line = csv.trimEnd().split('\r\n')[1];
+    expect(line).toContain(',ACCOUNT,'); // executedAt blank before entityType
+    expect(line.endsWith(',,,SIGNED')).toBe(true); // userId, userEmail blank
+  });
+
+  it('escapes commas, quotes, and newlines per RFC 4180', () => {
+    // Embedded LF doesn't collide with the CRLF row terminator, so a plain split works.
+    const csv = toCsv([row({ userEmail: 'a,b"c\nd' })]);
+    const dataLine = csv.trimEnd().split('\r\n')[1];
+    expect(dataLine).toContain('"a,b""c\nd"');
+  });
+});

--- a/back-end/apps/api/src/reports/signing-report.csv.spec.ts
+++ b/back-end/apps/api/src/reports/signing-report.csv.spec.ts
@@ -12,6 +12,7 @@ function row(overrides: Partial<SigningReportItemDto> = {}): SigningReportItemDt
     publicKey: 'pk_alice',
     userId: 7,
     userEmail: 'alice@example.com',
+    signedAt: '2026-01-01T00:00:03.000Z',
     signingStatus: SigningStatus.SIGNED,
     ...overrides,
   };
@@ -20,7 +21,7 @@ function row(overrides: Partial<SigningReportItemDto> = {}): SigningReportItemDt
 describe('toCsv', () => {
   it('emits a header row even with no data', () => {
     expect(toCsv([])).toBe(
-      'transactionId,createdAt,validStart,executedAt,entityType,entityId,publicKey,userId,userEmail,signingStatus\r\n',
+      'transactionId,createdAt,validStart,executedAt,entityType,entityId,publicKey,userId,userEmail,signedAt,signingStatus\r\n',
     );
   });
 
@@ -29,15 +30,15 @@ describe('toCsv', () => {
     const lines = csv.trimEnd().split('\r\n');
     expect(lines).toHaveLength(2);
     expect(lines[1]).toBe(
-      '0.0.1001@1700000000.000000000,2026-01-01T00:00:00.000Z,2026-01-01T00:00:01.000Z,2026-01-01T00:00:02.000Z,ACCOUNT,0.0.100,pk_alice,7,alice@example.com,SIGNED',
+      '0.0.1001@1700000000.000000000,2026-01-01T00:00:00.000Z,2026-01-01T00:00:01.000Z,2026-01-01T00:00:02.000Z,ACCOUNT,0.0.100,pk_alice,7,alice@example.com,2026-01-01T00:00:03.000Z,SIGNED',
     );
   });
 
-  it('renders null/absent user fields as empty', () => {
-    const csv = toCsv([row({ executedAt: null, userId: null, userEmail: null })]);
+  it('renders null/absent fields as empty', () => {
+    const csv = toCsv([row({ executedAt: null, userId: null, userEmail: null, signedAt: null })]);
     const line = csv.trimEnd().split('\r\n')[1];
     expect(line).toContain(',ACCOUNT,'); // executedAt blank before entityType
-    expect(line.endsWith(',,,SIGNED')).toBe(true); // userId, userEmail blank
+    expect(line.endsWith(',,,,SIGNED')).toBe(true); // userId, userEmail, signedAt blank
   });
 
   it('escapes commas, quotes, and newlines per RFC 4180', () => {

--- a/back-end/apps/api/src/reports/signing-report.csv.ts
+++ b/back-end/apps/api/src/reports/signing-report.csv.ts
@@ -1,0 +1,30 @@
+import { SigningReportItemDto } from './dto/signing-report.dto';
+
+// Column order for the CSV rendering — mirrors SigningReportItemDto.
+const COLUMNS: (keyof SigningReportItemDto)[] = [
+  'transactionId',
+  'createdAt',
+  'validStart',
+  'executedAt',
+  'entityType',
+  'entityId',
+  'publicKey',
+  'userId',
+  'userEmail',
+  'signingStatus',
+];
+
+// RFC 4180: quote fields containing a comma, quote, or newline; double embedded
+// quotes. null/undefined render as empty.
+function escape(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  return /[",\r\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+}
+
+/** Renders the report rows as a CSV document (header row + one line per entry). */
+export function toCsv(rows: SigningReportItemDto[]): string {
+  const header = COLUMNS.join(',');
+  const lines = rows.map(row => COLUMNS.map(column => escape(row[column])).join(','));
+  return [header, ...lines].join('\r\n') + '\r\n';
+}

--- a/back-end/apps/api/src/reports/signing-report.csv.ts
+++ b/back-end/apps/api/src/reports/signing-report.csv.ts
@@ -14,11 +14,16 @@ const COLUMNS: (keyof SigningReportItemDto)[] = [
   'signingStatus',
 ];
 
-// RFC 4180: quote fields containing a comma, quote, or newline; double embedded
-// quotes. null/undefined render as empty.
+// Serializes a single cell:
+// 1. Neutralizes spreadsheet formula injection — a cell starting with =, +, -,
+//    @, tab, or CR can be executed as a formula by Excel/Sheets, so prefix it
+//    with a single quote to force text. Fields like userEmail are user-supplied.
+// 2. RFC 4180: quote fields containing a comma, quote, or newline; double
+//    embedded quotes. null/undefined render as empty.
 function escape(value: unknown): string {
   if (value === null || value === undefined) return '';
-  const str = String(value);
+  let str = String(value);
+  if (/^[=+\-@\t\r]/.test(str)) str = `'${str}`;
   return /[",\r\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
 }
 

--- a/back-end/apps/api/src/reports/signing-report.csv.ts
+++ b/back-end/apps/api/src/reports/signing-report.csv.ts
@@ -11,6 +11,7 @@ const COLUMNS: (keyof SigningReportItemDto)[] = [
   'publicKey',
   'userId',
   'userEmail',
+  'signedAt',
   'signingStatus',
 ];
 

--- a/back-end/apps/api/src/reports/signing-report.service.spec.ts
+++ b/back-end/apps/api/src/reports/signing-report.service.spec.ts
@@ -119,8 +119,10 @@ function makeTx(
   } as Transaction;
 }
 
+const SIGNED_AT = new Date('2026-06-01T00:00:05.000Z');
+
 function makeSigner(transactionId: number, userKeyId: number): TransactionSigner {
-  return { transactionId, userKeyId } as TransactionSigner;
+  return { transactionId, userKeyId, createdAt: SIGNED_AT } as TransactionSigner;
 }
 
 // QueryBuilder mock where every chain method returns `this`.
@@ -226,6 +228,7 @@ describe('SigningReportService', () => {
           publicKey: PK_ALICE,
           userId: 7,
           userEmail: 'alice@example.com',
+          signedAt: SIGNED_AT.toISOString(),
           signingStatus: SigningStatus.SIGNED,
         },
         {
@@ -238,6 +241,7 @@ describe('SigningReportService', () => {
           publicKey: PK_BOB,
           userId: 8,
           userEmail: 'bob@example.com',
+          signedAt: null,
           signingStatus: SigningStatus.NOT_SIGNED,
         },
       ]);

--- a/back-end/apps/api/src/reports/signing-report.service.spec.ts
+++ b/back-end/apps/api/src/reports/signing-report.service.spec.ts
@@ -107,6 +107,7 @@ function makeTx(
 ): Transaction {
   return {
     id,
+    transactionId: `0.0.1001@${id}`,
     createdAt: CREATED_AT,
     validStart: VALID_START,
     executedAt: opts.executedAt === null ? undefined : (opts.executedAt ?? EXECUTED_AT),
@@ -216,7 +217,7 @@ describe('SigningReportService', () => {
 
       expect(result).toEqual([
         {
-          transactionId: 1,
+          transactionId: '0.0.1001@1',
           createdAt: CREATED_AT.toISOString(),
           validStart: VALID_START.toISOString(),
           executedAt: EXECUTED_AT.toISOString(),
@@ -228,7 +229,7 @@ describe('SigningReportService', () => {
           signingStatus: SigningStatus.SIGNED,
         },
         {
-          transactionId: 1,
+          transactionId: '0.0.1001@1',
           createdAt: CREATED_AT.toISOString(),
           validStart: VALID_START.toISOString(),
           executedAt: EXECUTED_AT.toISOString(),
@@ -335,7 +336,7 @@ describe('SigningReportService', () => {
 
       const result = await service.getSigningReport({ type: SigningReportType.GROUP, id: '5' });
 
-      expect(result.map(r => r.transactionId)).toEqual([1, 2]);
+      expect(result.map(r => r.transactionId)).toEqual(['0.0.1001@1', '0.0.1001@2']);
       expect(result.map(r => r.publicKey)).toEqual([PK_ALICE, PK_NODE]);
       expect(result.map(r => r.entityType)).toEqual([
         SigningEntityType.ACCOUNT,
@@ -514,7 +515,7 @@ describe('SigningReportService', () => {
       });
 
       // tx 2 reports only the queried account, not the unrelated 0.0.999.
-      expect(result.map(r => r.transactionId)).toEqual([1, 2]);
+      expect(result.map(r => r.transactionId)).toEqual(['0.0.1001@1', '0.0.1001@2']);
       expect(result.every(r => r.entityId === '0.0.100')).toBe(true);
       expect(transactionRepo.find).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -654,11 +655,11 @@ describe('SigningReportService', () => {
 
       expect(result.map(r => [r.transactionId, r.entityType, r.publicKey])).toEqual([
         // tx 1 first (earlier validStart): ACCOUNT keys sorted, then NODE
-        [1, SigningEntityType.ACCOUNT, PK_ALICE],
-        [1, SigningEntityType.ACCOUNT, PK_BOB],
-        [1, SigningEntityType.NODE, PK_NODE],
+        ['0.0.1001@1', SigningEntityType.ACCOUNT, PK_ALICE],
+        ['0.0.1001@1', SigningEntityType.ACCOUNT, PK_BOB],
+        ['0.0.1001@1', SigningEntityType.NODE, PK_NODE],
         // tx 2 last (later validStart)
-        [2, SigningEntityType.ACCOUNT, PK_ALICE],
+        ['0.0.1001@2', SigningEntityType.ACCOUNT, PK_ALICE],
       ]);
     });
   });

--- a/back-end/apps/api/src/reports/signing-report.service.spec.ts
+++ b/back-end/apps/api/src/reports/signing-report.service.spec.ts
@@ -129,6 +129,7 @@ function makeQb<T>(): ReturnType<typeof mockDeep<SelectQueryBuilder<T>>> {
     'where',
     'andWhere',
     'orderBy',
+    'addOrderBy',
     'limit',
     'innerJoin',
     'leftJoinAndSelect',
@@ -297,11 +298,14 @@ describe('SigningReportService', () => {
       ).rejects.toBeInstanceOf(NotFoundException);
     });
 
-    it('rejects a non-numeric id', async () => {
-      await expect(
-        service.getSigningReport({ type: SigningReportType.TRANSACTION, id: 'abc' }),
-      ).rejects.toBeInstanceOf(BadRequestException);
-    });
+    it.each(['abc', '1.5', '123abc', '0', '-1', ''])(
+      'rejects a non-positive-integer id (%p)',
+      async id => {
+        await expect(
+          service.getSigningReport({ type: SigningReportType.TRANSACTION, id }),
+        ).rejects.toBeInstanceOf(BadRequestException);
+      },
+    );
 
     it('skips receiver accounts that do not require a signature', async () => {
       const tx = makeTx(1, { accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE]), true)] });
@@ -492,7 +496,10 @@ describe('SigningReportService', () => {
         makeTx(1, { accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE]))] }),
         makeTx(2, {
           executedAt: null,
-          cachedAccounts: [makeTca(makeCachedAccount('0.0.100', [PK_BOB]))],
+          cachedAccounts: [
+            makeTca(makeCachedAccount('0.0.100', [PK_BOB])),
+            makeTca(makeCachedAccount('0.0.999', [PK_ALICE])), // other account, filtered out
+          ],
         }),
       ]);
       wireSigners([]);
@@ -506,7 +513,9 @@ describe('SigningReportService', () => {
         completedOnly: false,
       });
 
+      // tx 2 reports only the queried account, not the unrelated 0.0.999.
       expect(result.map(r => r.transactionId)).toEqual([1, 2]);
+      expect(result.every(r => r.entityId === '0.0.100')).toBe(true);
       expect(transactionRepo.find).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({ mirrorNetwork: MIRROR_NETWORK }),
@@ -567,6 +576,44 @@ describe('SigningReportService', () => {
     });
   });
 
+  describe('key owner resolution', () => {
+    it('keeps the first match per public key when duplicate UserKey rows exist', async () => {
+      const tx = makeTx(1, { accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE]))] });
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([makeSigner(1, 9)]); // signed with the kept (active) row's id
+
+      // The query orders non-deleted first, latest id first; the loop keeps the
+      // first match, so the active row (id 9) wins over the deleted one (id 5).
+      wireOwners([
+        makeUserKey(9, 7, PK_ALICE, makeUser(7, 'alice@example.com')),
+        {
+          id: 5,
+          userId: 7,
+          publicKey: PK_ALICE,
+          deletedAt: new Date(),
+          user: makeUser(7, 'old@example.com'),
+        } as UserKey,
+      ]);
+
+      const result = await service.getSigningReport({ type: SigningReportType.TRANSACTION, id: '1' });
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          publicKey: PK_ALICE,
+          userId: 7,
+          userEmail: 'alice@example.com',
+          signingStatus: SigningStatus.SIGNED,
+        }),
+      ]);
+    });
+  });
+
+  it('rejects an unknown report type', async () => {
+    await expect(
+      service.getSigningReport({ type: 'bogus' as SigningReportType, id: '1' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
   describe('date range', () => {
     it('rejects a startDate that is on or after the endDate', async () => {
       await expect(
@@ -578,6 +625,119 @@ describe('SigningReportService', () => {
           endDate: new Date('2026-06-01T00:00:00.000Z'),
         }),
       ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty for a group with no transactions', async () => {
+      transactionGroupRepo.findOne.mockResolvedValue({ id: 5 } as TransactionGroup);
+      transactionGroupItemRepo.find.mockResolvedValue([]);
+      wireSigners([]);
+
+      const result = await service.getSigningReport({ type: SigningReportType.GROUP, id: '5' });
+      expect(result).toEqual([]);
+    });
+
+    it('skips missing snapshot relations and treats null publicKeys as empty', async () => {
+      const tx = makeTx(1, {
+        accounts: [
+          makeTas(null as unknown as AccountSnapshot), // missing snapshot
+          makeTas(makeAccountSnapshot('0.0.100', null as unknown as string[])), // null publicKeys
+        ],
+        nodes: [
+          makeTns(null as unknown as NodeSnapshot), // missing node snapshot
+          makeTns(makeNodeSnapshot(3, null as unknown as string[])), // null node publicKeys
+        ],
+      });
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([]);
+      wireOwners();
+
+      const result = await service.getSigningReport({ type: SigningReportType.TRANSACTION, id: '1' });
+      expect(result).toEqual([]);
+    });
+
+    it('skips missing cached relations and treats null keys as empty', async () => {
+      const tx = makeTx(1, {
+        executedAt: null,
+        cachedAccounts: [
+          makeTca(null as unknown as CachedAccount), // missing cached account
+          makeTca({ account: '0.0.100' } as CachedAccount), // null keys
+        ],
+        cachedNodes: [
+          makeTcn(null as unknown as CachedNode), // missing cached node
+          makeTcn({ nodeId: 3 } as CachedNode), // null keys
+        ],
+      });
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([]);
+      wireOwners();
+
+      const result = await service.getSigningReport({
+        type: SigningReportType.TRANSACTION,
+        id: '1',
+        completedOnly: false,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it.each([
+      ['executed', EXECUTED_AT, { completedOnly: true }],
+      ['unexecuted', undefined, { completedOnly: false }],
+    ])('tolerates a %s transaction whose relations were not loaded', async (_label, executedAt, opts) => {
+      // Bare transaction (no relation arrays) exercises the `?? []` fallbacks on
+      // both the snapshot and cached collection paths.
+      const bare = {
+        id: 1,
+        createdAt: CREATED_AT,
+        validStart: VALID_START,
+        executedAt,
+        mirrorNetwork: MIRROR_NETWORK,
+      } as Transaction;
+      transactionRepo.find.mockResolvedValue([bare]);
+      wireSigners([]);
+      wireOwners();
+
+      const result = await service.getSigningReport({
+        type: SigningReportType.TRANSACTION,
+        id: '1',
+        ...opts,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('ignores a UserKey row with no associated user', async () => {
+      const tx = makeTx(1, { accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE]))] });
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([]);
+      wireOwners([makeUserKey(1, 7, PK_ALICE, undefined)]); // user relation not loaded/null
+
+      const result = await service.getSigningReport({ type: SigningReportType.TRANSACTION, id: '1' });
+      expect(result).toEqual([
+        expect.objectContaining({ publicKey: PK_ALICE, userId: null, userEmail: null }),
+      ]);
+    });
+
+    it('de-duplicates a public key repeated within one source', async () => {
+      const tx = makeTx(1, {
+        accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE, PK_ALICE]))],
+      });
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([]);
+      wireOwners();
+
+      const result = await service.getSigningReport({ type: SigningReportType.TRANSACTION, id: '1' });
+      expect(result.filter(r => r.publicKey === PK_ALICE)).toHaveLength(1);
+    });
+
+    it('groups multiple signers belonging to the same transaction', async () => {
+      const tx = makeTx(1, { accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE, PK_BOB]))] });
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([makeSigner(1, 1), makeSigner(1, 2)]); // two signers, same tx
+      wireOwners();
+
+      const result = await service.getSigningReport({ type: SigningReportType.TRANSACTION, id: '1' });
+      expect(result.every(r => r.signingStatus === SigningStatus.SIGNED)).toBe(true);
     });
   });
 });

--- a/back-end/apps/api/src/reports/signing-report.service.spec.ts
+++ b/back-end/apps/api/src/reports/signing-report.service.spec.ts
@@ -628,6 +628,41 @@ describe('SigningReportService', () => {
     });
   });
 
+  describe('output ordering', () => {
+    it('orders rows by validStart, then transaction, entity, and public key', async () => {
+      // Returned out of order; the report must sort deterministically.
+      const later = new Date('2026-06-02T00:00:00.000Z');
+      const txLater = {
+        ...makeTx(2, { accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE]))] }),
+        validStart: later,
+      } as Transaction;
+      const txEarly = makeTx(1, {
+        accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_BOB, PK_ALICE]))],
+        nodes: [makeTns(makeNodeSnapshot(3, [PK_NODE]))],
+      });
+
+      transactionGroupRepo.findOne.mockResolvedValue({ id: 5 } as TransactionGroup);
+      transactionGroupItemRepo.find.mockResolvedValue([
+        { transactionId: 2 } as TransactionGroupItem,
+        { transactionId: 1 } as TransactionGroupItem,
+      ]);
+      transactionRepo.find.mockResolvedValue([txLater, txEarly]);
+      wireSigners([]);
+      wireOwners();
+
+      const result = await service.getSigningReport({ type: SigningReportType.GROUP, id: '5' });
+
+      expect(result.map(r => [r.transactionId, r.entityType, r.publicKey])).toEqual([
+        // tx 1 first (earlier validStart): ACCOUNT keys sorted, then NODE
+        [1, SigningEntityType.ACCOUNT, PK_ALICE],
+        [1, SigningEntityType.ACCOUNT, PK_BOB],
+        [1, SigningEntityType.NODE, PK_NODE],
+        // tx 2 last (later validStart)
+        [2, SigningEntityType.ACCOUNT, PK_ALICE],
+      ]);
+    });
+  });
+
   describe('edge cases', () => {
     it('returns empty for a group with no transactions', async () => {
       transactionGroupRepo.findOne.mockResolvedValue({ id: 5 } as TransactionGroup);

--- a/back-end/apps/api/src/reports/signing-report.service.spec.ts
+++ b/back-end/apps/api/src/reports/signing-report.service.spec.ts
@@ -1,0 +1,583 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { mockDeep } from 'jest-mock-extended';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+
+import {
+  AccountSnapshot,
+  CachedAccount,
+  CachedAccountKey,
+  CachedNode,
+  CachedNodeAdminKey,
+  NodeSnapshot,
+  Transaction,
+  TransactionAccountSnapshot,
+  TransactionCachedAccount,
+  TransactionCachedNode,
+  TransactionGroup,
+  TransactionGroupItem,
+  TransactionNodeSnapshot,
+  TransactionSigner,
+  User,
+  UserKey,
+} from '@entities';
+
+import { SigningReportService } from './signing-report.service';
+import { SigningEntityType, SigningReportType, SigningStatus } from './dto/signing-report.dto';
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+const MIRROR_NETWORK = 'testnet';
+const CREATED_AT = new Date('2026-05-31T23:59:00.000Z');
+const VALID_START = new Date('2026-06-01T00:00:00.000Z');
+const EXECUTED_AT = new Date('2026-06-01T00:00:01.000Z');
+
+const PK_ALICE = 'pk_alice';
+const PK_BOB = 'pk_bob';
+const PK_NODE = 'pk_node';
+const PK_UNKNOWN = 'pk_unknown';
+
+function makeUser(id: number, email: string): User {
+  return { id, email } as User;
+}
+
+function makeUserKey(id: number, userId: number, pk: string, user?: User): UserKey {
+  return { id, userId, publicKey: pk, deletedAt: null, user } as UserKey;
+}
+
+function makeAccountSnapshot(
+  account: string,
+  publicKeys: string[],
+  receiverSignatureRequired = false,
+): AccountSnapshot {
+  return { account, mirrorNetwork: MIRROR_NETWORK, publicKeys, receiverSignatureRequired } as AccountSnapshot;
+}
+
+function makeNodeSnapshot(nodeId: number, publicKeys: string[]): NodeSnapshot {
+  return { nodeId, mirrorNetwork: MIRROR_NETWORK, publicKeys } as NodeSnapshot;
+}
+
+function makeTas(accountSnapshot: AccountSnapshot, isReceiver = false): TransactionAccountSnapshot {
+  return { accountSnapshot, isReceiver } as TransactionAccountSnapshot;
+}
+
+function makeTns(nodeSnapshot: NodeSnapshot): TransactionNodeSnapshot {
+  return { nodeSnapshot } as TransactionNodeSnapshot;
+}
+
+function makeCachedAccount(
+  account: string,
+  publicKeys: string[],
+  receiverSignatureRequired = false,
+): CachedAccount {
+  return {
+    account,
+    mirrorNetwork: MIRROR_NETWORK,
+    receiverSignatureRequired,
+    keys: publicKeys.map(publicKey => ({ publicKey }) as CachedAccountKey),
+  } as CachedAccount;
+}
+
+function makeCachedNode(nodeId: number, publicKeys: string[]): CachedNode {
+  return {
+    nodeId,
+    mirrorNetwork: MIRROR_NETWORK,
+    keys: publicKeys.map(publicKey => ({ publicKey }) as CachedNodeAdminKey),
+  } as CachedNode;
+}
+
+function makeTca(cachedAccount: CachedAccount, isReceiver = false): TransactionCachedAccount {
+  return { cachedAccount, isReceiver } as TransactionCachedAccount;
+}
+
+function makeTcn(cachedNode: CachedNode): TransactionCachedNode {
+  return { cachedNode } as TransactionCachedNode;
+}
+
+function makeTx(
+  id: number,
+  opts: {
+    accounts?: TransactionAccountSnapshot[];
+    nodes?: TransactionNodeSnapshot[];
+    cachedAccounts?: TransactionCachedAccount[];
+    cachedNodes?: TransactionCachedNode[];
+    executedAt?: Date | null;
+  } = {},
+): Transaction {
+  return {
+    id,
+    createdAt: CREATED_AT,
+    validStart: VALID_START,
+    executedAt: opts.executedAt === null ? undefined : (opts.executedAt ?? EXECUTED_AT),
+    mirrorNetwork: MIRROR_NETWORK,
+    transactionAccountSnapshots: opts.accounts ?? [],
+    transactionNodeSnapshots: opts.nodes ?? [],
+    transactionCachedAccounts: opts.cachedAccounts ?? [],
+    transactionCachedNodes: opts.cachedNodes ?? [],
+  } as Transaction;
+}
+
+function makeSigner(transactionId: number, userKeyId: number): TransactionSigner {
+  return { transactionId, userKeyId } as TransactionSigner;
+}
+
+// QueryBuilder mock where every chain method returns `this`.
+function makeQb<T>(): ReturnType<typeof mockDeep<SelectQueryBuilder<T>>> {
+  const qb = mockDeep<SelectQueryBuilder<T>>();
+  for (const m of [
+    'where',
+    'andWhere',
+    'orderBy',
+    'limit',
+    'innerJoin',
+    'leftJoinAndSelect',
+    'select',
+    'distinct',
+    'withDeleted',
+  ]) {
+    (qb as any)[m].mockReturnThis();
+  }
+  return qb;
+}
+
+// ─── suite ───────────────────────────────────────────────────────────────────
+
+describe('SigningReportService', () => {
+  let service: SigningReportService;
+
+  const transactionRepo = mockDeep<Repository<Transaction>>();
+  const txAccountSnapshotRepo = mockDeep<Repository<TransactionAccountSnapshot>>();
+  const txNodeSnapshotRepo = mockDeep<Repository<TransactionNodeSnapshot>>();
+  const txCachedAccountRepo = mockDeep<Repository<TransactionCachedAccount>>();
+  const txCachedNodeRepo = mockDeep<Repository<TransactionCachedNode>>();
+  const transactionGroupRepo = mockDeep<Repository<TransactionGroup>>();
+  const transactionGroupItemRepo = mockDeep<Repository<TransactionGroupItem>>();
+  const transactionSignerRepo = mockDeep<Repository<TransactionSigner>>();
+  const userKeyRepo = mockDeep<Repository<UserKey>>();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SigningReportService,
+        { provide: getRepositoryToken(Transaction), useValue: transactionRepo },
+        { provide: getRepositoryToken(TransactionAccountSnapshot), useValue: txAccountSnapshotRepo },
+        { provide: getRepositoryToken(TransactionNodeSnapshot), useValue: txNodeSnapshotRepo },
+        { provide: getRepositoryToken(TransactionCachedAccount), useValue: txCachedAccountRepo },
+        { provide: getRepositoryToken(TransactionCachedNode), useValue: txCachedNodeRepo },
+        { provide: getRepositoryToken(TransactionGroup), useValue: transactionGroupRepo },
+        { provide: getRepositoryToken(TransactionGroupItem), useValue: transactionGroupItemRepo },
+        { provide: getRepositoryToken(TransactionSigner), useValue: transactionSignerRepo },
+        { provide: getRepositoryToken(UserKey), useValue: userKeyRepo },
+      ],
+    }).compile();
+
+    service = module.get(SigningReportService);
+    jest.resetAllMocks();
+  });
+
+  // Default wiring: Alice/Bob/node-owner own their keys (unknown owns none).
+  function wireOwners(userKeys: UserKey[] = defaultUserKeys()) {
+    const qb = makeQb<UserKey>();
+    (qb as any).getMany.mockResolvedValue(userKeys);
+    userKeyRepo.createQueryBuilder.mockReturnValue(qb as any);
+  }
+
+  function defaultUserKeys(): UserKey[] {
+    return [
+      makeUserKey(1, 7, PK_ALICE, makeUser(7, 'alice@example.com')),
+      makeUserKey(2, 8, PK_BOB, makeUser(8, 'bob@example.com')),
+      makeUserKey(3, 9, PK_NODE, makeUser(9, 'node-admin@example.com')),
+    ];
+  }
+
+  function wireSigners(signers: TransactionSigner[]) {
+    transactionSignerRepo.find.mockResolvedValue(signers);
+  }
+
+  function wireRawTxIds(repo: { createQueryBuilder: any }, transactionIds: number[]) {
+    const qb = makeQb<TransactionAccountSnapshot>();
+    (qb as any).getRawMany.mockResolvedValue(transactionIds.map(transactionId => ({ transactionId })));
+    repo.createQueryBuilder.mockReturnValue(qb as any);
+  }
+
+  it('should be defined', () => expect(service).toBeDefined());
+
+  describe('type=transaction', () => {
+    it('flattens per-account keys with user info and signing status', async () => {
+      const tx = makeTx(1, { accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE, PK_BOB]))] });
+
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([makeSigner(1, 1)]); // Alice's userKey (id 1) signed
+      wireOwners();
+
+      const result = await service.getSigningReport({ type: SigningReportType.TRANSACTION, id: '1' });
+
+      expect(result).toEqual([
+        {
+          transactionId: 1,
+          createdAt: CREATED_AT.toISOString(),
+          validStart: VALID_START.toISOString(),
+          executedAt: EXECUTED_AT.toISOString(),
+          entityType: SigningEntityType.ACCOUNT,
+          entityId: '0.0.100',
+          publicKey: PK_ALICE,
+          userId: 7,
+          userEmail: 'alice@example.com',
+          signingStatus: SigningStatus.SIGNED,
+        },
+        {
+          transactionId: 1,
+          createdAt: CREATED_AT.toISOString(),
+          validStart: VALID_START.toISOString(),
+          executedAt: EXECUTED_AT.toISOString(),
+          entityType: SigningEntityType.ACCOUNT,
+          entityId: '0.0.100',
+          publicKey: PK_BOB,
+          userId: 8,
+          userEmail: 'bob@example.com',
+          signingStatus: SigningStatus.NOT_SIGNED,
+        },
+      ]);
+    });
+
+    it('includes node admin keys for the transaction', async () => {
+      const tx = makeTx(1, {
+        accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE]))],
+        nodes: [makeTns(makeNodeSnapshot(3, [PK_NODE]))],
+      });
+
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([makeSigner(1, 3)]); // node admin key signed
+      wireOwners();
+
+      const result = await service.getSigningReport({ type: SigningReportType.TRANSACTION, id: '1' });
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          entityType: SigningEntityType.ACCOUNT,
+          entityId: '0.0.100',
+          publicKey: PK_ALICE,
+          signingStatus: SigningStatus.NOT_SIGNED,
+        }),
+        expect.objectContaining({
+          entityType: SigningEntityType.NODE,
+          entityId: '3',
+          publicKey: PK_NODE,
+          userId: 9,
+          userEmail: 'node-admin@example.com',
+          signingStatus: SigningStatus.SIGNED,
+        }),
+      ]);
+    });
+
+    it('includes keys with no matching UserKey with null user fields', async () => {
+      const tx = makeTx(1, { accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_UNKNOWN]))] });
+
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([]);
+      wireOwners([]); // no UserKey records
+
+      const result = await service.getSigningReport({ type: SigningReportType.TRANSACTION, id: '1' });
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          publicKey: PK_UNKNOWN,
+          userId: null,
+          userEmail: null,
+          signingStatus: SigningStatus.NOT_SIGNED,
+        }),
+      ]);
+    });
+
+    it('throws when the transaction does not exist', async () => {
+      transactionRepo.find.mockResolvedValue([]);
+      await expect(
+        service.getSigningReport({ type: SigningReportType.TRANSACTION, id: '99' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('rejects a non-numeric id', async () => {
+      await expect(
+        service.getSigningReport({ type: SigningReportType.TRANSACTION, id: 'abc' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('skips receiver accounts that do not require a signature', async () => {
+      const tx = makeTx(1, { accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE]), true)] });
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([]);
+      wireOwners();
+
+      const result = await service.getSigningReport({ type: SigningReportType.TRANSACTION, id: '1' });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('type=group', () => {
+    it('reports across all transactions in the group', async () => {
+      transactionGroupRepo.findOne.mockResolvedValue({ id: 5 } as TransactionGroup);
+      transactionGroupItemRepo.find.mockResolvedValue([
+        { transactionId: 1 } as TransactionGroupItem,
+        { transactionId: 2 } as TransactionGroupItem,
+      ]);
+
+      transactionRepo.find.mockResolvedValue([
+        makeTx(1, { accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE]))] }),
+        makeTx(2, { nodes: [makeTns(makeNodeSnapshot(4, [PK_NODE]))] }),
+      ]);
+      wireSigners([]);
+      wireOwners();
+
+      const result = await service.getSigningReport({ type: SigningReportType.GROUP, id: '5' });
+
+      expect(result.map(r => r.transactionId)).toEqual([1, 2]);
+      expect(result.map(r => r.publicKey)).toEqual([PK_ALICE, PK_NODE]);
+      expect(result.map(r => r.entityType)).toEqual([
+        SigningEntityType.ACCOUNT,
+        SigningEntityType.NODE,
+      ]);
+    });
+
+    it('throws when the group does not exist', async () => {
+      transactionGroupRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.getSigningReport({ type: SigningReportType.GROUP, id: '5' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('type=account', () => {
+    it('selects transactions touching the account and only reports that account, no nodes', async () => {
+      wireRawTxIds(txAccountSnapshotRepo, [1]);
+
+      // Transaction touches two accounts and a node; only the queried account appears.
+      const tx = makeTx(1, {
+        accounts: [
+          makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE])),
+          makeTas(makeAccountSnapshot('0.0.999', [PK_BOB])),
+        ],
+        nodes: [makeTns(makeNodeSnapshot(3, [PK_NODE]))],
+      });
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([]);
+      wireOwners();
+
+      const result = await service.getSigningReport({
+        type: SigningReportType.ACCOUNT,
+        mirrorNetwork: MIRROR_NETWORK,
+        id: '0.0.100',
+        startDate: VALID_START,
+      });
+
+      expect(result.map(r => r.publicKey)).toEqual([PK_ALICE]);
+      expect(result.every(r => r.entityType === SigningEntityType.ACCOUNT)).toBe(true);
+    });
+
+    it('requires a startDate', async () => {
+      await expect(
+        service.getSigningReport({ mirrorNetwork: MIRROR_NETWORK, type: SigningReportType.ACCOUNT, id: '0.0.100' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('requires a mirrorNetwork', async () => {
+      await expect(
+        service.getSigningReport({ type: SigningReportType.ACCOUNT, id: '0.0.100', startDate: VALID_START }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('type=user', () => {
+    it('reports the user keys from both account and node snapshots', async () => {
+      userKeyRepo.find.mockResolvedValue([
+        makeUserKey(1, 7, PK_ALICE),
+        makeUserKey(3, 7, PK_NODE),
+      ]);
+
+      wireRawTxIds(txAccountSnapshotRepo, [1]);
+      wireRawTxIds(txNodeSnapshotRepo, [1]);
+
+      const tx = makeTx(1, {
+        accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE, PK_BOB]))],
+        nodes: [makeTns(makeNodeSnapshot(3, [PK_NODE]))],
+      });
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([makeSigner(1, 1)]);
+      wireOwners([
+        makeUserKey(1, 7, PK_ALICE, makeUser(7, 'alice@example.com')),
+        makeUserKey(2, 8, PK_BOB, makeUser(8, 'bob@example.com')),
+        makeUserKey(3, 7, PK_NODE, makeUser(7, 'alice@example.com')),
+      ]);
+
+      const result = await service.getSigningReport({
+        type: SigningReportType.USER,
+        mirrorNetwork: MIRROR_NETWORK,
+        id: '7',
+        startDate: VALID_START,
+      });
+
+      // Bob's key is excluded (different user); Alice's account + node keys remain.
+      expect(result.map(r => r.publicKey).sort()).toEqual([PK_ALICE, PK_NODE]);
+      expect(result.every(r => r.userId === 7)).toBe(true);
+    });
+
+    it('returns empty when the user has no keys', async () => {
+      userKeyRepo.find.mockResolvedValue([]);
+      const result = await service.getSigningReport({
+        type: SigningReportType.USER,
+        mirrorNetwork: MIRROR_NETWORK,
+        id: '7',
+        startDate: VALID_START,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('requires a mirrorNetwork', async () => {
+      await expect(
+        service.getSigningReport({ type: SigningReportType.USER, id: '7', startDate: VALID_START }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('requires a startDate', async () => {
+      await expect(
+        service.getSigningReport({ type: SigningReportType.USER, id: '7', mirrorNetwork: MIRROR_NETWORK }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('completedOnly', () => {
+    it('excludes not-yet-complete transactions by default', async () => {
+      const tx = makeTx(1, {
+        executedAt: null,
+        cachedAccounts: [makeTca(makeCachedAccount('0.0.100', [PK_ALICE]))],
+      });
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([]);
+      wireOwners();
+
+      const result = await service.getSigningReport({ type: SigningReportType.TRANSACTION, id: '1' });
+      expect(result).toEqual([]);
+    });
+
+    it('reads keys from the live cache for unexecuted transactions when requested', async () => {
+      const tx = makeTx(1, {
+        executedAt: null,
+        cachedAccounts: [makeTca(makeCachedAccount('0.0.100', [PK_ALICE]))],
+        cachedNodes: [makeTcn(makeCachedNode(3, [PK_NODE]))],
+      });
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([]);
+      wireOwners();
+
+      const result = await service.getSigningReport({
+        type: SigningReportType.TRANSACTION,
+        mirrorNetwork: MIRROR_NETWORK,
+        id: '1',
+        completedOnly: false,
+      });
+
+      expect(result.map(r => r.publicKey)).toEqual([PK_ALICE, PK_NODE]);
+      expect(result.map(r => r.entityType)).toEqual([
+        SigningEntityType.ACCOUNT,
+        SigningEntityType.NODE,
+      ]);
+      expect(result.every(r => r.executedAt === null)).toBe(true);
+    });
+
+    it('account report unions executed snapshots with pending cached accounts', async () => {
+      wireRawTxIds(txAccountSnapshotRepo, [1]); // executed match
+      wireRawTxIds(txCachedAccountRepo, [2]); // pending match
+
+      transactionRepo.find.mockResolvedValue([
+        makeTx(1, { accounts: [makeTas(makeAccountSnapshot('0.0.100', [PK_ALICE]))] }),
+        makeTx(2, {
+          executedAt: null,
+          cachedAccounts: [makeTca(makeCachedAccount('0.0.100', [PK_BOB]))],
+        }),
+      ]);
+      wireSigners([]);
+      wireOwners();
+
+      const result = await service.getSigningReport({
+        type: SigningReportType.ACCOUNT,
+        mirrorNetwork: MIRROR_NETWORK,
+        id: '0.0.100',
+        startDate: VALID_START,
+        completedOnly: false,
+      });
+
+      expect(result.map(r => r.transactionId)).toEqual([1, 2]);
+      expect(transactionRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ mirrorNetwork: MIRROR_NETWORK }),
+        }),
+      );
+    });
+
+    it('skips receiver accounts that do not require a signature on the cached path', async () => {
+      const tx = makeTx(1, {
+        executedAt: null,
+        cachedAccounts: [makeTca(makeCachedAccount('0.0.100', [PK_ALICE]), true)],
+      });
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([]);
+      wireOwners();
+
+      const result = await service.getSigningReport({
+        type: SigningReportType.TRANSACTION,
+        mirrorNetwork: MIRROR_NETWORK,
+        id: '1',
+        completedOnly: false,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('unions the user keys from pending account and node caches', async () => {
+      userKeyRepo.find.mockResolvedValue([makeUserKey(1, 7, PK_ALICE), makeUserKey(3, 7, PK_NODE)]);
+
+      // No executed matches; both pending cache selections match tx 1.
+      wireRawTxIds(txAccountSnapshotRepo, []);
+      wireRawTxIds(txNodeSnapshotRepo, []);
+      wireRawTxIds(txCachedAccountRepo, [1]);
+      wireRawTxIds(txCachedNodeRepo, [1]);
+
+      const tx = makeTx(1, {
+        executedAt: null,
+        cachedAccounts: [makeTca(makeCachedAccount('0.0.100', [PK_ALICE]))],
+        cachedNodes: [makeTcn(makeCachedNode(3, [PK_NODE]))],
+      });
+      transactionRepo.find.mockResolvedValue([tx]);
+      wireSigners([makeSigner(1, 3)]); // node key signed
+      wireOwners([
+        makeUserKey(1, 7, PK_ALICE, makeUser(7, 'alice@example.com')),
+        makeUserKey(3, 7, PK_NODE, makeUser(7, 'alice@example.com')),
+      ]);
+
+      const result = await service.getSigningReport({
+        type: SigningReportType.USER,
+        mirrorNetwork: MIRROR_NETWORK,
+        id: '7',
+        startDate: VALID_START,
+        completedOnly: false,
+      });
+
+      expect(result.map(r => r.publicKey).sort()).toEqual([PK_ALICE, PK_NODE]);
+      expect(result.find(r => r.publicKey === PK_NODE)?.signingStatus).toBe(SigningStatus.SIGNED);
+      expect(result.find(r => r.publicKey === PK_ALICE)?.signingStatus).toBe(SigningStatus.NOT_SIGNED);
+    });
+  });
+
+  describe('date range', () => {
+    it('rejects a startDate that is on or after the endDate', async () => {
+      await expect(
+        service.getSigningReport({
+          type: SigningReportType.ACCOUNT,
+          mirrorNetwork: MIRROR_NETWORK,
+          id: '0.0.100',
+          startDate: new Date('2026-06-10T00:00:00.000Z'),
+          endDate: new Date('2026-06-01T00:00:00.000Z'),
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+});

--- a/back-end/apps/api/src/reports/signing-report.service.ts
+++ b/back-end/apps/api/src/reports/signing-report.service.ts
@@ -458,6 +458,10 @@ export class SigningReportService {
    * and rejects uploads of a key owned by another user. If key sharing is added
    * later this would become a one-to-many lookup; that change lives here and in
    * the per-key emission loop in buildReport.
+   *
+   * publicKey has no unique DB constraint, so should duplicate rows ever exist
+   * the query orders deterministically (non-deleted first, then latest id) and
+   * we keep the first match per key rather than overwriting arbitrarily.
    */
   private async resolveKeyOwners(
     publicKeys: string[],
@@ -471,10 +475,13 @@ export class SigningReportService {
       .leftJoinAndSelect('uk.user', 'user')
       .where('uk.publicKey IN (:...publicKeys)', { publicKeys })
       .withDeleted()
+      .orderBy('uk.deletedAt', 'ASC', 'NULLS FIRST')
+      .addOrderBy('uk.id', 'DESC')
       .getMany();
 
     for (const userKey of userKeys) {
       if (!userKey.user) continue;
+      if (keyToOwner.has(userKey.publicKey)) continue;
       keyToOwner.set(userKey.publicKey, {
         userId: userKey.userId,
         userEmail: userKey.user.email,
@@ -486,8 +493,13 @@ export class SigningReportService {
   }
 
   private parseNumericId(id: string): number {
+    // Require the entire string to be digits so partially-numeric ids like
+    // '1.5' or '123abc' are rejected rather than silently truncated by parseInt.
+    if (!/^\d+$/.test(id)) {
+      throw new BadRequestException(`Invalid id: ${id}`);
+    }
     const parsed = Number.parseInt(id, 10);
-    if (!Number.isInteger(parsed) || parsed <= 0) {
+    if (parsed <= 0) {
       throw new BadRequestException(`Invalid id: ${id}`);
     }
     return parsed;

--- a/back-end/apps/api/src/reports/signing-report.service.ts
+++ b/back-end/apps/api/src/reports/signing-report.service.ts
@@ -1,0 +1,516 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, ObjectLiteral, Repository, SelectQueryBuilder } from 'typeorm';
+
+import {
+  Transaction,
+  TransactionAccountSnapshot,
+  TransactionCachedAccount,
+  TransactionCachedNode,
+  TransactionGroup,
+  TransactionGroupItem,
+  TransactionNodeSnapshot,
+  TransactionSigner,
+  UserKey,
+} from '@entities';
+
+import {
+  SigningEntityType,
+  SigningReportItemDto,
+  SigningReportQueryDto,
+  SigningReportType,
+  SigningStatus,
+} from './dto/signing-report.dto';
+
+// A flattened key source for a single transaction: either an account or a node,
+// along with the public keys that were active on it when the transaction ran.
+interface KeySource {
+  entityType: SigningEntityType;
+  entityId: string;
+  publicKeys: string[];
+}
+
+interface ReportOptions {
+  accountFilter?: string;
+  userFilter?: number;
+  includeUnexecuted: boolean;
+}
+
+// Snapshot key-overlap predicate, reused for the account and node snapshot
+// selection queries (the joined snapshot is always aliased `snap`).
+const SNAPSHOT_KEY_OVERLAP = 'snap."publicKeys" && ARRAY[:...publicKeys]::text[]';
+
+// A resolved, empty transaction-id selection — used to skip the pending-cache
+// queries when the report is limited to completed transactions.
+const noTransactionIds = (): Promise<number[]> => Promise.resolve([]);
+
+@Injectable()
+export class SigningReportService {
+  constructor(
+    @InjectRepository(Transaction)
+    private readonly transactionRepo: Repository<Transaction>,
+    @InjectRepository(TransactionAccountSnapshot)
+    private readonly txAccountSnapshotRepo: Repository<TransactionAccountSnapshot>,
+    @InjectRepository(TransactionNodeSnapshot)
+    private readonly txNodeSnapshotRepo: Repository<TransactionNodeSnapshot>,
+    @InjectRepository(TransactionCachedAccount)
+    private readonly txCachedAccountRepo: Repository<TransactionCachedAccount>,
+    @InjectRepository(TransactionCachedNode)
+    private readonly txCachedNodeRepo: Repository<TransactionCachedNode>,
+    @InjectRepository(TransactionGroup)
+    private readonly transactionGroupRepo: Repository<TransactionGroup>,
+    @InjectRepository(TransactionGroupItem)
+    private readonly transactionGroupItemRepo: Repository<TransactionGroupItem>,
+    @InjectRepository(TransactionSigner)
+    private readonly transactionSignerRepo: Repository<TransactionSigner>,
+    @InjectRepository(UserKey)
+    private readonly userKeyRepo: Repository<UserKey>,
+  ) {}
+
+  async getSigningReport(query: SigningReportQueryDto): Promise<SigningReportItemDto[]> {
+    // completedOnly defaults to true; when false we also report not-yet-complete
+    // transactions, reading their keys from the live account/node cache.
+    const includeUnexecuted = !(query.completedOnly ?? true);
+
+    switch (query.type) {
+      case SigningReportType.TRANSACTION:
+        return this.reportForTransaction(this.parseNumericId(query.id), includeUnexecuted);
+      case SigningReportType.GROUP:
+        return this.reportForGroup(this.parseNumericId(query.id), includeUnexecuted);
+      case SigningReportType.ACCOUNT:
+        return this.reportForAccount(
+          query.id,
+          query.mirrorNetwork,
+          query.startDate,
+          query.endDate,
+          includeUnexecuted,
+        );
+      case SigningReportType.USER:
+        return this.reportForUser(
+          this.parseNumericId(query.id),
+          query.mirrorNetwork,
+          query.startDate,
+          query.endDate,
+          includeUnexecuted,
+        );
+      default: {
+        // Exhaustive: if a new SigningReportType is added without a case here,
+        // this assignment fails to compile. At runtime it guards against an
+        // unexpected type slipping past validation.
+        const unhandled: never = query.type;
+        throw new BadRequestException(`Unsupported report type: ${unhandled}`);
+      }
+    }
+  }
+
+  // transaction and group are looked up by globally-unique database id, which
+  // already pins the network — so no mirrorNetwork scope is needed or accepted.
+  private async reportForTransaction(
+    id: number,
+    includeUnexecuted: boolean,
+  ): Promise<SigningReportItemDto[]> {
+    const transaction = await this.loadTransactions([id], includeUnexecuted);
+    if (transaction.length === 0) throw new NotFoundException(`Transaction ${id} not found`);
+    return this.buildReport(transaction, { includeUnexecuted });
+  }
+
+  private async reportForGroup(
+    groupId: number,
+    includeUnexecuted: boolean,
+  ): Promise<SigningReportItemDto[]> {
+    const group = await this.transactionGroupRepo.findOne({ where: { id: groupId } });
+    if (!group) throw new NotFoundException(`Group ${groupId} not found`);
+
+    const items = await this.transactionGroupItemRepo.find({ where: { groupId } });
+    const txIds = items.map(item => item.transactionId);
+
+    return this.buildReport(await this.loadTransactions(txIds, includeUnexecuted), {
+      includeUnexecuted,
+    });
+  }
+
+  private async reportForAccount(
+    accountId: string,
+    mirrorNetwork: string | undefined,
+    startDate: Date | undefined,
+    endDate: Date | undefined,
+    includeUnexecuted: boolean,
+  ): Promise<SigningReportItemDto[]> {
+    mirrorNetwork = this.requireMirrorNetwork(mirrorNetwork);
+    const range = this.parseDateRange(startDate, endDate);
+
+    // Executed transactions read their historical key from the account snapshot;
+    // not-yet-executed ones (only when requested) read the live account cache.
+    // The two selections are independent, so run them in parallel.
+    const [executedIds, pendingIds] = await Promise.all([
+      this.selectTransactionIds(
+        this.txAccountSnapshotRepo
+          .createQueryBuilder('tas')
+          .innerJoin('tas.accountSnapshot', 'snap', 'snap.account = :accountId', { accountId }),
+        true,
+        range,
+        mirrorNetwork,
+      ),
+      includeUnexecuted
+        ? this.selectTransactionIds(
+            this.txCachedAccountRepo
+              .createQueryBuilder('tca')
+              .innerJoin('tca.cachedAccount', 'ca', 'ca.account = :accountId', { accountId }),
+            false,
+            range,
+            mirrorNetwork,
+          )
+        : noTransactionIds(),
+    ]);
+
+    const txIds = new Set([...executedIds, ...pendingIds]);
+
+    const transactions = await this.loadTransactions([...txIds], includeUnexecuted, mirrorNetwork);
+    return this.buildReport(transactions, { accountFilter: accountId, includeUnexecuted });
+  }
+
+  private async reportForUser(
+    userId: number,
+    mirrorNetwork: string | undefined,
+    startDate: Date | undefined,
+    endDate: Date | undefined,
+    includeUnexecuted: boolean,
+  ): Promise<SigningReportItemDto[]> {
+    mirrorNetwork = this.requireMirrorNetwork(mirrorNetwork);
+    const range = this.parseDateRange(startDate, endDate);
+
+    const userKeys = await this.userKeyRepo.find({ where: { userId }, withDeleted: true });
+    if (userKeys.length === 0) return [];
+
+    const publicKeys = userKeys.map(key => key.publicKey);
+
+    // Executed transactions match the user's keys against account/node snapshots;
+    // not-yet-executed ones (only when requested) match the live account/node
+    // caches. All selections are independent, so run them in parallel.
+    const idLists = await Promise.all([
+      this.selectTransactionIds(
+        this.txAccountSnapshotRepo
+          .createQueryBuilder('tas')
+          .innerJoin('tas.accountSnapshot', 'snap', SNAPSHOT_KEY_OVERLAP, { publicKeys }),
+        true,
+        range,
+        mirrorNetwork,
+      ),
+      this.selectTransactionIds(
+        this.txNodeSnapshotRepo
+          .createQueryBuilder('tns')
+          .innerJoin('tns.nodeSnapshot', 'snap', SNAPSHOT_KEY_OVERLAP, { publicKeys }),
+        true,
+        range,
+        mirrorNetwork,
+      ),
+      includeUnexecuted
+        ? this.selectTransactionIds(
+            this.txCachedAccountRepo
+              .createQueryBuilder('tca')
+              .innerJoin('tca.cachedAccount', 'ca')
+              .innerJoin('ca.keys', 'cak', 'cak.publicKey IN (:...publicKeys)', { publicKeys }),
+            false,
+            range,
+            mirrorNetwork,
+          )
+        : noTransactionIds(),
+      includeUnexecuted
+        ? this.selectTransactionIds(
+            this.txCachedNodeRepo
+              .createQueryBuilder('tcn')
+              .innerJoin('tcn.cachedNode', 'cn')
+              .innerJoin('cn.keys', 'cnk', 'cnk.publicKey IN (:...publicKeys)', { publicKeys }),
+            false,
+            range,
+            mirrorNetwork,
+          )
+        : noTransactionIds(),
+    ]);
+
+    const txIds = new Set(idLists.flat());
+
+    const transactions = await this.loadTransactions([...txIds], includeUnexecuted, mirrorNetwork);
+    return this.buildReport(transactions, { userFilter: userId, includeUnexecuted });
+  }
+
+  /**
+   * Runs a transaction-id selection query. The caller supplies a query builder
+   * on a junction table with the entity-specific key join already applied; this
+   * adds the shared transaction join (date range + executed/pending filter),
+   * the DISTINCT select, and returns the matching transaction ids.
+   */
+  private async selectTransactionIds(
+    keyFilteredQuery: SelectQueryBuilder<ObjectLiteral>,
+    executed: boolean,
+    range: { start: Date; end: Date },
+    mirrorNetwork: string,
+  ): Promise<number[]> {
+    const junctionAlias = keyFilteredQuery.alias;
+    const rows = await keyFilteredQuery
+      .innerJoin(
+        `${junctionAlias}.transaction`,
+        'tx',
+        `tx.mirrorNetwork = :mirrorNetwork AND tx.validStart >= :start AND tx.validStart < :end AND tx.executedAt IS ${executed ? 'NOT NULL' : 'NULL'}`,
+        { ...range, mirrorNetwork },
+      )
+      .select(`DISTINCT ${junctionAlias}.transactionId`, 'transactionId')
+      .getRawMany<{ transactionId: number | string }>();
+
+    // getRawMany may return numeric columns as strings depending on the driver;
+    // normalize to numbers and drop anything non-numeric defensively.
+    return rows.map(row => Number(row.transactionId)).filter(id => Number.isInteger(id));
+  }
+
+  /**
+   * Loads transactions with the key data needed to build the report. When a
+   * mirrorNetwork is given (the account/user reports) the load is scoped to it,
+   * since account IDs are network-relative; the transaction/group reports omit
+   * it because their database id already pins the network. Executed transactions
+   * carry account/node snapshots (the historical key); when unexecuted
+   * transactions are requested, the live account/node cache relations are loaded
+   * too so their pending keys can be resolved.
+   */
+  private loadTransactions(
+    ids: number[],
+    includeUnexecuted: boolean,
+    mirrorNetwork?: string,
+  ): Promise<Transaction[]> {
+    if (ids.length === 0) return Promise.resolve([]);
+    return this.transactionRepo.find({
+      where: mirrorNetwork ? { id: In(ids), mirrorNetwork } : { id: In(ids) },
+      // Only the columns the report emits — avoids loading the large transaction
+      // byte blobs and other unused columns.
+      select: { id: true, createdAt: true, validStart: true, executedAt: true },
+      // Load each to-many relation in its own query rather than via LEFT JOINs,
+      // which would otherwise produce a cartesian product across the account and
+      // node relations.
+      relationLoadStrategy: 'query',
+      relations: {
+        transactionAccountSnapshots: { accountSnapshot: true },
+        transactionNodeSnapshots: { nodeSnapshot: true },
+        ...(includeUnexecuted
+          ? {
+              transactionCachedAccounts: { cachedAccount: { keys: true } },
+              transactionCachedNodes: { cachedNode: { keys: true } },
+            }
+          : {}),
+      },
+    });
+  }
+
+  private async buildReport(
+    transactions: Transaction[],
+    options: ReportOptions,
+  ): Promise<SigningReportItemDto[]> {
+    if (transactions.length === 0) return [];
+
+    const txIds = transactions.map(tx => tx.id);
+
+    // transactionId -> set of userKeyIds that signed the transaction
+    const signers = await this.transactionSignerRepo.find({
+      where: { transactionId: In(txIds) },
+      select: { transactionId: true, userKeyId: true },
+    });
+    const signersByTx = new Map<number, Set<number>>();
+    for (const signer of signers) {
+      let set = signersByTx.get(signer.transactionId);
+      if (!set) signersByTx.set(signer.transactionId, (set = new Set()));
+      set.add(signer.userKeyId);
+    }
+
+    // transactionId -> the account/node key sources to report
+    const sourcesByTx = new Map<number, KeySource[]>();
+    const allPublicKeys = new Set<string>();
+    for (const tx of transactions) {
+      const sources = this.collectKeySources(tx, options);
+      sourcesByTx.set(tx.id, sources);
+      for (const source of sources) {
+        for (const publicKey of source.publicKeys) allPublicKeys.add(publicKey);
+      }
+    }
+
+    const keyToOwner = await this.resolveKeyOwners([...allPublicKeys]);
+
+    const entries: SigningReportItemDto[] = [];
+
+    for (const tx of transactions) {
+      const txSignerKeyIds = signersByTx.get(tx.id) ?? new Set<number>();
+
+      for (const source of sourcesByTx.get(tx.id) ?? []) {
+        const seen = new Set<string>();
+
+        for (const publicKey of source.publicKeys) {
+          if (seen.has(publicKey)) continue;
+          seen.add(publicKey);
+
+          const owner = keyToOwner.get(publicKey) ?? null;
+
+          // For the user report, only include keys that belong to the queried user.
+          if (options.userFilter !== undefined && owner?.userId !== options.userFilter) continue;
+
+          const signed = owner != null && txSignerKeyIds.has(owner.userKeyId);
+
+          entries.push({
+            transactionId: tx.id,
+            createdAt: tx.createdAt.toISOString(),
+            validStart: tx.validStart.toISOString(),
+            executedAt: tx.executedAt?.toISOString() ?? null,
+            entityType: source.entityType,
+            entityId: source.entityId,
+            publicKey,
+            userId: owner?.userId ?? null,
+            userEmail: owner?.userEmail ?? null,
+            signingStatus: signed ? SigningStatus.SIGNED : SigningStatus.NOT_SIGNED,
+          });
+        }
+      }
+    }
+
+    return entries;
+  }
+
+  /**
+   * Flattens a transaction's keys into account/node key sources. Executed
+   * transactions read from immutable snapshots; unexecuted ones read from the
+   * live account/node cache. When an account filter is set (the account report)
+   * only that account is included and node keys are omitted.
+   */
+  private collectKeySources(tx: Transaction, options: ReportOptions): KeySource[] {
+    if (!tx.executedAt) {
+      return options.includeUnexecuted ? this.collectCachedKeySources(tx, options.accountFilter) : [];
+    }
+    return this.collectSnapshotKeySources(tx, options.accountFilter);
+  }
+
+  private collectSnapshotKeySources(tx: Transaction, accountFilter?: string): KeySource[] {
+    const sources: KeySource[] = [];
+
+    for (const tas of tx.transactionAccountSnapshots ?? []) {
+      const snapshot = tas.accountSnapshot;
+      if (!snapshot) continue;
+      if (accountFilter && snapshot.account !== accountFilter) continue;
+
+      // A receiver account only needs to sign when it requires a signature.
+      if (tas.isReceiver && !snapshot.receiverSignatureRequired) continue;
+
+      sources.push({
+        entityType: SigningEntityType.ACCOUNT,
+        entityId: snapshot.account,
+        publicKeys: snapshot.publicKeys ?? [],
+      });
+    }
+
+    if (accountFilter) return sources;
+
+    for (const tns of tx.transactionNodeSnapshots ?? []) {
+      const snapshot = tns.nodeSnapshot;
+      if (!snapshot) continue;
+
+      sources.push({
+        entityType: SigningEntityType.NODE,
+        entityId: String(snapshot.nodeId),
+        publicKeys: snapshot.publicKeys ?? [],
+      });
+    }
+
+    return sources;
+  }
+
+  private collectCachedKeySources(tx: Transaction, accountFilter?: string): KeySource[] {
+    const sources: KeySource[] = [];
+
+    for (const tca of tx.transactionCachedAccounts ?? []) {
+      const cachedAccount = tca.cachedAccount;
+      if (!cachedAccount) continue;
+      if (accountFilter && cachedAccount.account !== accountFilter) continue;
+
+      // A receiver account only needs to sign when it requires a signature.
+      if (tca.isReceiver && !cachedAccount.receiverSignatureRequired) continue;
+
+      sources.push({
+        entityType: SigningEntityType.ACCOUNT,
+        entityId: cachedAccount.account,
+        publicKeys: (cachedAccount.keys ?? []).map(key => key.publicKey),
+      });
+    }
+
+    if (accountFilter) return sources;
+
+    for (const tcn of tx.transactionCachedNodes ?? []) {
+      const cachedNode = tcn.cachedNode;
+      if (!cachedNode) continue;
+
+      sources.push({
+        entityType: SigningEntityType.NODE,
+        entityId: String(cachedNode.nodeId),
+        publicKeys: (cachedNode.keys ?? []).map(key => key.publicKey),
+      });
+    }
+
+    return sources;
+  }
+
+  /**
+   * Bulk-resolves public keys to their owning UserKey. A public key maps to at
+   * most one UserKey, bound to a single owner: the upload path reuses (recovers)
+   * the existing row for a given public key rather than inserting a duplicate,
+   * and rejects uploads of a key owned by another user. If key sharing is added
+   * later this would become a one-to-many lookup; that change lives here and in
+   * the per-key emission loop in buildReport.
+   */
+  private async resolveKeyOwners(
+    publicKeys: string[],
+  ): Promise<Map<string, { userId: number; userEmail: string; userKeyId: number }>> {
+    const keyToOwner = new Map<string, { userId: number; userEmail: string; userKeyId: number }>();
+
+    if (publicKeys.length === 0) return keyToOwner;
+
+    const userKeys = await this.userKeyRepo
+      .createQueryBuilder('uk')
+      .leftJoinAndSelect('uk.user', 'user')
+      .where('uk.publicKey IN (:...publicKeys)', { publicKeys })
+      .withDeleted()
+      .getMany();
+
+    for (const userKey of userKeys) {
+      if (!userKey.user) continue;
+      keyToOwner.set(userKey.publicKey, {
+        userId: userKey.userId,
+        userEmail: userKey.user.email,
+        userKeyId: userKey.id,
+      });
+    }
+
+    return keyToOwner;
+  }
+
+  private parseNumericId(id: string): number {
+    const parsed = Number.parseInt(id, 10);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new BadRequestException(`Invalid id: ${id}`);
+    }
+    return parsed;
+  }
+
+  // Required for the account/user reports, whose identifiers are network-relative.
+  private requireMirrorNetwork(mirrorNetwork?: string): string {
+    if (!mirrorNetwork) {
+      throw new BadRequestException('mirrorNetwork is required for this report type');
+    }
+    return mirrorNetwork;
+  }
+
+  private parseDateRange(startDate?: Date, endDate?: Date): { start: Date; end: Date } {
+    if (!startDate) throw new BadRequestException('startDate is required for this report type');
+
+    // Advance to the start of the next day so endDate is inclusive of its whole day.
+    const end = endDate ? new Date(endDate) : new Date();
+    end.setUTCDate(end.getUTCDate() + 1);
+    end.setUTCHours(0, 0, 0, 0);
+
+    if (startDate >= end) throw new BadRequestException('startDate must be before endDate');
+
+    return { start: startDate, end };
+  }
+}

--- a/back-end/apps/api/src/reports/signing-report.service.ts
+++ b/back-end/apps/api/src/reports/signing-report.service.ts
@@ -45,7 +45,7 @@ const noTransactionIds = (): Promise<number[]> => Promise.resolve([]);
 // the output ordering is a stable contract regardless of DB/relation order.
 const byReportOrder = (a: SigningReportItemDto, b: SigningReportItemDto): number =>
   a.validStart.localeCompare(b.validStart) ||
-  a.transactionId - b.transactionId ||
+  a.transactionId.localeCompare(b.transactionId) ||
   a.entityType.localeCompare(b.entityType) ||
   a.entityId.localeCompare(b.entityId, undefined, { numeric: true }) ||
   a.publicKey.localeCompare(b.publicKey);
@@ -287,7 +287,7 @@ export class SigningReportService {
       where: mirrorNetwork ? { id: In(ids), mirrorNetwork } : { id: In(ids) },
       // Only the columns the report emits — avoids loading the large transaction
       // byte blobs and other unused columns.
-      select: { id: true, createdAt: true, validStart: true, executedAt: true },
+      select: { id: true, transactionId: true, createdAt: true, validStart: true, executedAt: true },
       // Load each to-many relation in its own query rather than via LEFT JOINs,
       // which would otherwise produce a cartesian product across the account and
       // node relations.
@@ -358,7 +358,7 @@ export class SigningReportService {
           const signed = owner != null && txSignerKeyIds.has(owner.userKeyId);
 
           entries.push({
-            transactionId: tx.id,
+            transactionId: tx.transactionId,
             createdAt: tx.createdAt.toISOString(),
             validStart: tx.validStart.toISOString(),
             executedAt: tx.executedAt?.toISOString() ?? null,

--- a/back-end/apps/api/src/reports/signing-report.service.ts
+++ b/back-end/apps/api/src/reports/signing-report.service.ts
@@ -44,6 +44,16 @@ const SNAPSHOT_KEY_OVERLAP = 'snap."publicKeys" && ARRAY[:...publicKeys]::text[]
 // queries when the report is limited to completed transactions.
 const noTransactionIds = (): Promise<number[]> => Promise.resolve([]);
 
+// Deterministic report order: chronological by transaction, then by the
+// account/node within it, then by public key. Applied to the flat row list so
+// the output ordering is a stable contract regardless of DB/relation order.
+const byReportOrder = (a: SigningReportItemDto, b: SigningReportItemDto): number =>
+  a.validStart.localeCompare(b.validStart) ||
+  a.transactionId - b.transactionId ||
+  a.entityType.localeCompare(b.entityType) ||
+  a.entityId.localeCompare(b.entityId, undefined, { numeric: true }) ||
+  a.publicKey.localeCompare(b.publicKey);
+
 @Injectable()
 export class SigningReportService {
   constructor(
@@ -367,7 +377,7 @@ export class SigningReportService {
       }
     }
 
-    return entries;
+    return entries.sort(byReportOrder);
   }
 
   /**

--- a/back-end/apps/api/src/reports/signing-report.service.ts
+++ b/back-end/apps/api/src/reports/signing-report.service.ts
@@ -313,16 +313,16 @@ export class SigningReportService {
 
     const txIds = transactions.map(tx => tx.id);
 
-    // transactionId -> set of userKeyIds that signed the transaction
+    // transactionId -> (userKeyId -> when it signed)
     const signers = await this.transactionSignerRepo.find({
       where: { transactionId: In(txIds) },
-      select: { transactionId: true, userKeyId: true },
+      select: { transactionId: true, userKeyId: true, createdAt: true },
     });
-    const signersByTx = new Map<number, Set<number>>();
+    const signedAtByTx = new Map<number, Map<number, Date>>();
     for (const signer of signers) {
-      let set = signersByTx.get(signer.transactionId);
-      if (!set) signersByTx.set(signer.transactionId, (set = new Set()));
-      set.add(signer.userKeyId);
+      let byKey = signedAtByTx.get(signer.transactionId);
+      if (!byKey) signedAtByTx.set(signer.transactionId, (byKey = new Map()));
+      byKey.set(signer.userKeyId, signer.createdAt);
     }
 
     // transactionId -> the account/node key sources to report
@@ -341,7 +341,7 @@ export class SigningReportService {
     const entries: SigningReportItemDto[] = [];
 
     for (const tx of transactions) {
-      const txSignerKeyIds = signersByTx.get(tx.id) ?? new Set<number>();
+      const txSignedAt = signedAtByTx.get(tx.id) ?? new Map<number, Date>();
 
       for (const source of sourcesByTx.get(tx.id) ?? []) {
         const seen = new Set<string>();
@@ -355,7 +355,7 @@ export class SigningReportService {
           // For the user report, only include keys that belong to the queried user.
           if (options.userFilter !== undefined && owner?.userId !== options.userFilter) continue;
 
-          const signed = owner != null && txSignerKeyIds.has(owner.userKeyId);
+          const signedAt = owner ? (txSignedAt.get(owner.userKeyId) ?? null) : null;
 
           entries.push({
             transactionId: tx.transactionId,
@@ -367,7 +367,8 @@ export class SigningReportService {
             publicKey,
             userId: owner?.userId ?? null,
             userEmail: owner?.userEmail ?? null,
-            signingStatus: signed ? SigningStatus.SIGNED : SigningStatus.NOT_SIGNED,
+            signedAt: signedAt ? signedAt.toISOString() : null,
+            signingStatus: signedAt ? SigningStatus.SIGNED : SigningStatus.NOT_SIGNED,
           });
         }
       }

--- a/back-end/apps/api/src/reports/signing-report.service.ts
+++ b/back-end/apps/api/src/reports/signing-report.service.ts
@@ -36,10 +36,6 @@ interface ReportOptions {
   includeUnexecuted: boolean;
 }
 
-// Snapshot key-overlap predicate, reused for the account and node snapshot
-// selection queries (the joined snapshot is always aliased `snap`).
-const SNAPSHOT_KEY_OVERLAP = 'snap."publicKeys" && ARRAY[:...publicKeys]::text[]';
-
 // A resolved, empty transaction-id selection — used to skip the pending-cache
 // queries when the report is limited to completed transactions.
 const noTransactionIds = (): Promise<number[]> => Promise.resolve([]);
@@ -201,7 +197,7 @@ export class SigningReportService {
       this.selectTransactionIds(
         this.txAccountSnapshotRepo
           .createQueryBuilder('tas')
-          .innerJoin('tas.accountSnapshot', 'snap', SNAPSHOT_KEY_OVERLAP, { publicKeys }),
+          .innerJoin('tas.accountSnapshot', 'snap', 'snap."publicKeys" && ARRAY[:...publicKeys]::text[]', { publicKeys }),
         true,
         range,
         mirrorNetwork,
@@ -209,7 +205,7 @@ export class SigningReportService {
       this.selectTransactionIds(
         this.txNodeSnapshotRepo
           .createQueryBuilder('tns')
-          .innerJoin('tns.nodeSnapshot', 'snap', SNAPSHOT_KEY_OVERLAP, { publicKeys }),
+          .innerJoin('tns.nodeSnapshot', 'snap', 'snap."publicKeys" && ARRAY[:...publicKeys]::text[]', { publicKeys }),
         true,
         range,
         mirrorNetwork,
@@ -219,7 +215,7 @@ export class SigningReportService {
             this.txCachedAccountRepo
               .createQueryBuilder('tca')
               .innerJoin('tca.cachedAccount', 'ca')
-              .innerJoin('ca.keys', 'cak', 'cak.publicKey IN (:...publicKeys)', { publicKeys }),
+              .innerJoin('ca.keys', 'keys', 'keys.publicKey IN (:...publicKeys)', { publicKeys }),
             false,
             range,
             mirrorNetwork,
@@ -230,7 +226,7 @@ export class SigningReportService {
             this.txCachedNodeRepo
               .createQueryBuilder('tcn')
               .innerJoin('tcn.cachedNode', 'cn')
-              .innerJoin('cn.keys', 'cnk', 'cnk.publicKey IN (:...publicKeys)', { publicKeys }),
+              .innerJoin('cn.keys', 'keys', 'keys.publicKey IN (:...publicKeys)', { publicKeys }),
             false,
             range,
             mirrorNetwork,


### PR DESCRIPTION
**Description**:
This pull request introduces a new reporting feature to the API, specifically adding an endpoint for admin users to retrieve signing activity reports. The implementation includes a new module, controller, service, DTOs, and supporting utilities. The changes are grouped into new feature implementation, API integration, and utility/decorator additions.

Historical key lookup is served from the DB snapshot tables (AccountSnapshot/NodeSnapshot, captured at each transaction's terminal state and anchored on executedAt) rather than MirrorNodeClient.fetchAccountInfoAtTimestamp, because the mirror node has no timestamp-based history for node admin keys — so it could only satisfy half the report — and snapshots avoid a per-account, per-transaction mirror-node call on every request. The snapshots reconstruct the exact key active when each transaction ran, meeting the original intent of the executedAt-anchored lookup while covering both account and node keys.

**Related issue(s)**:

Fixes #2973 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
