### PR TITLE
fix: removing usage of v-html

### DIFF
--- a/front-end/src/renderer/components/ui/AppStepper.vue
+++ b/front-end/src/renderer/components/ui/AppStepper.vue
@@ -23,22 +23,6 @@ const isCompleted = (index: number) => {
     index < props.activeIndex || (props.activeIndex === index && index === props.items.length - 1)
   );
 };
-
-const getBubbleContent = (index: number, item: { bubbleIcon?: string; bubbleLabel?: string }) => {
-  if (isActive(index) || props.activeIndex < index) {
-    return index + 1;
-  } else if (isCompleted(index)) {
-    if (item.bubbleIcon) {
-      return `<i class="bi bi-${item.bubbleIcon}"></i>`;
-    } else if (item.bubbleLabel) {
-      return item.bubbleLabel;
-    } else {
-      return '<i class="bi bi-check-lg"></i>';
-    }
-  } else {
-    return '<i class="bi bi-check-lg"></i>';
-  }
-};
 </script>
 <template>
   <div class="stepper">
@@ -55,8 +39,15 @@ const getBubbleContent = (index: number, item: { bubbleIcon?: string; bubbleLabe
               class="stepper-nav-item-bubble text-small rounded-circle border border-dark p-2"
               :class="[isCompleted(index) ? item.bubbleClass : '']"
               :data-testid="`div-stepper-nav-item-bubble-${index}`"
-              v-html="getBubbleContent(index, item)"
-            ></div>
+            >
+              <span v-if="isActive(index) || props.activeIndex < index"> {{ index + 1 }}</span>
+              <template v-else-if="isCompleted(index)">
+                <i v-if="item.bubbleIcon" :class="['bi', `bi-${item.bubbleIcon}`]" />
+                <span v-else-if="item.bubbleLabel">{{ item.bubbleLabel }}</span>
+                <i v-else class="bi bi-check-lg" />
+              </template>
+              <i v-else class="bi bi-check-lg" />
+            </div>
             <span
               :data-testid="`stepper-title-${index}`"
               class="stepper-nav-item-title text-micro position-absolute mt-3"

--- a/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
+++ b/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
@@ -418,10 +418,7 @@ onBeforeRouteLeave(async to => {
                 class="text-truncate flex-grow-1 text-center"
                 :data-testid="'span-transaction-timestamp-' + index"
               >
-                <span
-                  v-if="groupItem.transferSummary"
-                  v-html="groupItem.transferSummary"
-                />
+                <span v-if="groupItem.transferSummary">{{ groupItem.transferSummary }}</span>
                 <template v-else>{{
                   groupItem.description !== ''
                     ? groupItem.description

--- a/front-end/src/renderer/utils/index.ts
+++ b/front-end/src/renderer/utils/index.ts
@@ -176,7 +176,7 @@ export const getAccountIdWithChecksum = (accountId: string): string => {
 
 const TINYBAR_THRESHOLD = 1_000_000;
 
-export function stringifyHbarWithFont(hbar: Hbar, fontClass = 'text-bold text-secondary'): string {
+export function stringifyHbarOrTinybar(hbar: Hbar): string {
   const amount = hbar.isNegative() ? hbar.toTinybars().negate() : hbar.toTinybars();
   const showTinybars = amount.lessThan(Long.fromNumber(TINYBAR_THRESHOLD));
 
@@ -185,7 +185,7 @@ export function stringifyHbarWithFont(hbar: Hbar, fontClass = 'text-bold text-se
     : Hbar.fromTinybars(amount).toBigNumber().toString();
   const displayUnit = showTinybars ? HbarUnit.Tinybar._symbol : HbarUnit.Hbar._symbol;
 
-  return `${displayAmount} <span class="${fontClass}">${displayUnit}</span>`;
+  return `${displayAmount} ${displayUnit}`;
 }
 
 export async function collectRequiredKeys(

--- a/front-end/src/renderer/utils/transferTransactions.ts
+++ b/front-end/src/renderer/utils/transferTransactions.ts
@@ -1,6 +1,6 @@
 import type { Transfer } from '@hiero-ledger/sdk';
 
-import { stringifyHbarWithFont } from './index';
+import { stringifyHbarOrTinybar } from './index';
 
 export function formatHbarTransfers(transfers: Transfer[]): string {
   if (transfers.length === 0) {
@@ -26,7 +26,7 @@ export function formatHbarTransfers(transfers: Transfer[]): string {
       sender = transfers[1];
       receiver = transfers[0];
     }
-    return `${sender.accountId} --> ${stringifyHbarWithFont(receiver.amount)} --> ${receiver.accountId}`;
+    return `${sender.accountId} --> ${stringifyHbarOrTinybar(receiver.amount)} --> ${receiver.accountId}`;
   }
 
   return 'Multiple transfers';


### PR DESCRIPTION
**Description**:
Changes below the two occurrences of `v-html`.

**Related issue(s)**:

Contributes to #2937 

**Notes for reviewer**:

```
M   front-end/src/...components/ui/AppStepper.vue
    # Remove usage of v-html (getBubbleContent() method)

M   front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
M   front-end/src/renderer/utils/index.ts
M   front-end/src/renderer/utils/transaction.ts
    # stringifyHbarWithFont() now returns plain text and is renamed stringifyHbarOrTinybar()
    # CreateTransactionGroup no longer to use v-html
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
