### PR TITLE
fix: remove unnecessary pnpm cache from audit job

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -83,8 +83,6 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
           node-version-file: package.json
 
       - name: Audit Dependencies

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -49,8 +49,6 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
           node-version-file: package.json
 
       - name: Initialize CodeQL


### PR DESCRIPTION
**Description**:

The `codeql` and `pnpm-audit` jobs in `security.yaml` both configured a pnpm cache via `setup-node` but neither ever runs `pnpm install`. On dependency-change PRs (for `pnpm-audit`) or after dependency bumps are merged to main (for `codeql`), the cache key misses, the pnpm store is never populated, and the post-job save errors:

```
Post job cleanup.
Error: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

Remove `cache: pnpm` and `cache-dependency-path` from both jobs' `setup-node` steps. `pnpm audit` reads the lockfile directly and CodeQL uses `build-mode: none` — neither needs the package store.

**Related issue(s)**:

Fixes #3090