### PR TITLE
fix: Registered Node Create draft editor now reports invalid payer id as informational message

### DIFF
--- a/front-end/src/renderer/components/AccountIdInput.vue
+++ b/front-end/src/renderer/components/AccountIdInput.vue
@@ -11,7 +11,6 @@ import { getAll } from '@renderer/services/accountsService';
 import {
   formatAccountId,
   getAccountIdWithChecksum,
-  isNodeCreationAuthorizedFeePayer,
   isUserLoggedIn,
 } from '@renderer/utils';
 
@@ -24,7 +23,6 @@ const props = defineProps<{
   modelValue: string;
   items?: string[];
   dataTestid?: string;
-  isNodeCreationPrivRequired?: boolean;
 }>();
 
 /* Emits */
@@ -58,10 +56,6 @@ const formattedAccountIds = computed(() => {
     } else {
       result = [];
     }
-  }
-  if (props.isNodeCreationPrivRequired) {
-    // We keep privileged accounts only
-    result = result.filter(accountId => isNodeCreationAuthorizedFeePayer(accountId));
   }
   return result.map(id => getAccountIdWithChecksum(id));
 });

--- a/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
@@ -117,7 +117,7 @@ const columnClass = 'col-4 col-xxxl-3';
           v-else-if="
             props.isNodeCreationPrivRequired && !isNodeCreationAuthorizedFeePayer(props.payerId)
           "
-          class="text-warning bi bi-exclamation-triangle-fill me-1"
+          class="text-info bi bi-exclamation-circle-fill me-1"
         >
           Account ID should belong to the 0.0.2-0.0.55 range
         </span>

--- a/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionIdControls.vue
@@ -96,7 +96,6 @@ const columnClass = 'col-4 col-xxxl-3';
         @update:modelValue="handlePayerChange"
         :filled="true"
         placeholder="Enter Payer ID"
-        :is-node-creation-priv-required="props.isNodeCreationPrivRequired"
         data-testid="input-payer-account"
       />
       <div class="text-micro mt-2">


### PR DESCRIPTION
**Description**:
Changes below update `Payer ID` validation logic in `Registered Node Create` transaction draft editor.
- `Account ID should belong to 0.0.2-0.0.55` is now styled as an informational message
- accounts in `Payer ID` suggestion dropdown are no longer limited to privileged accounts

<img width="431" height="132" alt="image" src="https://github.com/user-attachments/assets/8e4db342-d070-4f74-a14e-b9c1d8d509cb" />

**Related issue(s)**:

Fixes #3036

**Notes for reviewer**:
```
M   front-end/src/renderer/components/Transaction/TransactionIdControls.vue
M   front-end/src/renderer/components/AccountIdInput.vue
    # Removed privilege account filtering from AccountIdInput and TransactionIdControls.
```
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
