### PR TITLE
chore: fixing and updating create-users pnpm script

### DIFF
--- a/back-end/scripts/add-users.ts
+++ b/back-end/scripts/add-users.ts
@@ -2,6 +2,7 @@
 import 'tsconfig-paths/register';
 
 import * as path from 'path';
+import * as rl from 'readline-sync';
 
 import * as dotenv from 'dotenv';
 import * as pc from 'picocolors';
@@ -44,36 +45,59 @@ async function main() {
   /* Verify environment variables */
   verifyEnv();
 
+  const data = [
+    {
+      email: 'victor@test.com',
+      password: 'qwerty====',
+      admin: true,
+      status: UserStatus.NONE,
+    },
+    {
+      email: 'alice@test.com',
+      password: 'qwerty====',
+      admin: false,
+      status: UserStatus.NONE,
+    },
+    {
+      email: 'bob@test.com',
+      password: 'qwerty====',
+      admin: false,
+      status: UserStatus.NEW,
+    },
+  ];
+
+  console.log('The following users will be inserted in ' + postgresLabel() + ':');
+  console.log();
+  for (const d of data) {
+    console.log(
+      '    ' + d.email + ', password=' + d.password + ', admin=' + d.admin + ', status=' + d.status,
+    );
+  }
+  console.log();
+  if (!rl.keyInYN('Continue?')) {
+    return;
+  }
+
   /* Setup database connection */
   const dataSource = await connectDatabase();
   const userRepo = dataSource.getRepository(User);
 
-  const data = [
-    {
-      email: 'test10@test.com',
-      password: '159357',
-      admin: true,
+  for (const userData of data) {
+    const newUser = userRepo.create({
+      email: userData.email,
+      password: await hash(userData.password),
+      admin: userData.admin,
       status: UserStatus.NONE,
-    },
-    {
-      email: 'test11@test.com',
-      password: '159357',
-      admin: true,
-      status: UserStatus.NONE,
-    },
-  ];
-
-  for (let i = 0; i < data.length; i++) {
-    /* Create user */
-    let user = userRepo.create(data[i]);
-
-    const hashed = await hash(user.password);
-    user.password = hashed;
-    console.log(`Password set: ${pc.blue(hashed)}\n`);
+    });
 
     /* Create user in database */
     try {
-      user = await userRepo.save(user);
+      await userRepo.save(newUser);
+      console.log(pc.green('User created successfully\n'));
+      console.log(`User ID: ${pc.cyan(newUser.id)}`);
+      console.log(`Email: ${pc.cyan(newUser.email)}`);
+      console.log(`Password hash: ${pc.cyan(newUser.password)}`);
+      console.log(`Admin: ${pc.cyan(newUser.admin.toString())}`);
     } catch (error) {
       console.log(pc.red(error.message));
     }
@@ -110,6 +134,16 @@ function verifyEnv() {
   if (isNaN(Number(process.env.POSTGRES_PORT))) {
     throw new Error('POSTGRES_PORT must be a number');
   }
+}
+
+function postgresLabel(): string {
+  return (
+    process.env.POSTGRES_HOST +
+    ':' +
+    process.env.POSTGRES_PORT +
+    '/' +
+    process.env.POSTGRES_DATABASE
+  );
 }
 
 async function connectDatabase() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3179,8 +3179,8 @@ packages:
   '@types/node@26.0.0':
     resolution: {integrity: sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==}
 
-  '@types/node@26.1.0':
-    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
+  '@types/node@26.0.1':
+    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
 
   '@types/node@26.1.0':
     resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
@@ -8361,14 +8361,6 @@ packages:
       typescript:
         optional: true
 
-  ts-essentials@10.2.1:
-    resolution: {integrity: sha512-+Id1fRkuir+CsgK2x04/icS2b4V1hQmq7ObzIrDjhN0ozfRYivnP7aaKMVJfLApQm0trjR39A6NIMVchiB9Erw==}
-    peerDependencies:
-      typescript: '>=4.5.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   ts-jest@29.4.11:
     resolution: {integrity: sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
@@ -11977,7 +11969,7 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
-  '@types/node@26.1.0':
+  '@types/node@26.0.1':
     dependencies:
       undici-types: 8.3.0
 
@@ -18472,13 +18464,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-essentials@10.2.0(typescript@5.7.3):
+    optionalDependencies:
+      typescript: 5.7.3
+
   ts-essentials@10.2.0(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
-
-  ts-essentials@10.2.1(typescript@5.7.3):
-    optionalDependencies:
-      typescript: 5.7.3
 
   ts-jest@29.4.11(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
@@ -18940,7 +18932,7 @@ snapshots:
 
   vitest-mock-extended@4.0.0(typescript@5.7.3)(vitest@4.1.5):
     dependencies:
-      ts-essentials: 10.2.1(typescript@5.7.3)
+      ts-essentials: 10.2.0(typescript@5.7.3)
       typescript: 5.7.3
       vitest: 4.1.5(@types/node@25.5.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.10.3)(vite@6.4.3(@types/node@25.5.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 


### PR DESCRIPTION
**Description**:
Changes below fix and update `create-users` `pnpm` script.
Note: it also updates pnpm-lock.yaml which is currently obsolete.

This script is broken since months. 
I fixed it locally for my personal use and now propose those changes for publication.

The script works  as before : it creates three test users.
I changed user names and password ; one of the user is in the `NEW` state (see below).

```
/Users/eric/Applications/pnpm/pnpm run create-users

> back-end@0.34.0-SNAPSHOT create-users /Users/eric/Documents/Hedera/WS/hedera-transaction-tool/back-end
> pnpx ts-node ./scripts/add-users.ts

◇ injected env (5) from scripts/.env // tip: ◈ encrypted .env [www.dotenvx.com]
The following users will be inserted in localhost:5432/postgres:

    victor@test.com, password=qwerty====, admin=true, status=NONE
    alice@test.com, password=qwerty====, admin=false, status=NONE
    bob@test.com, password=qwerty====, admin=false, status=NEW

Continue? [y/n]: 
```

**Notes for reviewer**:
```
pnpm run docker:dev
pnpm run create-users

```
