### PR TITLE
feat: close task issue automatically at the end of release automation

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -569,18 +569,14 @@ jobs:
               gh issue comment "$EXISTING" \
                 --body "Release Automation completed for **v${VERSION}**. The automated steps are done — proceed with the Publish Release and Final deployment checklists." \
                 --repo ${{ github.repository }}
+              gh issue close "$EXISTING" \
+                --repo ${{ github.repository }}
             fi
-          else
-            if [ -n "$PRERELEASE" ]; then
-              ISSUE_BODY=$(sed \
-                  -e "s|<major\.minor\.patch>-beta\.<number>|${VERSION}|g" \
-                  -e "s|<major\.minor\.patch>|${RELEASE_VERSION}|g" \
-                  docs/release-process.md)
-            else
-              ISSUE_BODY=$(sed \
-                  -e "s|<major\.minor\.patch>|${VERSION}|g" \
-                  docs/release-process.md)
-            fi
+          elif [ -n "$PRERELEASE" ]; then
+            ISSUE_BODY=$(sed \
+                -e "s|<major\.minor\.patch>-beta\.<number>|${VERSION}|g" \
+                -e "s|<major\.minor\.patch>|${RELEASE_VERSION}|g" \
+                docs/release-process.md)
 
             # Substitute or remove the SNAPSHOT bump PR line.
             if [ "$CREATE_PR" = "true" ]; then

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -19,7 +19,6 @@
 ### Pre-requisites
 - [ ] Beta `v<major.minor.patch>-beta.<number>` deployed and stable
 - [ ] Run performance tests against `staging`
-- [ ] Manual testing issue created from `docs/test-scenarios.md`
 - [ ] Manual testing completed and beta approved
 
 ### Publish Release

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -23,6 +23,7 @@
 - [ ] Manual testing completed and beta approved
 
 ### Publish Release
+- [ ] Trigger the Release Automation workflow with version `<major.minor.patch>`
 - [ ] Add a short description to the GitHub release draft for `v<major.minor.patch>`
 - [ ] Publish the GitHub release draft
 


### PR DESCRIPTION
**Description**:
This pull request updates the release automation workflow to close the created issue on a GA release, if the issue exists. The pull request also prevents a GA release, with no related beta releases, from creating the task issue. 

`release-process.md` also updated to reflect the current process.

**Related issue(s)**:

Fixes #3068 

