### PR TITLE
feat: add config flag to globally disable non-transactional emails

### DIFF
--- a/back-end/apps/notifications/example.env
+++ b/back-end/apps/notifications/example.env
@@ -15,6 +15,10 @@ EMAIL_API_SECURE=<your email api security setting - true/false>
 EMAIL_API_USERNAME=<your email api username>
 EMAIL_API_PASSWORD=<your email api password>
 SENDER_EMAIL=no-reply@<yourdomain.com>
+# Set to true to suppress all non-transactional notification emails globally.
+# Transactional emails (registration invite, password reset) are unaffected.
+# Defaults to false (notification emails are sent).
+DISABLE_NOTIFICATION_EMAILS=false
 
 # Format of REDIS_URL:
 # redis[s]://[[username][:password]@][host][:port][/db-number]

--- a/back-end/apps/notifications/src/consumer/base-nats-consumer.service.spec.ts
+++ b/back-end/apps/notifications/src/consumer/base-nats-consumer.service.spec.ts
@@ -748,8 +748,8 @@ describe('BaseNatsConsumerService', () => {
       });
 
       const gen = (async function* () {
-        // Block forever to simulate waiting for next message
         await blockPromise;
+        yield; // unreachable: gen.return() terminates the generator before this
       })();
 
       const stopFn = jest.fn(() => {
@@ -792,6 +792,67 @@ describe('BaseNatsConsumerService', () => {
         'Unexpected consumer failure',
         expect.stringContaining('Unexpected config error'),
       );
+    });
+
+    it('should log String(err) when thrown value is not an Error instance (false branch of instanceof)', async () => {
+      const errorSpy = jest.spyOn(service['logger'], 'error');
+
+      // Throw a plain string — not an Error instance — to hit the String(err) branch
+      jest.spyOn(service as any, 'consumeWithReconnect').mockRejectedValue('raw string error');
+
+      await service.onModuleInit();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(errorSpy).toHaveBeenCalledWith('Unexpected consumer failure', 'raw string error');
+    });
+  });
+
+  describe('catch-block shutdown guard (line 107)', () => {
+    it('breaks out of catch block immediately when running is already false during error recovery', async () => {
+      const logSpy = jest.spyOn(service['logger'], 'log');
+
+      // waitForConnection sets running=false then throws, simulating shutdown arriving during recovery
+      jest.spyOn(service as any, 'waitForConnection').mockImplementation(async () => {
+        (service as any).running = false;
+        throw new Error('error while shutdown in progress');
+      });
+
+      (service as any).running = true;
+      await (service as any).consumeWithReconnect();
+
+      expect(logSpy).toHaveBeenCalledWith('Consumer loop stopped (shutdown)');
+    });
+  });
+
+  describe('startConsuming running-guard (line 137)', () => {
+    it('breaks out of for-await loop without processing message when running is false', async () => {
+      const handler = jest.fn();
+      service.mockHandlers = [{ subject: 'test.message', dtoClass: TestDto, handler }];
+
+      const handlerMap = new Map<string, MessageHandler>(
+        service.mockHandlers.map(h => [h.subject, h]),
+      );
+
+      const msg = {
+        subject: 'test.message',
+        data: new TextEncoder().encode('{}'),
+        ack: jest.fn(),
+      };
+
+      (MessageValidator.parseAndValidate as jest.Mock).mockResolvedValue({ id: 1 });
+      mockConsumer.consume.mockResolvedValueOnce({
+        stop: jest.fn(),
+        [Symbol.asyncIterator]() { return (async function* () { yield msg; })(); },
+      });
+
+      // Set running=false before consuming — the for-await check fires and breaks
+      (service as any).running = false;
+      (service as any).consumer = mockConsumer;
+
+      await (service as any).startConsuming(100, handlerMap);
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(msg.ack).not.toHaveBeenCalled();
     });
   });
 

--- a/back-end/apps/notifications/src/notifications.module.ts
+++ b/back-end/apps/notifications/src/notifications.module.ts
@@ -41,6 +41,7 @@ export const config = ConfigModule.forRoot({
     POSTGRES_SYNCHRONIZE: Joi.boolean().required(),
     REDIS_URL: Joi.string().required(),
     REDIS_DEFAULT_TTL_MS: Joi.number().optional(),
+    DISABLE_NOTIFICATION_EMAILS: Joi.boolean().optional().default(false),
     EMAIL_DEBOUNCE_DELAY_MS: Joi.number().integer().min(1).default(60*1000),
     EMAIL_DEBOUNCE_MAX_FLUSH_MS: Joi.number().integer().min(1).default(10*60*1000),
     MINIMUM_SUPPORTED_FRONTEND_VERSION: Joi.string().required(),

--- a/back-end/apps/notifications/src/receiver/receiver.service.spec.ts
+++ b/back-end/apps/notifications/src/receiver/receiver.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { ReceiverService } from './receiver.service';
 import { EntityManager, In } from 'typeorm';
 
@@ -60,11 +61,13 @@ describe('ReceiverService', () => {
   let em: ReturnType<typeof mockEntityManager>;
   let tss: ReturnType<typeof mockTransactionSignatureService>;
   let publisher: ReturnType<typeof mockPublisher>;
+  let configService: { get: jest.Mock };
 
   beforeEach(async () => {
     em = mockEntityManager();
     tss = mockTransactionSignatureService();
     publisher = mockPublisher();
+    configService = { get: jest.fn().mockReturnValue(false) };
 
     // Make transaction execute the callback with our mock em
     em.transaction.mockImplementation(async (cb: any) => cb(em));
@@ -75,6 +78,7 @@ describe('ReceiverService', () => {
         { provide: EntityManager, useValue: em },
         { provide: TransactionSignatureService, useValue: tss },
         { provide: NatsPublisherService, useValue: publisher },
+        { provide: ConfigService, useValue: configService },
       ],
     }).compile();
 
@@ -480,21 +484,60 @@ describe('ReceiverService', () => {
     });
 
     it('excludes user with inApp:false for an inApp-only notification type', async () => {
-      // USER_REGISTERED is inApp-only (email:false, inApp:true)
+      // TRANSACTION_INDICATOR_SIGN is inApp-only (email:false, inApp:true)
       em.find.mockResolvedValueOnce([
-        { id: 1, notificationPreferences: [{ type: NotificationType.USER_REGISTERED, email: true, inApp: false }] },
-        { id: 2, notificationPreferences: [{ type: NotificationType.USER_REGISTERED, email: false, inApp: true }] },
+        { id: 1, notificationPreferences: [{ type: NotificationType.TRANSACTION_INDICATOR_SIGN, email: true, inApp: false }] },
+        { id: 2, notificationPreferences: [{ type: NotificationType.TRANSACTION_INDICATOR_SIGN, email: false, inApp: true }] },
+      ]);
+
+      const cache = new Map<number, User>();
+      const res = await (service as any).filterReceiversByPreferenceForType(
+        em as any,
+        NotificationType.TRANSACTION_INDICATOR_SIGN,
+        new Set([1, 2]),
+        cache,
+      );
+
+      expect(res).toEqual([2]);
+    });
+
+    it('channel=inApp includes only users with inApp enabled, ignoring email preference', async () => {
+      // USER_REGISTERED is now dual-channel; channel='inApp' should check only inApp preference
+      em.find.mockResolvedValueOnce([
+        { id: 1, notificationPreferences: [{ type: NotificationType.USER_REGISTERED, email: false, inApp: true }] },  // inApp on, email off
+        { id: 2, notificationPreferences: [{ type: NotificationType.USER_REGISTERED, email: true, inApp: false }] }, // inApp off, email on
+        { id: 3, notificationPreferences: [{ type: NotificationType.USER_REGISTERED, email: true, inApp: true }] },  // both on
       ]);
 
       const cache = new Map<number, User>();
       const res = await (service as any).filterReceiversByPreferenceForType(
         em as any,
         NotificationType.USER_REGISTERED,
-        new Set([1, 2]),
+        new Set([1, 2, 3]),
         cache,
+        'inApp',
       );
 
-      expect(res).toEqual([2]);
+      expect(res).toEqual([1, 3]); // included regardless of email preference
+    });
+
+    it('channel=email includes only users with email enabled, ignoring inApp preference', async () => {
+      em.find.mockResolvedValueOnce([
+        { id: 1, notificationPreferences: [{ type: NotificationType.USER_REGISTERED, email: false, inApp: true }] },  // email off
+        { id: 2, notificationPreferences: [{ type: NotificationType.USER_REGISTERED, email: true, inApp: false }] }, // email on
+        { id: 3, notificationPreferences: [{ type: NotificationType.USER_REGISTERED, email: true, inApp: true }] },  // both on
+      ]);
+
+      const cache = new Map<number, User>();
+      const res = await (service as any).filterReceiversByPreferenceForType(
+        em as any,
+        NotificationType.USER_REGISTERED,
+        new Set([1, 2, 3]),
+        cache,
+        'email',
+      );
+
+      expect(res).toEqual([2, 3]); // included regardless of inApp preference
     });
 
     it('includes user with inApp:false when notification type is email-only', async () => {
@@ -583,6 +626,17 @@ describe('ReceiverService', () => {
     expect(result).toEqual([{ userId: 1, receiverId: 10 }]);
   });
 
+  it('deleteExistingIndicators skips receiver-delete when notification has no receivers', async () => {
+    em.find.mockResolvedValueOnce([{ id: 100, notificationReceivers: [] }]);
+    em.delete.mockResolvedValue({ raw: [], affected: 1 });
+
+    const result = await (service as any).deleteExistingIndicators(em as any, { id: 5 } as any);
+
+    // Only the notification delete runs; receiver delete is skipped (false branch of length>0)
+    expect(em.delete).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([]);
+  });
+
   it('processNotificationType creates new and updates existing receivers', async () => {
     const notification = {
       id: 200,
@@ -614,6 +668,48 @@ describe('ReceiverService', () => {
     expect(newReceivers.length).toBe(1);
     expect(updatedReceivers.length).toBe(1);
     expect(em.update).toHaveBeenCalled();
+  });
+
+  it('processNotificationType skips update when no existing receivers match receiverIds', async () => {
+    const notification = {
+      id: 200,
+      notificationReceivers: [{ id: 700, userId: 99 }], // userId 99 not in receiverIds
+      type: NotificationType.TRANSACTION_EXECUTED,
+    } as any;
+
+    em.findOne.mockResolvedValueOnce(notification);
+    jest.spyOn(service as any, 'filterReceiversByPreferenceForType').mockResolvedValue([1, 2]);
+    em.save.mockResolvedValueOnce([{ id: 801, userId: 1 }, { id: 802, userId: 2 }]);
+
+    const { newReceivers, updatedReceivers } = await (service as any).processNotificationType(
+      em as any,
+      55,
+      NotificationType.TRANSACTION_EXECUTED,
+      new Set([1, 2]),
+      new Map(),
+    );
+
+    // false branch of if (receiversToUpdate.length > 0) — no update, only creates
+    expect(updatedReceivers.length).toBe(0);
+    expect(newReceivers.length).toBe(2);
+    expect(em.update).not.toHaveBeenCalled();
+  });
+
+  it('processNotificationType returns empty result when findOne returns null (no prior notification row)', async () => {
+    em.findOne.mockResolvedValueOnce(null);
+
+    const { newReceivers, updatedReceivers } = await (service as any).processNotificationType(
+      em as any,
+      55,
+      NotificationType.TRANSACTION_EXECUTED,
+      new Set([1, 2]),
+      new Map(),
+    );
+
+    expect(newReceivers).toEqual([]);
+    expect(updatedReceivers).toEqual([]);
+    expect(em.save).not.toHaveBeenCalled();
+    expect(em.update).not.toHaveBeenCalled();
   });
 
   it('processNotificationType uses in-app update fields when channel.email is falsey', async () => {
@@ -687,6 +783,26 @@ describe('ReceiverService', () => {
       expect(Object.keys(emailNotifications)).toEqual(['ok@example.com']);
       expect(emailNotifications['ok@example.com'][0].id).toBe(102);
       expect(receiverIds).toContain(12);
+    });
+
+    it('accumulates notifications under the same email key (false branch of key-exists check)', () => {
+      const cache = new Map<number, any>();
+      cache.set(2, { id: 2, email: 'shared@example.com' });
+      cache.set(3, { id: 3, email: 'shared@example.com' }); // same email as user 2
+
+      const receivers = [
+        { id: 10, userId: 2, notification: { id: 100 } },
+        { id: 11, userId: 3, notification: { id: 101 } },
+      ] as any[];
+
+      const emailNotifications: { [email: string]: any[] } = {};
+      const receiverIds: number[] = [];
+
+      (service as any).collectEmailNotifications(receivers, [], emailNotifications, receiverIds, cache);
+
+      // Second receiver hits the false branch of if(!notificationMap[keyString])
+      expect(emailNotifications['shared@example.com'].length).toBe(2);
+      expect(receiverIds).toEqual([10, 11]);
     });
 
     it('logs and skips receivers when user missing or has no email', () => {
@@ -933,6 +1049,30 @@ describe('ReceiverService', () => {
     });
   });
 
+  describe('addAffectedUser', () => {
+    it('creates a new entry when userId is not yet in map', () => {
+      const affectedUsers = new Map<number, any>();
+      (service as any).addAffectedUser(affectedUsers, 1, 100);
+      expect(affectedUsers.get(1)!.transactionIds.has(100)).toBe(true);
+      expect(affectedUsers.get(1)!.groupIds.size).toBe(0);
+    });
+
+    it('reuses existing entry when userId already in map (false branch of !has)', () => {
+      const affectedUsers = new Map<number, any>();
+      (service as any).addAffectedUser(affectedUsers, 1, 100);
+      (service as any).addAffectedUser(affectedUsers, 1, 200); // second call — false branch
+      expect(affectedUsers.size).toBe(1);
+      expect(affectedUsers.get(1)!.transactionIds.has(100)).toBe(true);
+      expect(affectedUsers.get(1)!.transactionIds.has(200)).toBe(true);
+    });
+
+    it('adds groupId to groupIds set when groupId is provided (true branch of if(groupId))', () => {
+      const affectedUsers = new Map<number, any>();
+      (service as any).addAffectedUser(affectedUsers, 1, 100, 42);
+      expect(affectedUsers.get(1)!.groupIds.has(42)).toBe(true);
+    });
+  });
+
   describe('handleTransactionStatusUpdateNotifications', () => {
     beforeEach(() => jest.clearAllMocks());
 
@@ -993,6 +1133,52 @@ describe('ReceiverService', () => {
       // createNotificationWithReceivers called twice (sync + email) and collectEmailNotifications invoked for email receivers
       expect(createSpy).toHaveBeenCalledTimes(2);
       expect(collectEmailSpy).toHaveBeenCalledWith(createdEmail, [], emailNotifications, emailReceiverIds, expect.any(Map));
+    });
+
+    it('skips in-app and deletion steps when syncType is null (false branch)', async () => {
+      const deleteIndicatorsSpy = jest.spyOn(service as any, 'deleteExistingIndicators').mockResolvedValue([]);
+      const createSpy = jest.spyOn(service as any, 'createNotificationWithReceivers').mockResolvedValue([]);
+
+      await (service as any).handleTransactionStatusUpdateNotifications(
+        em as any,
+        { transactionId: 'tx', mirrorNetwork: 'net' } as any,
+        [],
+        null,  // syncType=null → false branch at if(syncType)
+        null,
+        new Map(), new Map(),
+        {}, {}, [], {}, [], new Map(), 123,
+      );
+
+      expect(deleteIndicatorsSpy).not.toHaveBeenCalled();
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it('uses pre-populated deletionNotifications / inAppNotifications entries (false branch of !x[userId])', async () => {
+      const deletionNotifications: any = { 1: [5] }; // userId 1 pre-populated
+      const inAppNotifications: any = {};
+      const inAppReceiverIds: number[] = [];
+      const affectedUsers = new Map<number, any>();
+
+      jest.spyOn(service as any, 'deleteExistingIndicators').mockResolvedValue([
+        { userId: 1, receiverId: 20 }, // userId 1 already in deletionNotifications → false branch at 771
+      ]);
+      jest.spyOn(service as any, 'createNotificationWithReceivers')
+        .mockResolvedValueOnce([{ id: 101, userId: 2 }, { id: 102, userId: 2 }]); // two receivers for userId 2
+      jest.spyOn(service as any, 'collectEmailNotifications').mockImplementation(() => {});
+
+      await (service as any).handleTransactionStatusUpdateNotifications(
+        em as any,
+        { transactionId: 'tx', mirrorNetwork: 'net' } as any,
+        [],
+        NotificationType.TRANSACTION_INDICATOR_EXECUTED,
+        null,
+        new Map(), new Map(),
+        deletionNotifications, inAppNotifications, inAppReceiverIds, {}, [], affectedUsers, 123,
+      );
+
+      expect(deletionNotifications[1]).toContain(20);
+      // Second receiver for userId 2 hits false branch of if(!inAppNotifications[nr.userId])
+      expect(inAppNotifications[2].length).toBe(2);
     });
 
     it('logs an error when internal call throws', async () => {
@@ -1115,6 +1301,39 @@ describe('ReceiverService', () => {
       expect(emailNotifications['user3@example.com']).toBeDefined();
       expect(emailNotifications['user3@example.com'][0].id).toBe(savedNotification.id);
       expect(emailReceiverIds).toContain(11);
+    });
+
+    it('skips email receiver creation when DISABLE_NOTIFICATION_EMAILS=true', async () => {
+      configService.get.mockReturnValue(true);
+
+      const filterSpy = jest.spyOn(service as any, 'filterReceiversByPreferenceForType')
+        .mockResolvedValueOnce([2]); // in-app only; email query is skipped
+
+      const savedNotification = { id: 200, type: NotificationType.USER_REGISTERED } as any;
+      const savedReceivers = [{ id: 10, userId: 2, notification: savedNotification } as any];
+      jest.spyOn(em as any, 'save')
+        .mockResolvedValueOnce(savedNotification)
+        .mockResolvedValueOnce(savedReceivers);
+
+      const emailNotifications: { [email: string]: Notification[] } = {};
+      const emailReceiverIds: number[] = [];
+
+      await (service as any).handleUserRegisteredNotifications(
+        em as any,
+        77,
+        new Set([2, 3]),
+        { foo: 'bar' },
+        new Map(),
+        {},
+        emailNotifications,
+        [],
+        emailReceiverIds,
+      );
+
+      // filterReceiversByPreferenceForType only called once (in-app; email query skipped)
+      expect(filterSpy).toHaveBeenCalledTimes(1);
+      expect(Object.keys(emailNotifications).length).toBe(0);
+      expect(emailReceiverIds).toEqual([]);
     });
   });
 
@@ -1300,6 +1519,120 @@ describe('ReceiverService', () => {
       consoleSpy.mockRestore();
       handlerSpy.mockRestore();
     });
+
+    it('passes null emailType when DISABLE_NOTIFICATION_EMAILS=true', async () => {
+      configService.get.mockReturnValue(true);
+
+      const handlerSpy = jest
+        .spyOn(service as any, 'handleTransactionStatusUpdateNotifications')
+        .mockResolvedValue(undefined);
+
+      await service.processTransactionStatusUpdateNotifications([{ entityId: 42 } as any]);
+
+      expect(handlerSpy).toHaveBeenCalled();
+      const passedEmailType = handlerSpy.mock.calls[0][4] as NotificationType | null;
+      expect(passedEmailType).toBeNull();
+
+      handlerSpy.mockRestore();
+    });
+  });
+
+  describe('handleSignerReminderNotifications', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('skips in-app block when syncType is null', async () => {
+      jest.spyOn(service as any, 'getInAppNotificationType').mockReturnValue(null);
+      jest.spyOn(service as any, 'getEmailNotificationType').mockReturnValue(null);
+      const processNotifSpy = jest.spyOn(service as any, 'processNotificationType').mockResolvedValue({ newReceivers: [], updatedReceivers: [] });
+      jest.spyOn(service as any, 'processReminderEmail').mockResolvedValue([]);
+      jest.spyOn(service as any, 'collectEmailNotifications').mockImplementation(() => {});
+
+      await (service as any).handleSignerReminderNotifications(
+        em as any, {} as any, 1, new Set([1]), new Map(), false,
+        {}, {}, [], {}, [],
+      );
+
+      // syncType=null → if(syncType) not entered
+      expect(processNotifSpy).not.toHaveBeenCalled();
+      expect((service as any).processReminderEmail).toHaveBeenCalled();
+    });
+
+    it('calls processNotificationType for emailType when isManual=true and emailType truthy (true branch of if(emailType))', async () => {
+      const emailType = NotificationType.TRANSACTION_WAITING_FOR_SIGNATURES;
+      jest.spyOn(service as any, 'getInAppNotificationType').mockReturnValue(null);
+      jest.spyOn(service as any, 'getEmailNotificationType').mockReturnValue(emailType);
+      const processSpy = jest.spyOn(service as any, 'processNotificationType').mockResolvedValue({ newReceivers: [], updatedReceivers: [] });
+      jest.spyOn(service as any, 'collectEmailNotifications').mockImplementation(() => {});
+
+      await (service as any).handleSignerReminderNotifications(
+        em as any, {} as any, 1, new Set([1]), new Map(), true,
+        {}, {}, [], {}, [],
+      );
+
+      expect(processSpy).toHaveBeenCalledWith(em as any, 1, emailType, expect.any(Set), expect.any(Map));
+    });
+
+    it('skips email processNotificationType when isManual=true but emailType is null (false branch of if(emailType))', async () => {
+      jest.spyOn(service as any, 'getInAppNotificationType').mockReturnValue(null);
+      jest.spyOn(service as any, 'getEmailNotificationType').mockReturnValue(null);
+      const processSpy = jest.spyOn(service as any, 'processNotificationType').mockResolvedValue({ newReceivers: [], updatedReceivers: [] });
+
+      await (service as any).handleSignerReminderNotifications(
+        em as any, {} as any, 1, new Set([1]), new Map(), true,
+        {}, {}, [], {}, [],
+      );
+
+      expect(processSpy).not.toHaveBeenCalled();
+    });
+
+    it('appends to existing deletionNotifications entry for updated receivers (false branch of !x[userId])', async () => {
+      jest.spyOn(service as any, 'getInAppNotificationType').mockReturnValue(NotificationType.TRANSACTION_INDICATOR_SIGN);
+      jest.spyOn(service as any, 'getEmailNotificationType').mockReturnValue(null);
+      const updatedReceiver = { id: 700, userId: 10 } as any;
+      jest.spyOn(service as any, 'processNotificationType').mockResolvedValue({
+        newReceivers: [],
+        updatedReceivers: [updatedReceiver],
+      });
+      jest.spyOn(service as any, 'collectInAppNotifications').mockImplementation(() => {});
+      jest.spyOn(service as any, 'processReminderEmail').mockResolvedValue([]);
+      jest.spyOn(service as any, 'collectEmailNotifications').mockImplementation(() => {});
+
+      const deletionNotifications: any = { 10: [5] }; // userId 10 pre-populated
+
+      await (service as any).handleSignerReminderNotifications(
+        em as any, {} as any, 1, new Set([10]), new Map(), false,
+        deletionNotifications, {}, [], {}, [],
+      );
+
+      // false branch: deletionNotifications[10] already exists, so 700 is pushed onto it
+      expect(deletionNotifications[10]).toEqual([5, 700]);
+    });
+
+    it('skips email type creation when DISABLE_NOTIFICATION_EMAILS=true and isManual=true', async () => {
+      configService.get.mockReturnValue(true);
+      jest.spyOn(service as any, 'getEmailNotificationType').mockReturnValue(NotificationType.TRANSACTION_WAITING_FOR_SIGNATURES);
+      const processSpy = jest.spyOn(service as any, 'processNotificationType').mockResolvedValue({ newReceivers: [], updatedReceivers: [] });
+
+      await (service as any).handleSignerReminderNotifications(
+        em as any, {} as any, 1, new Set([1]), new Map(), true,
+        {}, {}, [], {}, [],
+      );
+
+      expect(processSpy).not.toHaveBeenCalled();
+    });
+
+    it('skips processReminderEmail when DISABLE_NOTIFICATION_EMAILS=true and isManual=false', async () => {
+      configService.get.mockReturnValue(true);
+      jest.spyOn(service as any, 'getInAppNotificationType').mockReturnValue(null);
+      const reminderSpy = jest.spyOn(service as any, 'processReminderEmail').mockResolvedValue([]);
+
+      await (service as any).handleSignerReminderNotifications(
+        em as any, {} as any, 1, new Set([1]), new Map(), false,
+        {}, {}, [], {}, [],
+      );
+
+      expect(reminderSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('processTransactionUpdateNotifications', () => {
@@ -1334,6 +1667,38 @@ describe('ReceiverService', () => {
       await service.processTransactionUpdateNotifications([{ entityId: 7 } as any]);
 
       expect(emitNotifyClients).toHaveBeenCalled();
+    });
+
+    it('skips processing when transaction not found in map (continue at line 1098)', async () => {
+      const ctx = {
+        keyCache: new Map(),
+        transactionMap: new Map(), // empty — entityId 999 will not be found
+        approversMap: new Map(),
+        affectedUsers: new Map(),
+      };
+      jest.spyOn(service as any, 'prepareEventContext').mockResolvedValue(ctx);
+      const getReceiverSpy = jest.spyOn(service as any, 'getNotificationReceiverIds').mockResolvedValue([]);
+
+      await service.processTransactionUpdateNotifications([{ entityId: 999 } as any]);
+
+      expect(getReceiverSpy).not.toHaveBeenCalled();
+    });
+
+    it('skips notify-clients call when syncType is null for transaction (false branch at if(syncType))', async () => {
+      const transaction: any = { id: 7, status: 9999 as any }; // unknown status → null syncType
+      const ctx = {
+        keyCache: new Map(),
+        transactionMap: new Map([[7, transaction]]),
+        approversMap: new Map([[7, []]]),
+        affectedUsers: new Map(),
+      };
+      jest.spyOn(service as any, 'prepareEventContext').mockResolvedValue(ctx);
+      const getReceiverSpy = jest.spyOn(service as any, 'getNotificationReceiverIds').mockResolvedValue([]);
+
+      await service.processTransactionUpdateNotifications([{ entityId: 7 } as any]);
+
+      // syncType is null for unmapped status → if(syncType) false → no receiver lookup
+      expect(getReceiverSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -1865,6 +2230,20 @@ describe('ReceiverService', () => {
 
       consoleSpy.mockRestore();
     });
+
+    it('returns immediately when DISABLE_NOTIFICATION_EMAILS=true, skipping all DB work', async () => {
+      configService.get.mockReturnValue(true);
+      const approversSpy = jest.spyOn(service as any, 'getApproversByTransactionIds');
+      const createSpy = jest.spyOn(service as any, 'createNotificationWithReceivers');
+
+      const tx = makeTx(1, TransactionStatus.EXECUTED);
+      await (service as any).handleGroupEmailForLastTransaction(
+        em as any, new Map(), new Map(), {}, [], [tx],
+      );
+
+      expect(approversSpy).not.toHaveBeenCalled();
+      expect(createSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('processTransactionStatusUpdateNotifications - group email logic', () => {
@@ -2065,6 +2444,38 @@ describe('ReceiverService', () => {
       // TRANSACTION_FAILED and TRANSACTION_REJECTED have email: false — must not reach the mailer
       expect(handlerSpy.mock.calls[0][4]).toBeNull();
       expect(handlerSpy.mock.calls[1][4]).toBeNull();
+    });
+
+    it('skips null-groupId entries in pre-fetched results and falls back to empty cache for groupTxs', async () => {
+      const tx = makeGroupTx(90, TransactionStatus.EXECUTED, 99);
+
+      const ctx = {
+        cache: new Map(), keyCache: new Map(),
+        transactionMap: new Map([[90, tx]]),
+        approversMap: new Map(),
+        deletionNotifications: {}, inAppNotifications: {}, emailNotifications: {},
+        inAppReceiverIds: [], emailReceiverIds: [], affectedUsers: new Map(),
+      };
+
+      jest.spyOn(service as any, 'prepareEventContext').mockResolvedValue(ctx);
+      // Pre-fetch returns a tx with null groupItem → gId=null → continue (line 1143 branch)
+      // groupTransactionCache never gets an entry for groupId 99
+      em.find.mockResolvedValueOnce([{ id: 99, status: TransactionStatus.EXECUTED, groupItem: null }]);
+      jest.spyOn(service as any, 'handleTransactionStatusUpdateNotifications').mockResolvedValue(undefined);
+      const groupHandlerSpy = jest.spyOn(service as any, 'handleGroupEmailForLastTransaction').mockResolvedValue(undefined);
+
+      await service.processTransactionStatusUpdateNotifications([{ entityId: 90 } as any]);
+
+      // groupTransactionCache has no entry for 99 → ?? [] hits at both lines 1181 and 1215
+      // isLastInGroupToReachStage([]) = true → groupsNeedingEmail fires with empty groupTxs
+      expect(groupHandlerSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Map),
+        expect.any(Map),
+        ctx.emailNotifications,
+        ctx.emailReceiverIds,
+        [],
+      );
     });
 
     it('pre-fetches group transactions exactly once per unique groupId', async () => {

--- a/back-end/apps/notifications/src/receiver/receiver.service.ts
+++ b/back-end/apps/notifications/src/receiver/receiver.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { EntityManager, In } from 'typeorm';
 
@@ -72,6 +73,7 @@ export class ReceiverService {
     @InjectEntityManager() private entityManager: EntityManager,
     private readonly transactionSignatureService: TransactionSignatureService,
     private readonly notificationsPublisher: NatsPublisherService,
+    private readonly configService: ConfigService,
   ) {}
 
   // --- Small lookups -----------------------------------------------------
@@ -284,6 +286,7 @@ export class ReceiverService {
     notificationType: NotificationType,
     userIds: Set<number>,
     cache: Map<number, User>, // User with preferences relation
+    channel: 'email' | 'inApp' | 'any' = 'any',
   ): Promise<number[]> {
     // Load uncached users
     await this.loadUsersWithPreferences(entityManager, Array.from(userIds), cache);
@@ -298,12 +301,16 @@ export class ReceiverService {
         p => p.type === notificationType
       );
 
-      const channel = NOTIFICATION_CHANNELS[notificationType];
-      const emailAllowed = !channel.email || !preference || preference.email !== false;
-      const inAppAllowed = !channel.inApp || !preference || preference.inApp !== false;
-      if (emailAllowed && inAppAllowed) {
-        result.push(id);
-      }
+      const ch = NOTIFICATION_CHANNELS[notificationType];
+      const emailAllowed = !ch.email || !preference || preference.email !== false;
+      const inAppAllowed = !ch.inApp || !preference || preference.inApp !== false;
+
+      const passes =
+        channel === 'email' ? emailAllowed :
+        channel === 'inApp' ? inAppAllowed :
+        emailAllowed && inAppAllowed;
+
+      if (passes) result.push(id);
     }
 
     return result;
@@ -420,11 +427,9 @@ export class ReceiverService {
       });
     }
 
-    if (indicatorNotifications.length > 0) {
-      await entityManager.delete(Notification, {
-        id: In(indicatorNotifications.map(n => n.id)),
-      });
-    }
+    await entityManager.delete(Notification, {
+      id: In(indicatorNotifications.map(n => n.id)),
+    });
 
     return deletedReceiverIds;
   }
@@ -453,6 +458,8 @@ export class ReceiverService {
       },
       relations: { notificationReceivers: true },
     });
+
+    if (!notification) return { newReceivers: [], updatedReceivers: [] };
 
     // Get users who should receive this notification (filtered by preferences)
     const receiverIds = await this.filterReceiversByPreferenceForType(
@@ -866,8 +873,9 @@ export class ReceiverService {
       );
     }
 
+    const emailsDisabled = this.configService.get<boolean>('DISABLE_NOTIFICATION_EMAILS');
     if (isManual) {
-      const emailType = this.getEmailNotificationType(transaction.status);
+      const emailType = emailsDisabled ? null : this.getEmailNotificationType(transaction.status);
       if (emailType) {
         const { newReceivers, updatedReceivers } = await this.processNotificationType(
           entityManager,
@@ -885,7 +893,7 @@ export class ReceiverService {
           cache,
         );
       }
-    } else {
+    } else if (!emailsDisabled) {
       const newReceivers = await this.processReminderEmail(
         entityManager,
         transaction,
@@ -920,15 +928,19 @@ export class ReceiverService {
       NotificationType.USER_REGISTERED,
       adminUserIds,
       cache,
+      'inApp',
     );
 
     // Get admin users who want email notifications (filtered by preferences)
-    const emailReceiverUserIds = await this.filterReceiversByPreferenceForType(
-      entityManager,
-      NotificationType.USER_REGISTERED,
-      adminUserIds,
-      cache,
-    );
+    const emailReceiverUserIds = this.configService.get<boolean>('DISABLE_NOTIFICATION_EMAILS')
+      ? []
+      : await this.filterReceiversByPreferenceForType(
+          entityManager,
+          NotificationType.USER_REGISTERED,
+          adminUserIds,
+          cache,
+          'email',
+        );
 
     // Combine all receivers (union of in-app and email preferences)
     const allReceiverIds = new Set([...inAppReceiverUserIds, ...emailReceiverUserIds]);
@@ -1066,6 +1078,7 @@ export class ReceiverService {
     groupTransactions: Transaction[],
   ): Promise<void> {
     if (groupTransactions.length === 0) return;
+    if (this.configService.get<boolean>('DISABLE_NOTIFICATION_EMAILS')) return;
 
     const approversMap = await this.getApproversByTransactionIds(
       entityManager,
@@ -1143,6 +1156,7 @@ export class ReceiverService {
     // Groups that need a group email after the loop. The tiebreaker in
     // isLastInGroupToReachStage guarantees at most one add per group per batch.
     const groupsNeedingEmail = new Set<number>();
+    const emailsDisabled = this.configService.get<boolean>('DISABLE_NOTIFICATION_EMAILS');
 
     // Process each event
     for (const { entityId: transactionId } of events) {
@@ -1161,7 +1175,7 @@ export class ReceiverService {
       }
 
       const groupId = transaction.groupItem?.groupId;
-      const emailType = this.getEmailNotificationType(transaction.status);
+      const emailType = emailsDisabled ? null : this.getEmailNotificationType(transaction.status);
 
       // CANCELLED always fires an individual email even inside a group.
       // Null (unmapped) emailTypes are excluded from group email logic entirely.

--- a/back-end/apps/notifications/src/receiver/receiver.service.ts
+++ b/back-end/apps/notifications/src/receiver/receiver.service.ts
@@ -459,7 +459,12 @@ export class ReceiverService {
       relations: { notificationReceivers: true },
     });
 
-    if (!notification) return { newReceivers: [], updatedReceivers: [] };
+    if (!notification) {
+      console.warn(
+        `Notification row not found for entityId=${transactionId}, type=${notificationType}; skipping receiver updates/creates`,
+      );
+      return { newReceivers: [], updatedReceivers: [] };
+    }
 
     // Get users who should receive this notification (filtered by preferences)
     const receiverIds = await this.filterReceiversByPreferenceForType(

--- a/back-end/libs/common/src/database/entities/notifications/notification.entity.ts
+++ b/back-end/libs/common/src/database/entities/notifications/notification.entity.ts
@@ -77,7 +77,7 @@ export const NOTIFICATION_CHANNELS: Record<NotificationType, {
     inApp: true,
   },
   [NotificationType.USER_REGISTERED]: {
-    email: false,
+    email: true,
     inApp: true,
   },
 


### PR DESCRIPTION
**Description**:
This pull request introduces a global configuration option to disable all non-transactional notification emails, along with related updates to ensure notification logic respects this setting. It also improves the flexibility of user notification preference filtering and adds comprehensive tests for notification consumer shutdown and error handling.

**Related issue(s)**:

Fixes #2990 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
