### PR TITLE
fix: ensure updated organization email is used during migration

### DIFF
--- a/front-end/src/renderer/pages/Migrate/components/SetupOrganization.vue
+++ b/front-end/src/renderer/pages/Migrate/components/SetupOrganization.vue
@@ -91,15 +91,10 @@ const handleFormSubmit: SubmitCallback = async (formData: ModelValue) => {
   loadingText.value = 'Storing encrypted credentials...';
 
   /* Add Organization Credentials */
-  let email;
-  if (props.personalUser.useKeychain) {
-    if (!formData.organizationEmail) {
-      throw new Error('(BUG) Organization email is required');
-    }
-    email = formData.organizationEmail;
-  } else {
-    email = props.personalUser.email;
+  if (!formData.organizationEmail) {
+    throw new Error('(BUG) Organization email is required');
   }
+  const email = formData.organizationEmail;
 
   const addOrganizationCredentialsResult = await safeAwait(
     addOrganizationCredentials(
@@ -140,15 +135,10 @@ const setupOrganization = async ({ organizationURL, organizationNickname }: Mode
 };
 
 const loginInOrganization = async (data: ModelValue) => {
-  let email;
-  if (props.personalUser.useKeychain) {
-    if (!data.organizationEmail) {
-      throw new Error('(BUG) Organization email is required');
-    }
-    email = data.organizationEmail;
-  } else {
-    email = props.personalUser.email;
+  if (!data.organizationEmail) {
+    throw new Error('(BUG) Organization email is required');
   }
+  const email = data.organizationEmail;
 
   const { id, jwtToken } = await login(
     data.organizationURL,

--- a/front-end/src/renderer/pages/Migrate/components/SetupOrganizationForm.vue
+++ b/front-end/src/renderer/pages/Migrate/components/SetupOrganizationForm.vue
@@ -64,9 +64,7 @@ const handleOnFormSubmit = async () => {
 
   const result = await props.submitCallback({
     organizationURL,
-    organizationEmail: props.personalUser.useKeychain
-      ? organizationEmail
-      : props.personalUser.email,
+    organizationEmail,
     organizationNickname: organizationNickname || 'Organization 1',
     temporaryOrganizationPassword,
     newOrganizationPassword,

--- a/front-end/src/renderer/pages/Migrate/components/SetupOrganizationForm.vue
+++ b/front-end/src/renderer/pages/Migrate/components/SetupOrganizationForm.vue
@@ -56,7 +56,7 @@ const handleOnFormSubmit = async () => {
 
   if (
     inputOrganizationURLInvalid.value ||
-    (props.personalUser.useKeychain ? organizationEmail.length === 0 : false) ||
+    organizationEmail.length === 0 ||
     temporaryOrganizationPassword.length === 0
   ) {
     return;
@@ -208,7 +208,7 @@ watch(
           :disabled="
             inputTemporaryOrganizationPassword.trim().length === 0 ||
             inputOrganizationURL.trim().length === 0 ||
-            (personalUser.useKeychain ? inputOrganizationEmail.length === 0 : false) ||
+            inputOrganizationEmail.trim().length === 0 ||
             inputNewOrganizationPassword.trim().length === 0 ||
             inputNewOrganizationPassword.trim() === inputTemporaryOrganizationPassword.trim()
           "

--- a/front-end/src/tests/renderer/pages/Migrate/SetupOrganization.spec.ts
+++ b/front-end/src/tests/renderer/pages/Migrate/SetupOrganization.spec.ts
@@ -1,0 +1,153 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import SetupOrganization from '@renderer/pages/Migrate/components/SetupOrganization.vue';
+import type { PersonalUser } from '@renderer/pages/Migrate/components/SetupPersonal.vue';
+
+const mocks = vi.hoisted(() => ({
+  addOrganization: vi.fn(),
+  deleteOrganization: vi.fn(),
+  login: vi.fn(),
+  changePassword: vi.fn(),
+  healthCheck: vi.fn(),
+  addOrganizationCredentials: vi.fn(),
+  toggleAuthTokenInSessionStorage: vi.fn(),
+  getVersionStatusForOrg: vi.fn(),
+}));
+
+vi.mock('@renderer/services/organizationsService', () => ({
+  addOrganization: mocks.addOrganization,
+  deleteOrganization: mocks.deleteOrganization,
+}));
+
+vi.mock('@renderer/services/organization', () => ({
+  login: mocks.login,
+  changePassword: mocks.changePassword,
+  healthCheck: mocks.healthCheck,
+}));
+
+vi.mock('@renderer/services/organizationCredentials', () => ({
+  addOrganizationCredentials: mocks.addOrganizationCredentials,
+}));
+
+vi.mock('@renderer/stores/versionState', () => ({
+  getVersionStatusForOrg: mocks.getVersionStatusForOrg,
+}));
+
+vi.mock('@renderer/utils', () => ({
+  safeAwait: async (promise: Promise<unknown>) => {
+    try {
+      const data = await promise;
+      return { data };
+    } catch (error) {
+      return { error };
+    }
+  },
+  toggleAuthTokenInSessionStorage: mocks.toggleAuthTokenInSessionStorage,
+  isPasswordStrong: vi.fn(() => ({ result: true, length: true })),
+  isUrl: vi.fn((url: string) => {
+    try {
+      new URL(url);
+      return true;
+    } catch {
+      return false;
+    }
+  }),
+}));
+
+const personalUserWithPassword: PersonalUser = {
+  personalId: 'personal-id-123',
+  useKeychain: false,
+  email: 'original@example.com',
+  password: 'personalPassword',
+};
+
+const stubs = {
+  AppButton: {
+    props: ['disabled', 'loading', 'loadingText'],
+    template: '<button v-bind="$attrs" :disabled="disabled"><slot /></button>',
+  },
+  AppInput: {
+    props: ['modelValue', 'filled'],
+    template:
+      '<input v-bind="$attrs" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+  AppPasswordInput: {
+    props: ['modelValue', 'filled'],
+    template:
+      '<input v-bind="$attrs" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+};
+
+describe('SetupOrganization.vue — email field during migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.healthCheck.mockResolvedValue(undefined);
+    mocks.getVersionStatusForOrg.mockReturnValue('ok');
+    mocks.addOrganization.mockResolvedValue({ id: 'org-id' });
+    mocks.login.mockResolvedValue({ id: 1, jwtToken: 'jwt-token' });
+    mocks.changePassword.mockResolvedValue(undefined);
+    mocks.addOrganizationCredentials.mockResolvedValue(undefined);
+  });
+
+  function mountSetupOrganization(personalUser: PersonalUser = personalUserWithPassword) {
+    return mount(SetupOrganization, {
+      props: { personalUser },
+      global: { stubs },
+    });
+  }
+
+  async function fillAndSubmit(wrapper: ReturnType<typeof mountSetupOrganization>, email: string) {
+    await wrapper.find('[data-testid="input-organization-email"]').setValue(email);
+    await wrapper.find('[data-testid="input-organization-url"]').setValue('https://org.example.com');
+    await wrapper
+      .find('[data-testid="input-temporary-organization-password"]')
+      .setValue('tempPass123');
+    await wrapper
+      .find('[data-testid="input-new-organization-password"]')
+      .setValue('newPass456');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+  }
+
+  test('email field is pre-filled with the personal user email', () => {
+    const wrapper = mountSetupOrganization();
+
+    const emailInput = wrapper.find('[data-testid="input-organization-email"]');
+    expect((emailInput.element as HTMLInputElement).value).toBe('original@example.com');
+  });
+
+  test('updated email is submitted when the user edits the pre-filled value', async () => {
+    const wrapper = mountSetupOrganization();
+
+    await fillAndSubmit(wrapper, 'updated@example.com');
+
+    expect(mocks.login).toHaveBeenCalledWith(
+      'https://org.example.com',
+      'updated@example.com',
+      'tempPass123',
+    );
+    expect(mocks.addOrganizationCredentials).toHaveBeenCalledWith(
+      'updated@example.com',
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  test('original email is not used when the user has changed it', async () => {
+    const wrapper = mountSetupOrganization();
+
+    await fillAndSubmit(wrapper, 'updated@example.com');
+
+    expect(mocks.login).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'original@example.com',
+      expect.anything(),
+    );
+  });
+});

--- a/front-end/src/tests/renderer/pages/Migrate/SetupOrganization.spec.ts
+++ b/front-end/src/tests/renderer/pages/Migrate/SetupOrganization.spec.ts
@@ -56,13 +56,6 @@ vi.mock('@renderer/utils', () => ({
   }),
 }));
 
-const personalUserWithPassword: PersonalUser = {
-  personalId: 'personal-id-123',
-  useKeychain: false,
-  email: 'original@example.com',
-  password: 'personalPassword',
-};
-
 const stubs = {
   AppButton: {
     props: ['disabled', 'loading', 'loadingText'],
@@ -91,7 +84,7 @@ describe('SetupOrganization.vue — email field during migration', () => {
     mocks.addOrganizationCredentials.mockResolvedValue(undefined);
   });
 
-  function mountSetupOrganization(personalUser: PersonalUser = personalUserWithPassword) {
+  function mountSetupOrganization(personalUser: PersonalUser) {
     return mount(SetupOrganization, {
       props: { personalUser },
       global: { stubs },
@@ -104,50 +97,94 @@ describe('SetupOrganization.vue — email field during migration', () => {
     await wrapper
       .find('[data-testid="input-temporary-organization-password"]')
       .setValue('tempPass123');
-    await wrapper
-      .find('[data-testid="input-new-organization-password"]')
-      .setValue('newPass456');
+    await wrapper.find('[data-testid="input-new-organization-password"]').setValue('newPass456');
     await wrapper.find('form').trigger('submit');
     await flushPromises();
   }
 
-  test('email field is pre-filled with the personal user email', () => {
-    const wrapper = mountSetupOrganization();
+  describe('non-keychain (email/password) user', () => {
+    const personalUser: PersonalUser = {
+      personalId: 'personal-id-123',
+      useKeychain: false,
+      email: 'original@example.com',
+      password: 'personalPassword',
+    };
 
-    const emailInput = wrapper.find('[data-testid="input-organization-email"]');
-    expect((emailInput.element as HTMLInputElement).value).toBe('original@example.com');
+    test('email field is pre-filled with the personal user email', () => {
+      const wrapper = mountSetupOrganization(personalUser);
+
+      const emailInput = wrapper.find('[data-testid="input-organization-email"]');
+      expect((emailInput.element as HTMLInputElement).value).toBe('original@example.com');
+    });
+
+    test('updated email is submitted when the user edits the pre-filled value', async () => {
+      const wrapper = mountSetupOrganization(personalUser);
+
+      await fillAndSubmit(wrapper, 'updated@example.com');
+
+      expect(mocks.login).toHaveBeenCalledWith(
+        'https://org.example.com',
+        'updated@example.com',
+        'tempPass123',
+      );
+      expect(mocks.addOrganizationCredentials).toHaveBeenCalledWith(
+        'updated@example.com',
+        'newPass456',
+        'org-id',
+        'personal-id-123',
+        'jwt-token',
+        'personalPassword',
+        true,
+      );
+    });
+
+    test('original email is not used when the user has changed it', async () => {
+      const wrapper = mountSetupOrganization(personalUser);
+
+      await fillAndSubmit(wrapper, 'updated@example.com');
+
+      expect(mocks.login).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'original@example.com',
+        expect.anything(),
+      );
+    });
   });
 
-  test('updated email is submitted when the user edits the pre-filled value', async () => {
-    const wrapper = mountSetupOrganization();
+  describe('keychain user', () => {
+    const personalUser: PersonalUser = {
+      personalId: 'personal-id-123',
+      useKeychain: true,
+      email: null,
+      password: null,
+    };
 
-    await fillAndSubmit(wrapper, 'updated@example.com');
+    test('email field is empty (not pre-filled) when using keychain auth', () => {
+      const wrapper = mountSetupOrganization(personalUser);
 
-    expect(mocks.login).toHaveBeenCalledWith(
-      'https://org.example.com',
-      'updated@example.com',
-      'tempPass123',
-    );
-    expect(mocks.addOrganizationCredentials).toHaveBeenCalledWith(
-      'updated@example.com',
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
-    );
-  });
+      const emailInput = wrapper.find('[data-testid="input-organization-email"]');
+      expect((emailInput.element as HTMLInputElement).value).toBe('');
+    });
 
-  test('original email is not used when the user has changed it', async () => {
-    const wrapper = mountSetupOrganization();
+    test('entered organization email is used for login and credential storage', async () => {
+      const wrapper = mountSetupOrganization(personalUser);
 
-    await fillAndSubmit(wrapper, 'updated@example.com');
+      await fillAndSubmit(wrapper, 'org@example.com');
 
-    expect(mocks.login).not.toHaveBeenCalledWith(
-      expect.anything(),
-      'original@example.com',
-      expect.anything(),
-    );
+      expect(mocks.login).toHaveBeenCalledWith(
+        'https://org.example.com',
+        'org@example.com',
+        'tempPass123',
+      );
+      expect(mocks.addOrganizationCredentials).toHaveBeenCalledWith(
+        'org@example.com',
+        'newPass456',
+        'org-id',
+        'personal-id-123',
+        'jwt-token',
+        null,
+        true,
+      );
+    });
   });
 });


### PR DESCRIPTION
**Description**:
This pull request simplifies how the organization email is handled during the organization setup and migration process, ensuring that the email entered by the user is always used, regardless of their keychain settings. Additionally, it introduces comprehensive tests to verify this behavior.

**Related issue(s)**:

Fixes #2993 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
