### PR TITLE
feat: add additional metadata fields to transaction signer entity

### DIFF
--- a/back-end/apps/api/src/transactions/dto/transaction-signer.dto.ts
+++ b/back-end/apps/api/src/transactions/dto/transaction-signer.dto.ts
@@ -13,6 +13,15 @@ export class TransactionSignerDto {
   userKeyId: number;
 
   @Expose()
+  recorderId: number | null;
+
+  @Expose()
+  tool: string | null;
+
+  @Expose()
+  version: string | null;
+
+  @Expose()
   createdAt: Date;
 }
 
@@ -26,6 +35,15 @@ export class TransactionSignerUserKeyDto {
   @Expose()
   @Type(() => UserKeyCoreDto)
   userKey: UserKeyCoreDto;
+
+  @Expose()
+  recorderId: number | null;
+
+  @Expose()
+  tool: string | null;
+
+  @Expose()
+  version: string | null;
 
   @Expose()
   createdAt: Date;
@@ -42,6 +60,15 @@ export class TransactionSignerFullDto {
   @Expose()
   @Type(() => UserKeyCoreDto)
   userKey: UserKeyCoreDto;
+
+  @Expose()
+  recorderId: number | null;
+
+  @Expose()
+  tool: string | null;
+
+  @Expose()
+  version: string | null;
 
   @Expose()
   createdAt: Date;

--- a/back-end/apps/api/src/transactions/dto/upload-signature.dto.ts
+++ b/back-end/apps/api/src/transactions/dto/upload-signature.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 import { IsSignatureMap } from '@app/common';
-import { IsDefined, IsNotEmptyObject, IsNumber } from 'class-validator';
+import { IsDefined, IsNotEmptyObject, IsNumber, IsOptional, IsString } from 'class-validator';
 import { SignatureMap } from '@hiero-ledger/sdk';
 
 export class UploadSignatureMapDto {
@@ -40,4 +40,9 @@ export class UploadSignatureMapDto {
   @IsNotEmptyObject()
   @IsSignatureMap()
   signatureMap: SignatureMap;
+
+  @ApiProperty({ description: 'Signing tool identifier (v1, v2, api)', required: false })
+  @IsOptional()
+  @IsString()
+  tool?: string;
 }

--- a/back-end/apps/api/src/transactions/dto/upload-signature.dto.ts
+++ b/back-end/apps/api/src/transactions/dto/upload-signature.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 import { IsSignatureMap } from '@app/common';
-import { IsDefined, IsNotEmptyObject, IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsDefined, IsIn, IsNotEmptyObject, IsNumber, IsOptional } from 'class-validator';
 import { SignatureMap } from '@hiero-ledger/sdk';
 
 export class UploadSignatureMapDto {
@@ -41,8 +41,8 @@ export class UploadSignatureMapDto {
   @IsSignatureMap()
   signatureMap: SignatureMap;
 
-  @ApiProperty({ description: 'Signing tool identifier (v1, v2, api)', required: false })
+  @ApiProperty({ description: 'Signing tool identifier', enum: ['v1', 'v2', 'api'], required: false })
   @IsOptional()
-  @IsString()
+  @IsIn(['v1', 'v2', 'api'])
   tool?: string;
 }

--- a/back-end/apps/api/src/transactions/signers/signers.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.controller.spec.ts
@@ -255,5 +255,37 @@ describe('SignaturesController', () => {
 
       expect(signersService.uploadSignatureMaps).toHaveBeenCalledWith([transformedDto], user, null);
     });
+
+    it('should strip a leading v from the version header before forwarding', async () => {
+      const dtoInput = { id: 1, signatureMap: new SignatureMap() };
+      const transformedDto = { transformed: 'value' };
+
+      (plainToInstance as jest.Mock).mockReturnValueOnce(transformedDto);
+      (validateOrReject as jest.Mock).mockResolvedValue(undefined);
+      (signersService.uploadSignatureMaps as jest.Mock).mockResolvedValue({
+        signers: [],
+        notificationReceiverIds: [],
+      });
+
+      await controller.uploadSignatureMap(dtoInput, user, undefined, 'v1.5.0');
+
+      expect(signersService.uploadSignatureMaps).toHaveBeenCalledWith([transformedDto], user, '1.5.0');
+    });
+
+    it('should pass null for an invalid version string', async () => {
+      const dtoInput = { id: 1, signatureMap: new SignatureMap() };
+      const transformedDto = { transformed: 'value' };
+
+      (plainToInstance as jest.Mock).mockReturnValueOnce(transformedDto);
+      (validateOrReject as jest.Mock).mockResolvedValue(undefined);
+      (signersService.uploadSignatureMaps as jest.Mock).mockResolvedValue({
+        signers: [],
+        notificationReceiverIds: [],
+      });
+
+      await controller.uploadSignatureMap(dtoInput, user, undefined, 'not-a-version');
+
+      expect(signersService.uploadSignatureMaps).toHaveBeenCalledWith([transformedDto], user, null);
+    });
   });
 });

--- a/back-end/apps/api/src/transactions/signers/signers.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.controller.spec.ts
@@ -86,6 +86,10 @@ describe('SignaturesController', () => {
       userId: 1,
       userKey: null,
       userKeyId: 0,
+      recorder: null,
+      recorderId: null,
+      tool: null,
+      version: null,
     };
   });
 
@@ -134,7 +138,7 @@ describe('SignaturesController', () => {
 
       expect(plainToInstance).toHaveBeenCalledWith(UploadSignatureMapDto, dtoInput);
       expect(validateOrReject).toHaveBeenCalledWith(transformedDto);
-      expect(signersService.uploadSignatureMaps).toHaveBeenCalledWith([transformedDto], user);
+      expect(signersService.uploadSignatureMaps).toHaveBeenCalledWith([transformedDto], user, null);
       expect(result).toEqual(expectedSigners);
     });
 
@@ -161,7 +165,7 @@ describe('SignaturesController', () => {
       expect((plainToInstance as jest.Mock).mock.calls[0]).toEqual([UploadSignatureMapDto, dtoInput[0]]);
       expect((plainToInstance as jest.Mock).mock.calls[1]).toEqual([UploadSignatureMapDto, dtoInput[1]]);
       expect(validateOrReject).toHaveBeenCalledTimes(2);
-      expect(signersService.uploadSignatureMaps).toHaveBeenCalledWith(transformedDtos, user);
+      expect(signersService.uploadSignatureMaps).toHaveBeenCalledWith(transformedDtos, user, null);
       expect(result).toEqual(expectedSigners);
     });
 
@@ -218,6 +222,38 @@ describe('SignaturesController', () => {
       const result = await controller.uploadSignatureMap(dtoInput, user);
 
       expect(result).toEqual(expectedSigners);
+    });
+
+    it('should forward x-frontend-version header to uploadSignatureMaps', async () => {
+      const dtoInput = { id: 1, signatureMap: new SignatureMap() };
+      const transformedDto = { transformed: 'value' };
+
+      (plainToInstance as jest.Mock).mockReturnValueOnce(transformedDto);
+      (validateOrReject as jest.Mock).mockResolvedValue(undefined);
+      (signersService.uploadSignatureMaps as jest.Mock).mockResolvedValue({
+        signers: [],
+        notificationReceiverIds: [],
+      });
+
+      await controller.uploadSignatureMap(dtoInput, user, undefined, '1.5.0');
+
+      expect(signersService.uploadSignatureMaps).toHaveBeenCalledWith([transformedDto], user, '1.5.0');
+    });
+
+    it('should pass null version when header is absent', async () => {
+      const dtoInput = { id: 1, signatureMap: new SignatureMap() };
+      const transformedDto = { transformed: 'value' };
+
+      (plainToInstance as jest.Mock).mockReturnValueOnce(transformedDto);
+      (validateOrReject as jest.Mock).mockResolvedValue(undefined);
+      (signersService.uploadSignatureMaps as jest.Mock).mockResolvedValue({
+        signers: [],
+        notificationReceiverIds: [],
+      });
+
+      await controller.uploadSignatureMap(dtoInput, user);
+
+      expect(signersService.uploadSignatureMaps).toHaveBeenCalledWith([transformedDto], user, null);
     });
   });
 });

--- a/back-end/apps/api/src/transactions/signers/signers.controller.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.controller.ts
@@ -20,6 +20,7 @@ import {
   transformAndValidateDto,
   withPaginatedResponse,
 } from '@app/common';
+import * as semver from 'semver';
 import { TransactionSigner, User } from '@entities';
 
 import { JwtAuthGuard, JwtBlackListAuthGuard, VerifiedUserGuard } from '../../guards';
@@ -112,7 +113,7 @@ export class SignersController {
     const { signers, notificationReceiverIds } = await this.signaturesService.uploadSignatureMaps(
       transformedSignatureMaps,
       user,
-      version ?? null,
+      version ? semver.clean(version) ?? null : null,
     );
 
     if (includeNotifications) {

--- a/back-end/apps/api/src/transactions/signers/signers.controller.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Get,
+  Headers,
   HttpCode,
   Param,
   ParseIntPipe,
@@ -104,12 +105,14 @@ export class SignersController {
     @Body() body: UploadSignatureMapDto | UploadSignatureMapDto[],
     @GetUser() user: User,
     @Query('includeNotifications') includeNotifications?: boolean,
+    @Headers('x-frontend-version') version?: string,
   ): Promise<TransactionSigner[] | UploadSignatureMapResponseDto> {
     const transformedSignatureMaps = await transformAndValidateDto(UploadSignatureMapDto, body);
 
     const { signers, notificationReceiverIds } = await this.signaturesService.uploadSignatureMaps(
       transformedSignatureMaps,
       user,
+      version ?? null,
     );
 
     if (includeNotifications) {

--- a/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
@@ -1191,7 +1191,7 @@ describe('SignersService', () => {
       user.keys[0].publicKey = originalPublicKey;
     });
 
-    it('should use null tool when not provided in dto', async () => {
+    it('should default tool to api when not provided in dto', async () => {
       const transactionId = 3;
       const originalPublicKey = user.keys[0].publicKey;
       const privateKey = PrivateKey.generateECDSA();
@@ -1239,7 +1239,7 @@ describe('SignersService', () => {
         null,
       );
 
-      expect(valuesCapture[0]).toMatchObject({ tool: null });
+      expect(valuesCapture[0]).toMatchObject({ tool: 'api' });
 
       user.keys[0].publicKey = originalPublicKey;
     });

--- a/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
@@ -530,7 +530,7 @@ describe('SignersService', () => {
       };
       mockManager.createQueryBuilder.mockReturnValue(mockQueryBuilder);
 
-      const signersToInsert = [{ userId: 1, transactionId: 1, userKeyId: 3 }];
+      const signersToInsert = [{ userId: 1, transactionId: 1, userKeyId: 3, recorderId: 1, tool: 'v2', version: '1.0.0' }];
 
       const result = await service['bulkInsertSigners'](mockManager, signersToInsert);
 
@@ -1083,6 +1083,218 @@ describe('SignersService', () => {
       expect(result.notificationReceiverIds).toEqual([]);
 
       consoleError.mockRestore();
+    });
+
+    it('should set recorderId to user.id on signer rows', async () => {
+      const transactionId = 3;
+      const originalPublicKey = user.keys[0].publicKey;
+      const privateKey = PrivateKey.generateECDSA();
+      user.keys[0].publicKey = privateKey.publicKey.toStringRaw();
+
+      const sdkTransaction = new AccountCreateTransaction()
+        .setTransactionId(TransactionId.generate('0.0.2'))
+        .setNodeAccountIds([AccountId.fromString('0.0.3')])
+        .freeze();
+
+      const transaction = {
+        id: transactionId,
+        transactionBytes: sdkTransaction.toBytes(),
+        status: TransactionStatus.WAITING_FOR_EXECUTION,
+      };
+
+      await sdkTransaction.sign(privateKey);
+
+      dataSource.manager.find.mockResolvedValueOnce([transaction]);
+      dataSource.manager.find.mockResolvedValueOnce([]);
+      jest.mocked(isExpired).mockReturnValue(false);
+
+      const valuesCapture: any[] = [];
+      const mockManager = mockDeep<any>();
+      mockManager.query
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([[], 0]);
+      mockManager.createQueryBuilder.mockReturnValue({
+        insert: jest.fn().mockReturnThis(),
+        into: jest.fn().mockReturnThis(),
+        values: jest.fn().mockImplementation((v) => { valuesCapture.push(...v); return { returning: jest.fn().mockReturnThis(), execute: jest.fn().mockResolvedValue({ raw: [] }) }; }),
+        returning: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ raw: [] }),
+      });
+
+      (dataSource.transaction as jest.Mock).mockImplementation(async (arg1: any, arg2?: any) => {
+        const callback = typeof arg1 === 'function' ? arg1 : arg2;
+        return callback(mockManager);
+      });
+      jest.mocked(processTransactionStatus).mockResolvedValue(new Map());
+
+      await service.uploadSignatureMaps(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        user,
+        null,
+      );
+
+      expect(valuesCapture[0]).toMatchObject({ recorderId: user.id });
+
+      user.keys[0].publicKey = originalPublicKey;
+    });
+
+    it('should set tool from dto item on signer rows', async () => {
+      const transactionId = 3;
+      const originalPublicKey = user.keys[0].publicKey;
+      const privateKey = PrivateKey.generateECDSA();
+      user.keys[0].publicKey = privateKey.publicKey.toStringRaw();
+
+      const sdkTransaction = new AccountCreateTransaction()
+        .setTransactionId(TransactionId.generate('0.0.2'))
+        .setNodeAccountIds([AccountId.fromString('0.0.3')])
+        .freeze();
+
+      const transaction = {
+        id: transactionId,
+        transactionBytes: sdkTransaction.toBytes(),
+        status: TransactionStatus.WAITING_FOR_EXECUTION,
+      };
+
+      await sdkTransaction.sign(privateKey);
+
+      dataSource.manager.find.mockResolvedValueOnce([transaction]);
+      dataSource.manager.find.mockResolvedValueOnce([]);
+      jest.mocked(isExpired).mockReturnValue(false);
+
+      const valuesCapture: any[] = [];
+      const mockManager = mockDeep<any>();
+      mockManager.query
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([[], 0]);
+      mockManager.createQueryBuilder.mockReturnValue({
+        insert: jest.fn().mockReturnThis(),
+        into: jest.fn().mockReturnThis(),
+        values: jest.fn().mockImplementation((v) => { valuesCapture.push(...v); return { returning: jest.fn().mockReturnThis(), execute: jest.fn().mockResolvedValue({ raw: [] }) }; }),
+        returning: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ raw: [] }),
+      });
+
+      (dataSource.transaction as jest.Mock).mockImplementation(async (arg1: any, arg2?: any) => {
+        const callback = typeof arg1 === 'function' ? arg1 : arg2;
+        return callback(mockManager);
+      });
+      jest.mocked(processTransactionStatus).mockResolvedValue(new Map());
+
+      await service.uploadSignatureMaps(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures(), tool: 'v1' }],
+        user,
+        null,
+      );
+
+      expect(valuesCapture[0]).toMatchObject({ tool: 'v1' });
+
+      user.keys[0].publicKey = originalPublicKey;
+    });
+
+    it('should use null tool when not provided in dto', async () => {
+      const transactionId = 3;
+      const originalPublicKey = user.keys[0].publicKey;
+      const privateKey = PrivateKey.generateECDSA();
+      user.keys[0].publicKey = privateKey.publicKey.toStringRaw();
+
+      const sdkTransaction = new AccountCreateTransaction()
+        .setTransactionId(TransactionId.generate('0.0.2'))
+        .setNodeAccountIds([AccountId.fromString('0.0.3')])
+        .freeze();
+
+      const transaction = {
+        id: transactionId,
+        transactionBytes: sdkTransaction.toBytes(),
+        status: TransactionStatus.WAITING_FOR_EXECUTION,
+      };
+
+      await sdkTransaction.sign(privateKey);
+
+      dataSource.manager.find.mockResolvedValueOnce([transaction]);
+      dataSource.manager.find.mockResolvedValueOnce([]);
+      jest.mocked(isExpired).mockReturnValue(false);
+
+      const valuesCapture: any[] = [];
+      const mockManager = mockDeep<any>();
+      mockManager.query
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([[], 0]);
+      mockManager.createQueryBuilder.mockReturnValue({
+        insert: jest.fn().mockReturnThis(),
+        into: jest.fn().mockReturnThis(),
+        values: jest.fn().mockImplementation((v) => { valuesCapture.push(...v); return { returning: jest.fn().mockReturnThis(), execute: jest.fn().mockResolvedValue({ raw: [] }) }; }),
+        returning: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ raw: [] }),
+      });
+
+      (dataSource.transaction as jest.Mock).mockImplementation(async (arg1: any, arg2?: any) => {
+        const callback = typeof arg1 === 'function' ? arg1 : arg2;
+        return callback(mockManager);
+      });
+      jest.mocked(processTransactionStatus).mockResolvedValue(new Map());
+
+      await service.uploadSignatureMaps(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        user,
+        null,
+      );
+
+      expect(valuesCapture[0]).toMatchObject({ tool: null });
+
+      user.keys[0].publicKey = originalPublicKey;
+    });
+
+    it('should set version from parameter on signer rows', async () => {
+      const transactionId = 3;
+      const originalPublicKey = user.keys[0].publicKey;
+      const privateKey = PrivateKey.generateECDSA();
+      user.keys[0].publicKey = privateKey.publicKey.toStringRaw();
+
+      const sdkTransaction = new AccountCreateTransaction()
+        .setTransactionId(TransactionId.generate('0.0.2'))
+        .setNodeAccountIds([AccountId.fromString('0.0.3')])
+        .freeze();
+
+      const transaction = {
+        id: transactionId,
+        transactionBytes: sdkTransaction.toBytes(),
+        status: TransactionStatus.WAITING_FOR_EXECUTION,
+      };
+
+      await sdkTransaction.sign(privateKey);
+
+      dataSource.manager.find.mockResolvedValueOnce([transaction]);
+      dataSource.manager.find.mockResolvedValueOnce([]);
+      jest.mocked(isExpired).mockReturnValue(false);
+
+      const valuesCapture: any[] = [];
+      const mockManager = mockDeep<any>();
+      mockManager.query
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([[], 0]);
+      mockManager.createQueryBuilder.mockReturnValue({
+        insert: jest.fn().mockReturnThis(),
+        into: jest.fn().mockReturnThis(),
+        values: jest.fn().mockImplementation((v) => { valuesCapture.push(...v); return { returning: jest.fn().mockReturnThis(), execute: jest.fn().mockResolvedValue({ raw: [] }) }; }),
+        returning: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ raw: [] }),
+      });
+
+      (dataSource.transaction as jest.Mock).mockImplementation(async (arg1: any, arg2?: any) => {
+        const callback = typeof arg1 === 'function' ? arg1 : arg2;
+        return callback(mockManager);
+      });
+      jest.mocked(processTransactionStatus).mockResolvedValue(new Map());
+
+      await service.uploadSignatureMaps(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        user,
+        '0.35.0',
+      );
+
+      expect(valuesCapture[0]).toMatchObject({ version: '0.35.0' });
+
+      user.keys[0].publicKey = originalPublicKey;
     });
   });
 });

--- a/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.service.spec.ts
@@ -159,6 +159,9 @@ describe('SignersService', () => {
           id: true,
           transactionId: true,
           userKeyId: true,
+          recorderId: true,
+          tool: true,
+          version: true,
           createdAt: true,
         },
         withDeleted: true,
@@ -940,7 +943,7 @@ describe('SignersService', () => {
         user,
       );
 
-      expect(consoleError).toHaveBeenCalledWith(`[TX ${transactionId}] Error:`, 'Fail');
+      expect(consoleError).toHaveBeenCalledWith(`[TX ${transactionId}] Error:`, expect.objectContaining({ message: 'Fail' }));
       expect(result.signers).toHaveLength(0);
       expect(result.notificationReceiverIds).toEqual([]);
 

--- a/back-end/apps/api/src/transactions/signers/signers.service.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.service.ts
@@ -100,6 +100,7 @@ export class SignersService {
   async uploadSignatureMaps(
     dto: UploadSignatureMapDto[],
     user: User,
+    version: string | null = null,
   ): Promise<{ signers: TransactionSigner[]; notificationReceiverIds: number[] }> {
     // Load all necessary data
     const { transactionMap, signersByTransaction } = await this.loadTransactionData(dto);
@@ -113,7 +114,7 @@ export class SignersService {
     );
 
     // Persist changes to database
-    const { transactionsToProcess, signers, notificationsToDismiss } = await this.persistSignatureChanges(validationResults, user);
+    const { transactionsToProcess, signers, notificationsToDismiss } = await this.persistSignatureChanges(validationResults, user, version);
 
     // Update transaction statuses and emit notifications
     await this.updateStatusesAndNotify(transactionsToProcess);
@@ -166,7 +167,7 @@ export class SignersService {
     }
 
     return Promise.all(
-      dto.map(async ({ id, signatureMap: map }) => {
+      dto.map(async ({ id, signatureMap: map, tool }) => {
         try {
           const transaction = transactionMap.get(id);
           if (!transaction) return { id, error: ErrorCodes.TNF };
@@ -189,6 +190,7 @@ export class SignersService {
             sdkTransaction,
             userKeys,
             isSameBytes,
+            tool: tool ?? null,
             error: null,
           };
         } catch (err) {
@@ -264,6 +266,7 @@ export class SignersService {
   private async persistSignatureChanges(
     validationResults: any[],
     user: User,
+    version: string | null,
   ) {
     const signers = new Set<TransactionSigner>();
     let notificationsToDismiss: number[] = [];
@@ -271,7 +274,7 @@ export class SignersService {
     // Prepare batched operations
     const transactionsToUpdate: { id: number; transactionBytes: Buffer }[] = [];
     const notificationsToUpdate: { userId: number; transactionId: number }[] = [];
-    const signersToInsert: { userId: number; transactionId: number; userKeyId: number }[] = [];
+    const signersToInsert: { userId: number; transactionId: number; userKeyId: number; recorderId: number; tool: string | null; version: string | null }[] = [];
     const transactionsToProcess: { id: number; transaction: Transaction }[] = [];
 
     for (const result of validationResults) {
@@ -280,7 +283,7 @@ export class SignersService {
         continue;
       }
 
-      const { id, transaction, sdkTransaction, userKeys, isSameBytes } = result;
+      const { id, transaction, sdkTransaction, userKeys, isSameBytes, tool } = result;
 
       // Skip if nothing to do - no signatures were added to the transaction
       // AND no new signers were inserted (the signature can be present on the transaction
@@ -299,6 +302,9 @@ export class SignersService {
           userId: user.id,
           transactionId: id,
           userKeyId: userKey.id,
+          recorderId: user.id,
+          tool,
+          version,
         }));
         signersToInsert.push(...newSigners);
       }

--- a/back-end/apps/api/src/transactions/signers/signers.service.ts
+++ b/back-end/apps/api/src/transactions/signers/signers.service.ts
@@ -17,7 +17,7 @@ import {
   TransactionSignatureService,
   validateSignature,
 } from '@app/common';
-import { Transaction, TransactionSigner, TransactionStatus, User, UserKey } from '@entities';
+import { type NewSignerRow, Transaction, TransactionSigner, TransactionStatus, User, UserKey } from '@entities';
 
 import { UploadSignatureMapDto } from '../dto';
 
@@ -60,6 +60,9 @@ export class SignersService {
         id: true,
         transactionId: true,
         userKeyId: true,
+        recorderId: true,
+        tool: true,
+        version: true,
         createdAt: true,
       },
       withDeleted,
@@ -190,12 +193,13 @@ export class SignersService {
             sdkTransaction,
             userKeys,
             isSameBytes,
-            tool: tool ?? null,
+            tool: tool ?? 'api',
             error: null,
           };
         } catch (err) {
-          console.error(`[TX ${id}] Error:`, err.message);
-          return { id, error: err.message };
+          const e = err instanceof Error ? err : new Error(String(err));
+          console.error(`[TX ${id}] Error:`, e);
+          return { id, error: e.message };
         }
       })
     );
@@ -274,7 +278,7 @@ export class SignersService {
     // Prepare batched operations
     const transactionsToUpdate: { id: number; transactionBytes: Buffer }[] = [];
     const notificationsToUpdate: { userId: number; transactionId: number }[] = [];
-    const signersToInsert: { userId: number; transactionId: number; userKeyId: number; recorderId: number; tool: string | null; version: string | null }[] = [];
+    const signersToInsert: NewSignerRow[] = [];
     const transactionsToProcess: { id: number; transaction: Transaction }[] = [];
 
     for (const result of validationResults) {

--- a/back-end/apps/api/src/transactions/transactions.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.controller.spec.ts
@@ -174,7 +174,7 @@ describe('TransactionsController', () => {
 
       expect(plainToInstance).toHaveBeenCalledWith(UploadSignatureMapDto, dtoInput);
       expect(validateOrReject).toHaveBeenCalledWith(transformedDto);
-      expect(transactionService.importSignatures).toHaveBeenCalledWith([transformedDto], user);
+      expect(transactionService.importSignatures).toHaveBeenCalledWith([transformedDto], user, null);
       expect(result).toEqual(expectedResult);
     });
 
@@ -205,8 +205,34 @@ describe('TransactionsController', () => {
       expect((plainToInstance as jest.Mock).mock.calls[0]).toEqual([UploadSignatureMapDto, dtoInput[0]]);
       expect((plainToInstance as jest.Mock).mock.calls[1]).toEqual([UploadSignatureMapDto, dtoInput[1]]);
       expect(validateOrReject).toHaveBeenCalledTimes(2);
-      expect(transactionService.importSignatures).toHaveBeenCalledWith(transformedDtos, user);
+      expect(transactionService.importSignatures).toHaveBeenCalledWith(transformedDtos, user, null);
       expect(result).toEqual(expectedResult);
+    });
+
+    it('should forward x-frontend-version header to importSignatures', async () => {
+      const dtoInput = { id: 1, signatureMap: new SignatureMap() };
+      const transformedDto = { transformed: 'value' };
+
+      (plainToInstance as jest.Mock).mockReturnValueOnce(transformedDto);
+      (validateOrReject as jest.Mock).mockResolvedValue(undefined);
+      (transactionService.importSignatures as jest.Mock).mockResolvedValue([]);
+
+      await controller.importSignatures(dtoInput, user, '2.0.0');
+
+      expect(transactionService.importSignatures).toHaveBeenCalledWith([transformedDto], user, '2.0.0');
+    });
+
+    it('should pass null version when header is absent', async () => {
+      const dtoInput = { id: 1, signatureMap: new SignatureMap() };
+      const transformedDto = { transformed: 'value' };
+
+      (plainToInstance as jest.Mock).mockReturnValueOnce(transformedDto);
+      (validateOrReject as jest.Mock).mockResolvedValue(undefined);
+      (transactionService.importSignatures as jest.Mock).mockResolvedValue([]);
+
+      await controller.importSignatures(dtoInput, user);
+
+      expect(transactionService.importSignatures).toHaveBeenCalledWith([transformedDto], user, null);
     });
   });
 

--- a/back-end/apps/api/src/transactions/transactions.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.controller.spec.ts
@@ -234,6 +234,32 @@ describe('TransactionsController', () => {
 
       expect(transactionService.importSignatures).toHaveBeenCalledWith([transformedDto], user, null);
     });
+
+    it('should strip a leading v from the version header before forwarding', async () => {
+      const dtoInput = { id: 1, signatureMap: new SignatureMap() };
+      const transformedDto = { transformed: 'value' };
+
+      (plainToInstance as jest.Mock).mockReturnValueOnce(transformedDto);
+      (validateOrReject as jest.Mock).mockResolvedValue(undefined);
+      (transactionService.importSignatures as jest.Mock).mockResolvedValue([]);
+
+      await controller.importSignatures(dtoInput, user, 'v2.0.0');
+
+      expect(transactionService.importSignatures).toHaveBeenCalledWith([transformedDto], user, '2.0.0');
+    });
+
+    it('should pass null for an invalid version string', async () => {
+      const dtoInput = { id: 1, signatureMap: new SignatureMap() };
+      const transformedDto = { transformed: 'value' };
+
+      (plainToInstance as jest.Mock).mockReturnValueOnce(transformedDto);
+      (validateOrReject as jest.Mock).mockResolvedValue(undefined);
+      (transactionService.importSignatures as jest.Mock).mockResolvedValue([]);
+
+      await controller.importSignatures(dtoInput, user, 'not-a-version');
+
+      expect(transactionService.importSignatures).toHaveBeenCalledWith([transformedDto], user, null);
+    });
   });
 
   describe('getTransactions', () => {

--- a/back-end/apps/api/src/transactions/transactions.controller.ts
+++ b/back-end/apps/api/src/transactions/transactions.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  Headers,
   HttpCode,
   Param,
   ParseIntPipe,
@@ -96,6 +97,7 @@ export class TransactionsController {
   async importSignatures(
     @Body() body: UploadSignatureMapDto[] | UploadSignatureMapDto,
     @GetUser() user: User,
+    @Headers('x-frontend-version') version?: string,
   ): Promise<SignatureImportResultDto[]> {
     const transformedSignatureMaps = await transformAndValidateDto(
       UploadSignatureMapDto,
@@ -103,7 +105,7 @@ export class TransactionsController {
     );
 
     // Delegate to service to perform the import
-    return this.transactionsService.importSignatures(transformedSignatureMaps, user);
+    return this.transactionsService.importSignatures(transformedSignatureMaps, user, version ?? null);
   }
 
   /* Get all transactions visible by the user */

--- a/back-end/apps/api/src/transactions/transactions.controller.ts
+++ b/back-end/apps/api/src/transactions/transactions.controller.ts
@@ -19,6 +19,7 @@ import {
 } from '@nestjs/swagger';
 
 import { TransactionId } from '@hiero-ledger/sdk';
+import * as semver from 'semver';
 
 import {
   Filtering,
@@ -105,7 +106,7 @@ export class TransactionsController {
     );
 
     // Delegate to service to perform the import
-    return this.transactionsService.importSignatures(transformedSignatureMaps, user, version ?? null);
+    return this.transactionsService.importSignatures(transformedSignatureMaps, user, version ? semver.clean(version) ?? null : null);
   }
 
   /* Get all transactions visible by the user */

--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -1372,7 +1372,7 @@ describe('TransactionsService', () => {
       /* New signer row inserted so the key owner is recognised as a participant. */
       expect(insertQb.into).toHaveBeenCalledWith(TransactionSigner);
       expect(insertQb.values).toHaveBeenCalledWith([
-        { userId: 7, transactionId, userKeyId: 42 },
+        { userId: 7, transactionId, userKeyId: 42, recorderId: userWithKeys.id, tool: null, version: null },
       ]);
       expect(insertQb.execute).toHaveBeenCalled();
 
@@ -1502,8 +1502,8 @@ describe('TransactionsService', () => {
       );
 
       expect(insertQb.values).toHaveBeenCalledWith([
-        { userId: 7, transactionId, userKeyId: 42 },
-        { userId: 9, transactionId, userKeyId: 43 },
+        { userId: 7, transactionId, userKeyId: 42, recorderId: userWithKeys.id, tool: null, version: null },
+        { userId: 9, transactionId, userKeyId: 43, recorderId: userWithKeys.id, tool: null, version: null },
       ]);
     });
 
@@ -1543,8 +1543,8 @@ describe('TransactionsService', () => {
 
       expect(insertQb.values).toHaveBeenCalledWith(
         expect.arrayContaining([
-          { userId: 7, transactionId, userKeyId: 42 },
-          { userId: 9, transactionId, userKeyId: 43 },
+          { userId: 7, transactionId, userKeyId: 42, recorderId: userWithKeys.id, tool: null, version: null },
+          { userId: 9, transactionId, userKeyId: 43, recorderId: userWithKeys.id, tool: null, version: null },
         ]),
       );
     });
@@ -2020,6 +2020,134 @@ describe('TransactionsService', () => {
         id: transactionId,
         error: 'An unexpected error occurred while importing the signatures',
       });
+    });
+
+    it('should set recorderId to the caller (importer) not the key owner', async () => {
+      const transaction = {
+        id: transactionId,
+        transactionId: sdkTransaction.transactionId.toString(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      const matchingUserKey = { id: 42, userId: 99, publicKey: privateKey.publicKey.toStringRaw() };
+      await sdkTransaction.sign(privateKey);
+
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction], [matchingUserKey]) as any);
+      const updateQb = makeUpdateQb();
+      const insertQb = makeInsertQb();
+      const manager = makeTxManager();
+      manager.createQueryBuilder.mockReturnValueOnce(updateQb).mockReturnValueOnce(insertQb);
+      stubTransaction(manager);
+      mockValidatedKeys([privateKey.publicKey]);
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
+      jest.mocked(processTransactionStatus).mockResolvedValue(new Map());
+
+      await service.importSignatures(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys,
+      );
+
+      expect(insertQb.values).toHaveBeenCalledWith([
+        expect.objectContaining({
+          userId: 99,
+          recorderId: userWithKeys.id,
+        }),
+      ]);
+    });
+
+    it('should propagate tool from the DTO item to the signer row', async () => {
+      const transaction = {
+        id: transactionId,
+        transactionId: sdkTransaction.transactionId.toString(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      const matchingUserKey = { id: 42, userId: 7, publicKey: privateKey.publicKey.toStringRaw() };
+      await sdkTransaction.sign(privateKey);
+
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction], [matchingUserKey]) as any);
+      const updateQb = makeUpdateQb();
+      const insertQb = makeInsertQb();
+      const manager = makeTxManager();
+      manager.createQueryBuilder.mockReturnValueOnce(updateQb).mockReturnValueOnce(insertQb);
+      stubTransaction(manager);
+      mockValidatedKeys([privateKey.publicKey]);
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
+      jest.mocked(processTransactionStatus).mockResolvedValue(new Map());
+
+      await service.importSignatures(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures(), tool: 'v1' }],
+        userWithKeys,
+      );
+
+      expect(insertQb.values).toHaveBeenCalledWith([
+        expect.objectContaining({ tool: 'v1' }),
+      ]);
+    });
+
+    it('should use null tool when not present on the DTO item', async () => {
+      const transaction = {
+        id: transactionId,
+        transactionId: sdkTransaction.transactionId.toString(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      const matchingUserKey = { id: 42, userId: 7, publicKey: privateKey.publicKey.toStringRaw() };
+      await sdkTransaction.sign(privateKey);
+
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction], [matchingUserKey]) as any);
+      const updateQb = makeUpdateQb();
+      const insertQb = makeInsertQb();
+      const manager = makeTxManager();
+      manager.createQueryBuilder.mockReturnValueOnce(updateQb).mockReturnValueOnce(insertQb);
+      stubTransaction(manager);
+      mockValidatedKeys([privateKey.publicKey]);
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
+      jest.mocked(processTransactionStatus).mockResolvedValue(new Map());
+
+      await service.importSignatures(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys,
+      );
+
+      expect(insertQb.values).toHaveBeenCalledWith([
+        expect.objectContaining({ tool: null }),
+      ]);
+    });
+
+    it('should propagate version parameter to signer rows', async () => {
+      const transaction = {
+        id: transactionId,
+        transactionId: sdkTransaction.transactionId.toString(),
+        status: TransactionStatus.WAITING_FOR_SIGNATURES,
+        transactionBytes: sdkTransaction.toBytes(),
+        mirrorNetwork: 'testnet',
+      };
+      const matchingUserKey = { id: 42, userId: 7, publicKey: privateKey.publicKey.toStringRaw() };
+      await sdkTransaction.sign(privateKey);
+
+      entityManager.find.mockImplementation(makeFindDispatcher([transaction], [matchingUserKey]) as any);
+      const updateQb = makeUpdateQb();
+      const insertQb = makeInsertQb();
+      const manager = makeTxManager();
+      manager.createQueryBuilder.mockReturnValueOnce(updateQb).mockReturnValueOnce(insertQb);
+      stubTransaction(manager);
+      mockValidatedKeys([privateKey.publicKey]);
+      jest.mocked(userKeysRequiredToSign).mockResolvedValue([1]);
+      jest.mocked(processTransactionStatus).mockResolvedValue(new Map());
+
+      await service.importSignatures(
+        [{ id: transactionId, signatureMap: sdkTransaction.getSignatures() }],
+        userWithKeys,
+        '0.35.0',
+      );
+
+      expect(insertQb.values).toHaveBeenCalledWith([
+        expect.objectContaining({ version: '0.35.0' }),
+      ]);
     });
   });
 

--- a/back-end/apps/api/src/transactions/transactions.service.spec.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.spec.ts
@@ -1372,7 +1372,7 @@ describe('TransactionsService', () => {
       /* New signer row inserted so the key owner is recognised as a participant. */
       expect(insertQb.into).toHaveBeenCalledWith(TransactionSigner);
       expect(insertQb.values).toHaveBeenCalledWith([
-        { userId: 7, transactionId, userKeyId: 42, recorderId: userWithKeys.id, tool: null, version: null },
+        { userId: 7, transactionId, userKeyId: 42, recorderId: userWithKeys.id, tool: 'api', version: null },
       ]);
       expect(insertQb.execute).toHaveBeenCalled();
 
@@ -1502,8 +1502,8 @@ describe('TransactionsService', () => {
       );
 
       expect(insertQb.values).toHaveBeenCalledWith([
-        { userId: 7, transactionId, userKeyId: 42, recorderId: userWithKeys.id, tool: null, version: null },
-        { userId: 9, transactionId, userKeyId: 43, recorderId: userWithKeys.id, tool: null, version: null },
+        { userId: 7, transactionId, userKeyId: 42, recorderId: userWithKeys.id, tool: 'api', version: null },
+        { userId: 9, transactionId, userKeyId: 43, recorderId: userWithKeys.id, tool: 'api', version: null },
       ]);
     });
 
@@ -1543,8 +1543,8 @@ describe('TransactionsService', () => {
 
       expect(insertQb.values).toHaveBeenCalledWith(
         expect.arrayContaining([
-          { userId: 7, transactionId, userKeyId: 42, recorderId: userWithKeys.id, tool: null, version: null },
-          { userId: 9, transactionId, userKeyId: 43, recorderId: userWithKeys.id, tool: null, version: null },
+          { userId: 7, transactionId, userKeyId: 42, recorderId: userWithKeys.id, tool: 'api', version: null },
+          { userId: 9, transactionId, userKeyId: 43, recorderId: userWithKeys.id, tool: 'api', version: null },
         ]),
       );
     });
@@ -2087,7 +2087,7 @@ describe('TransactionsService', () => {
       ]);
     });
 
-    it('should use null tool when not present on the DTO item', async () => {
+    it('should default tool to api when not present on the DTO item', async () => {
       const transaction = {
         id: transactionId,
         transactionId: sdkTransaction.transactionId.toString(),
@@ -2114,7 +2114,7 @@ describe('TransactionsService', () => {
       );
 
       expect(insertQb.values).toHaveBeenCalledWith([
-        expect.objectContaining({ tool: null }),
+        expect.objectContaining({ tool: 'api' }),
       ]);
     });
 

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -647,7 +647,7 @@ export class TransactionsService {
         intermediate.set(id, { transaction, publicKeys: validNewKeys, newBytes, isSameBytes, tool: tool ?? 'api' });
       } catch (error) {
         if (!(error instanceof BadRequestException)) {
-          this.logger.error(`[TX ${id}] Unexpected error during signature import`, error);
+          this.logger.error(`[TX ${id}] Unexpected error during signature import`, (error as any)?.stack ?? (error as any)?.message ?? String(error));
         }
         results.set(id, {
           id,

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -547,6 +547,7 @@ export class TransactionsService {
   async importSignatures(
     dto: UploadSignatureMapDto[],
     user: User,
+    version: string | null = null,
   ): Promise<SignatureImportResultDto[]> {
     type UpdateRecord = {
       id: number;
@@ -586,7 +587,7 @@ export class TransactionsService {
 
     const results = new Map<number, SignatureImportResultDto>();
     const updates = new Map<number, UpdateRecord>();
-    const newSignerRows: { userId: number; transactionId: number; userKeyId: number }[] = [];
+    const newSignerRows: { userId: number; transactionId: number; userKeyId: number; recorderId: number; tool: string | null; version: string | null }[] = [];
     const notificationDismissals: { userId: number; transactionId: number }[] = [];
     // Dedups (userId, txId) so one user with multiple keys produces one UNNEST row.
     const notificationDismissalKeys = new Set<string>();
@@ -598,12 +599,13 @@ export class TransactionsService {
       publicKeys: PublicKey[];
       newBytes: Buffer;
       isSameBytes: boolean;
+      tool: string | null;
     };
     const intermediate = new Map<number, DtoIntermediate>();
     const allPubKeyStrings = new Set<string>();
 
     // Two-pass: defer UserKey resolution to a single bulk find below (was N+1).
-    for (const { id, signatureMap: map } of dto) {
+    for (const { id, signatureMap: map, tool } of dto) {
       const transaction = transactionMap.get(id);
 
       try {
@@ -641,7 +643,7 @@ export class TransactionsService {
           allPubKeyStrings.add(pk.toStringDer());
         }
 
-        intermediate.set(id, { transaction, publicKeys: validNewKeys, newBytes, isSameBytes });
+        intermediate.set(id, { transaction, publicKeys: validNewKeys, newBytes, isSameBytes, tool: tool ?? null });
       } catch (error) {
         results.set(id, {
           id,
@@ -668,9 +670,9 @@ export class TransactionsService {
       }
     }
 
-    for (const [id, { transaction, publicKeys, newBytes, isSameBytes }] of intermediate) {
+    for (const [id, { transaction, publicKeys, newBytes, isSameBytes, tool }] of intermediate) {
       // Create TransactionSigner rows for any keys found in the imported signatures (issue #2552).
-      const newSignersForDto: { userId: number; transactionId: number; userKeyId: number }[] = [];
+      const newSignersForDto: { userId: number; transactionId: number; userKeyId: number; recorderId: number; tool: string | null; version: string | null }[] = [];
       if (publicKeys.length > 0) {
         let txExistingSigners = signersByTransaction.get(id);
         if (!txExistingSigners) {
@@ -685,7 +687,7 @@ export class TransactionsService {
           for (const uk of matches) {
             if (txExistingSigners.has(uk.id)) continue;
             txExistingSigners.add(uk.id);
-            newSignersForDto.push({ userId: uk.userId, transactionId: id, userKeyId: uk.id });
+            newSignersForDto.push({ userId: uk.userId, transactionId: id, userKeyId: uk.id, recorderId: user.id, tool, version });
           }
         }
       }

--- a/back-end/apps/api/src/transactions/transactions.service.ts
+++ b/back-end/apps/api/src/transactions/transactions.service.ts
@@ -27,6 +27,7 @@ import {
 } from 'typeorm';
 
 import {
+  type NewSignerRow,
   Transaction,
   TransactionApprover,
   TransactionObserver,
@@ -587,7 +588,7 @@ export class TransactionsService {
 
     const results = new Map<number, SignatureImportResultDto>();
     const updates = new Map<number, UpdateRecord>();
-    const newSignerRows: { userId: number; transactionId: number; userKeyId: number; recorderId: number; tool: string | null; version: string | null }[] = [];
+    const newSignerRows: NewSignerRow[] = [];
     const notificationDismissals: { userId: number; transactionId: number }[] = [];
     // Dedups (userId, txId) so one user with multiple keys produces one UNNEST row.
     const notificationDismissalKeys = new Set<string>();
@@ -643,8 +644,11 @@ export class TransactionsService {
           allPubKeyStrings.add(pk.toStringDer());
         }
 
-        intermediate.set(id, { transaction, publicKeys: validNewKeys, newBytes, isSameBytes, tool: tool ?? null });
+        intermediate.set(id, { transaction, publicKeys: validNewKeys, newBytes, isSameBytes, tool: tool ?? 'api' });
       } catch (error) {
+        if (!(error instanceof BadRequestException)) {
+          this.logger.error(`[TX ${id}] Unexpected error during signature import`, error);
+        }
         results.set(id, {
           id,
           error:
@@ -672,7 +676,7 @@ export class TransactionsService {
 
     for (const [id, { transaction, publicKeys, newBytes, isSameBytes, tool }] of intermediate) {
       // Create TransactionSigner rows for any keys found in the imported signatures (issue #2552).
-      const newSignersForDto: { userId: number; transactionId: number; userKeyId: number; recorderId: number; tool: string | null; version: string | null }[] = [];
+      const newSignersForDto: NewSignerRow[] = [];
       if (publicKeys.length > 0) {
         let txExistingSigners = signersByTransaction.get(id);
         if (!txExistingSigners) {

--- a/back-end/libs/common/src/database/entities/transaction-signer.entity.ts
+++ b/back-end/libs/common/src/database/entities/transaction-signer.entity.ts
@@ -11,6 +11,15 @@ import { Transaction } from './transaction.entity';
 import { UserKey } from './user-key.entity';
 import { User } from './user.entity';
 
+export type NewSignerRow = {
+  userId: number;
+  transactionId: number;
+  userKeyId: number;
+  recorderId: number;
+  tool: string | null;
+  version: string | null;
+};
+
 @Entity()
 @Index(['transactionId', 'userKeyId'])
 export class TransactionSigner {

--- a/back-end/libs/common/src/database/entities/transaction-signer.entity.ts
+++ b/back-end/libs/common/src/database/entities/transaction-signer.entity.ts
@@ -38,6 +38,19 @@ export class TransactionSigner {
   @Column()
   userId: number;
 
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({ name: 'recorderId' })
+  recorder: User | null;
+
+  @Column({ nullable: true })
+  recorderId: number | null;
+
+  @Column({ nullable: true })
+  tool: string | null;
+
+  @Column({ nullable: true })
+  version: string | null;
+
   @CreateDateColumn()
   createdAt: Date;
 }

--- a/back-end/typeorm/migrations/1783555200000-TransactionSignerRecorderToolVersion.ts
+++ b/back-end/typeorm/migrations/1783555200000-TransactionSignerRecorderToolVersion.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class TransactionSignerRecorderToolVersion1783555200000 implements MigrationInterface {
+    name = 'TransactionSignerRecorderToolVersion1783555200000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "transaction_signer" ADD "recorderId" integer`);
+        await queryRunner.query(`ALTER TABLE "transaction_signer" ADD "tool" character varying`);
+        await queryRunner.query(`ALTER TABLE "transaction_signer" ADD "version" character varying`);
+        await queryRunner.query(`ALTER TABLE "transaction_signer" ADD CONSTRAINT "FK_transaction_signer_recorderId" FOREIGN KEY ("recorderId") REFERENCES "user"("id")`);
+        await queryRunner.query(`CREATE INDEX "IDX_transaction_signer_recorderId" ON "transaction_signer" ("recorderId")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "public"."IDX_transaction_signer_recorderId"`);
+        await queryRunner.query(`ALTER TABLE "transaction_signer" DROP CONSTRAINT "FK_transaction_signer_recorderId"`);
+        await queryRunner.query(`ALTER TABLE "transaction_signer" DROP COLUMN "recorderId"`);
+        await queryRunner.query(`ALTER TABLE "transaction_signer" DROP COLUMN "tool"`);
+        await queryRunner.query(`ALTER TABLE "transaction_signer" DROP COLUMN "version"`);
+    }
+}

--- a/back-end/typeorm/migrations/1783555200000-TransactionSignerRecorderToolVersion.ts
+++ b/back-end/typeorm/migrations/1783555200000-TransactionSignerRecorderToolVersion.ts
@@ -7,13 +7,11 @@ export class TransactionSignerRecorderToolVersion1783555200000 implements Migrat
         await queryRunner.query(`ALTER TABLE "transaction_signer" ADD "recorderId" integer`);
         await queryRunner.query(`ALTER TABLE "transaction_signer" ADD "tool" character varying`);
         await queryRunner.query(`ALTER TABLE "transaction_signer" ADD "version" character varying`);
-        await queryRunner.query(`ALTER TABLE "transaction_signer" ADD CONSTRAINT "FK_transaction_signer_recorderId" FOREIGN KEY ("recorderId") REFERENCES "user"("id")`);
-        await queryRunner.query(`CREATE INDEX "IDX_transaction_signer_recorderId" ON "transaction_signer" ("recorderId")`);
+        await queryRunner.query(`ALTER TABLE "transaction_signer" ADD CONSTRAINT "FK_12e4f7f1cfff91745d83f9bd57f" FOREIGN KEY ("recorderId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`DROP INDEX "public"."IDX_transaction_signer_recorderId"`);
-        await queryRunner.query(`ALTER TABLE "transaction_signer" DROP CONSTRAINT "FK_transaction_signer_recorderId"`);
+        await queryRunner.query(`ALTER TABLE "transaction_signer" DROP CONSTRAINT "FK_12e4f7f1cfff91745d83f9bd57f"`);
         await queryRunner.query(`ALTER TABLE "transaction_signer" DROP COLUMN "recorderId"`);
         await queryRunner.query(`ALTER TABLE "transaction_signer" DROP COLUMN "tool"`);
         await queryRunner.query(`ALTER TABLE "transaction_signer" DROP COLUMN "version"`);

--- a/front-end/src/renderer/components/TransactionImportModal.vue
+++ b/front-end/src/renderer/components/TransactionImportModal.vue
@@ -9,6 +9,7 @@ import TransactionImportRow from '@renderer/components/TransactionImportRow.vue'
 import {
   type ISignatureImport,
   type ITransactionFull,
+  SignerTool,
   type SignatureImportResultDto,
   type V1ImportCandidate,
   type V1ImportFilterResult,
@@ -101,7 +102,7 @@ const importSelectedCandidates = async (): Promise<void> => {
         importInputs.push({
           id: transaction.id,
           signatureMap,
-          tool: 'v1',
+          tool: SignerTool.V1,
         });
       } catch {
         rejectedTransactionIds.push(transactionId);

--- a/front-end/src/renderer/components/TransactionImportModal.vue
+++ b/front-end/src/renderer/components/TransactionImportModal.vue
@@ -101,6 +101,7 @@ const importSelectedCandidates = async (): Promise<void> => {
         importInputs.push({
           id: transaction.id,
           signatureMap,
+          tool: 'v1',
         });
       } catch {
         rejectedTransactionIds.push(transactionId);

--- a/front-end/src/renderer/pages/Transactions/Transactions.vue
+++ b/front-end/src/renderer/pages/Transactions/Transactions.vue
@@ -7,6 +7,7 @@ import { computed, onBeforeMount, ref, watch } from 'vue';
 import {
   type ISignatureImport,
   NotificationType,
+  SignerTool,
   type V1ImportFilterResult,
 } from '@shared/interfaces';
 import {
@@ -234,7 +235,7 @@ async function importSignaturesFromV2File(filePath: string) {
       importInputs.push({
         id: transaction.id,
         signatureMap: map,
-        tool: 'v2',
+        tool: SignerTool.V2,
       });
     } catch {
       unknownTransactionIds.push(transactionId!.toString());

--- a/front-end/src/renderer/pages/Transactions/Transactions.vue
+++ b/front-end/src/renderer/pages/Transactions/Transactions.vue
@@ -234,6 +234,7 @@ async function importSignaturesFromV2File(filePath: string) {
       importInputs.push({
         id: transaction.id,
         signatureMap: map,
+        tool: 'v2',
       });
     } catch {
       unknownTransactionIds.push(transactionId!.toString());

--- a/front-end/src/renderer/services/organization/transaction.ts
+++ b/front-end/src/renderer/services/organization/transaction.ts
@@ -86,7 +86,7 @@ export const uploadSignatures = async (
   transactionId?: number,
   items?: SignatureItem[],
 ) => {
-  const formattedMaps: { id: number; signatureMap: FormattedMap }[] = [];
+  const formattedMaps: { id: number; signatureMap: FormattedMap; tool: string }[] = [];
 
   if (!items) {
     if (!publicKeys || !transaction || !transactionId) {
@@ -113,6 +113,7 @@ export const uploadSignatures = async (
     formattedMaps.push({
       id: transactionId,
       signatureMap: formatSignatureMap(signatureMap),
+      tool: 'v2',
     });
   }
 

--- a/front-end/src/renderer/services/organization/transaction.ts
+++ b/front-end/src/renderer/services/organization/transaction.ts
@@ -134,12 +134,13 @@ export const importSignatures = async (
   organization: LoggedInOrganization & Organization,
   signatureImport: ISignatureImport[] | ISignatureImport,
 ): Promise<SignatureImportResultDto[]> => {
-  const formattedMaps: { id: number; signatureMap: FormattedMap }[] = [];
+  const formattedMaps: { id: number; signatureMap: FormattedMap; tool?: string }[] = [];
   const imports = Array.isArray(signatureImport) ? signatureImport : [signatureImport];
-  for (const signatureImport of imports) {
+  for (const si of imports) {
     formattedMaps.push({
-      id: signatureImport.id,
-      signatureMap: formatSignatureMap(signatureImport.signatureMap),
+      id: si.id,
+      signatureMap: formatSignatureMap(si.signatureMap),
+      tool: si.tool,
     });
   }
   return commonRequestHandler(async () => {

--- a/front-end/src/renderer/services/organization/transaction.ts
+++ b/front-end/src/renderer/services/organization/transaction.ts
@@ -11,6 +11,7 @@ import type {
   SignatureImportResultDto,
   TransactionApproverDto,
 } from '@shared/interfaces';
+import { SignerTool } from '@shared/interfaces';
 
 import {
   axiosWithCredentials,
@@ -113,7 +114,7 @@ export const uploadSignatures = async (
     formattedMaps.push({
       id: transactionId,
       signatureMap: formatSignatureMap(signatureMap),
-      tool: 'v2',
+      tool: SignerTool.V2,
     });
   }
 

--- a/front-end/src/shared/interfaces/organization/signers/index.ts
+++ b/front-end/src/shared/interfaces/organization/signers/index.ts
@@ -8,17 +8,26 @@ interface IBaseTransactionSigner {
 export interface ITransactionSigner extends IBaseTransactionSigner {
   transactionId: number;
   userKeyId: number;
+  recorderId?: number | null;
+  tool?: string | null;
+  version?: string | null;
   createdAt: string | Date;
 }
 
 export interface ITransactionSignerUserKey extends IBaseTransactionSigner {
   transactionId: number;
   userKey?: IUserKey;
+  recorderId?: number | null;
+  tool?: string | null;
+  version?: string | null;
   createdAt: string | Date;
 }
 
 export interface ITransactionSignerFull extends IBaseTransactionSigner {
   transaction: ITransaction;
   userKey?: IUserKey;
+  recorderId?: number | null;
+  tool?: string | null;
+  version?: string | null;
   createdAt: string | Date;
 }

--- a/front-end/src/shared/interfaces/organization/signers/index.ts
+++ b/front-end/src/shared/interfaces/organization/signers/index.ts
@@ -1,6 +1,13 @@
 import type { ITransaction } from '../transactions';
 import type { IUserKey } from '../userKeys';
 
+export const SignerTool = {
+  V1: 'v1',
+  V2: 'v2',
+  API: 'api',
+} as const;
+export type SignerTool = (typeof SignerTool)[keyof typeof SignerTool];
+
 interface IBaseTransactionSigner {
   id: number;
 }
@@ -9,7 +16,7 @@ export interface ITransactionSigner extends IBaseTransactionSigner {
   transactionId: number;
   userKeyId: number;
   recorderId?: number | null;
-  tool?: string | null;
+  tool?: SignerTool | null;
   version?: string | null;
   createdAt: string | Date;
 }
@@ -18,7 +25,7 @@ export interface ITransactionSignerUserKey extends IBaseTransactionSigner {
   transactionId: number;
   userKey?: IUserKey;
   recorderId?: number | null;
-  tool?: string | null;
+  tool?: SignerTool | null;
   version?: string | null;
   createdAt: string | Date;
 }
@@ -27,7 +34,7 @@ export interface ITransactionSignerFull extends IBaseTransactionSigner {
   transaction: ITransaction;
   userKey?: IUserKey;
   recorderId?: number | null;
-  tool?: string | null;
+  tool?: SignerTool | null;
   version?: string | null;
   createdAt: string | Date;
 }

--- a/front-end/src/shared/interfaces/organization/transactions/index.ts
+++ b/front-end/src/shared/interfaces/organization/transactions/index.ts
@@ -110,6 +110,7 @@ export type IDefaultNetworks = 'mainnet' | 'testnet' | 'previewnet' | 'local-nod
 export interface ISignatureImport {
   id: number; // Database ID of the transaction to which the signatures belong. In a bulk transaction (File Append with multiple transactions inside), this ID refers to the parent transaction.
   signatureMap: SignatureMap;
+  tool?: string;
 }
 
 export interface SignatureImportResultDto {

--- a/front-end/src/shared/interfaces/organization/transactions/index.ts
+++ b/front-end/src/shared/interfaces/organization/transactions/index.ts
@@ -3,6 +3,7 @@ import { SignatureMap } from '@hiero-ledger/sdk';
 import type { ITransactionApprover } from '../approvers';
 import type { ITransactionObserverUserId } from '../observers';
 import type { ITransactionSignerUserKey } from '../signers';
+import { type SignerTool } from '../signers';
 
 export enum BackEndTransactionType {
   ACCOUNT_CREATE = 'ACCOUNT CREATE',
@@ -110,7 +111,7 @@ export type IDefaultNetworks = 'mainnet' | 'testnet' | 'previewnet' | 'local-nod
 export interface ISignatureImport {
   id: number; // Database ID of the transaction to which the signatures belong. In a bulk transaction (File Append with multiple transactions inside), this ID refers to the parent transaction.
   signatureMap: SignatureMap;
-  tool?: string;
+  tool?: SignerTool;
 }
 
 export interface SignatureImportResultDto {


### PR DESCRIPTION
**Description**:
This pull request extends the transaction signature system to capture and persist additional metadata about the signing process, including the tool used, the recorder, and the frontend version. These enhancements are reflected throughout the DTOs, service logic, and tests to ensure the new fields are handled correctly and consistently.

**Related issue(s)**:

Fixes #3071 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
