### PR TITLE
fix: code scanning alert no. 7 and 8 - insecure randomness

### DIFF
--- a/automation/pages/OrganizationPage.ts
+++ b/automation/pages/OrganizationPage.ts
@@ -21,6 +21,7 @@ import {
   verifyOrganizationExists,
 } from '../utils/db/databaseQueries.js';
 import * as fs from 'node:fs';
+import { randomInt } from 'node:crypto';
 import { argonHash } from '../utils/crypto/crypto.js';
 import { generateMnemonic } from '../utils/crypto/keyUtil.js';
 import {
@@ -250,7 +251,7 @@ export class OrganizationPage extends BasePage {
   }
 
   async setupWrongOrganization(organizationNickname = 'Bad Organization') {
-    const serverUrl = (process.env.ORGANIZATION_URL ?? '') + Math.floor(Math.random() * 10);
+    const serverUrl = (process.env.ORGANIZATION_URL ?? '') + randomInt(0, 10);
     await this.clickOnAddNewOrganizationButton();
     await this.fillOrganizationDetailsAndContinue(organizationNickname, serverUrl);
   }

--- a/automation/utils/data/random.ts
+++ b/automation/utils/data/random.ts
@@ -1,5 +1,7 @@
+import { randomBytes, randomInt } from 'node:crypto';
+
 export const generateRandomEmail = (domain = 'test.com') => {
-  const randomPart = Math.random().toString(36).substring(2, 8);
+  const randomPart = randomBytes(3).toString('hex');
   return `${randomPart}@${domain}`;
 };
 
@@ -9,7 +11,7 @@ export const generateRandomPassword = (length = 10) => {
   const charactersLength = characters.length;
 
   for (let i = 0; i < length; i++) {
-    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    result += characters.charAt(randomInt(0, charactersLength));
   }
 
   return result;

--- a/back-end/apps/api/src/auth/auth.service.spec.ts
+++ b/back-end/apps/api/src/auth/auth.service.spec.ts
@@ -146,6 +146,30 @@ describe('AuthService', () => {
     );
   });
 
+  it('should use FRONTEND_REPO_URL when building the download URL', async () => {
+    const dto: SignUpUserDto = { email: 'test@email.com' };
+
+    configService.get
+      //@ts-expect-error - incorrect overload expected
+      .calledWith('FRONTEND_REPO_URL')
+      .mockReturnValue('https://example.com/releases/');
+
+    jest.spyOn(userService, 'createUser').mockResolvedValue({ id: 1, email: dto.email } as User);
+
+    await service.signUpByAdmin(dto, 'http://localhost');
+
+    expect(notificationsPublisher.publish).toHaveBeenCalledWith(
+      'notifications.queue.email.invite',
+      expect.arrayContaining([
+        expect.objectContaining({
+          additionalData: expect.objectContaining({
+            downloadUrl: 'https://example.com/releases/latest',
+          }),
+        }),
+      ]),
+    );
+  });
+
   it('should update the password and resend an email for an existing user with status NEW', async () => {
     const dto: SignUpUserDto = { email: 'test@test.com' };
 

--- a/back-end/apps/api/src/auth/auth.service.ts
+++ b/back-end/apps/api/src/auth/auth.service.ts
@@ -8,6 +8,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import type { StringValue } from 'ms';
+import { randomInt } from 'crypto';
 
 import { totp } from 'otplib';
 import * as bcrypt from 'bcryptjs';
@@ -147,9 +148,7 @@ export class AuthService {
   /* Generate a random password */
   private generatePassword() {
     const getRandomLetters = (length: number) =>
-      Array.from({ length }, () => String.fromCharCode(97 + Math.floor(Math.random() * 26))).join(
-        '',
-      );
+      Array.from({ length }, () => String.fromCharCode(97 + randomInt(26))).join('');
 
     return `${getRandomLetters(5)}-${getRandomLetters(5)}`;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/hashgraph/hedera-transaction-tool/security/code-scanning/7](https://github.com/hashgraph/hedera-transaction-tool/security/code-scanning/7)

Use Node.js cryptographic randomness for password generation. In this file, the best fix is to replace letter generation logic that currently uses `Math.random()` with `crypto.randomInt(26)` (or equivalent secure byte logic). This keeps the same output format (`xxxxx-xxxxx`, lowercase letters) and avoids functionality changes while removing predictability.

Concretely in `back-end/apps/api/src/auth/auth.service.ts`:
- Add an import for Node crypto (`randomInt`) near existing imports.
- Update `generatePassword()` so each character index is produced with `randomInt(26)` instead of `Math.floor(Math.random() * 26)`.

No other methods or signatures need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
