### PR TITLE
fix: adding @MaxLength to description field in CreateTransactionDto and CreateTransactionGroupItemDto

### DIFF
--- a/back-end/apps/api/src/transactions/dto/create-transaction-group.dto.spec.ts
+++ b/back-end/apps/api/src/transactions/dto/create-transaction-group.dto.spec.ts
@@ -3,6 +3,8 @@ import { plainToInstance } from 'class-transformer'
 
 import { CreateTransactionGroupDto } from './create-transaction-group.dto'
 import { CreateTransactionGroupItemDto } from './create-transaction-group-item.dto'
+import { validateSync } from 'class-validator';
+import { MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH } from '@entities';
 
 const toDto = (plain: Record<string, unknown>) =>
   plainToInstance(CreateTransactionGroupDto, plain, { enableImplicitConversion: true })
@@ -64,5 +66,18 @@ describe('CreateTransactionGroupDto', () => {
     expect((dtoMissing as any).groupItems).toBeUndefined()
     expect(Array.isArray((dtoEmpty as any).groupItems)).toBe(true)
     expect((dtoEmpty as any).groupItems.length).toBe(0)
+  })
+
+  test('validation fails when description is too long', () => {
+    const plain = {
+      description: 'a'.repeat(MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH + 1),
+      atomic: true,
+      sequential: false,
+      groupItems: [{ id: 1 }, { id: 2 }],
+    };
+
+    const dto = toDto(plain);
+    const errors = validateSync(dto as any);
+    expect(errors.length).toBeGreaterThan(0);
   })
 })

--- a/back-end/apps/api/src/transactions/dto/create-transaction-group.dto.spec.ts
+++ b/back-end/apps/api/src/transactions/dto/create-transaction-group.dto.spec.ts
@@ -79,5 +79,7 @@ describe('CreateTransactionGroupDto', () => {
     const dto = toDto(plain);
     const errors = validateSync(dto as any);
     expect(errors.length).toBeGreaterThan(0);
+    const descriptionError = errors.find(e => e.property === 'description');
+    expect(descriptionError?.constraints).toHaveProperty('maxLength');
   })
 })

--- a/back-end/apps/api/src/transactions/dto/create-transaction-group.dto.ts
+++ b/back-end/apps/api/src/transactions/dto/create-transaction-group.dto.ts
@@ -4,13 +4,16 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  MaxLength,
   ValidateNested,
 } from 'class-validator';
 import { CreateTransactionGroupItemDto } from './create-transaction-group-item.dto';
 import { Type } from 'class-transformer';
+import { MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH } from '@entities';
 
 export class CreateTransactionGroupDto {
   @IsString()
+  @MaxLength(MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH)
   description: string;
 
   @IsOptional()

--- a/back-end/apps/api/src/transactions/dto/create-transaction.dto.spec.ts
+++ b/back-end/apps/api/src/transactions/dto/create-transaction.dto.spec.ts
@@ -3,6 +3,7 @@ import { plainToInstance } from 'class-transformer'
 import { validateSync } from 'class-validator'
 
 import { CreateTransactionDto } from './create-transaction.dto'
+import { MAX_TRANSACTION_DESCRIPTION_LENGTH } from '@app/common/database/entities';
 
 const toDto = (plain: Record<string, unknown>) =>
   plainToInstance(CreateTransactionDto, plain)
@@ -50,4 +51,22 @@ describe('CreateTransactionDto', () => {
     const errors = validateSync(dto as any)
     expect(errors.length).toBeGreaterThan(0)
   })
+
+  test('validation fails when description is too long', () => {
+    const plain = {
+      name: 'Send',
+      description: 'a'.repeat(MAX_TRANSACTION_DESCRIPTION_LENGTH + 1),
+      transactionBytes: 'deadbeef',
+      signature: 'beef',
+      creatorKeyId: 7,
+      mirrorNetwork: 'testnet',
+      cutoffAt: '2024-01-02T00:00:00.000Z',
+      isManual: false,
+      reminderMillisecondsBefore: 60000,
+    };
+
+    const dto = toDto(plain);
+    const errors = validateSync(dto as any);
+    expect(errors.length).toBeGreaterThan(0);
+  });
 })

--- a/back-end/apps/api/src/transactions/dto/create-transaction.dto.spec.ts
+++ b/back-end/apps/api/src/transactions/dto/create-transaction.dto.spec.ts
@@ -67,6 +67,7 @@ describe('CreateTransactionDto', () => {
 
     const dto = toDto(plain);
     const errors = validateSync(dto as any);
-    expect(errors.length).toBeGreaterThan(0);
+    const descriptionError = errors.find(e => e.property === 'description');
+    expect(descriptionError?.constraints).toHaveProperty('maxLength');
   });
 })

--- a/back-end/apps/api/src/transactions/dto/create-transaction.dto.ts
+++ b/back-end/apps/api/src/transactions/dto/create-transaction.dto.ts
@@ -1,7 +1,16 @@
-import { IsBoolean, IsDate, IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsDate,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 import { TransformBuffer } from '@app/common';
+import { MAX_TRANSACTION_DESCRIPTION_LENGTH } from '@entities';
 
 //TODO approvers and observers can be added to this dto, validatenested,
 // also adding cascade to the transaction relations to enable single saves
@@ -10,6 +19,7 @@ export class CreateTransactionDto {
   name: string;
 
   @IsString()
+  @MaxLength(MAX_TRANSACTION_DESCRIPTION_LENGTH)
   description: string;
 
   @IsNotEmpty()

--- a/back-end/libs/common/src/database/entities/transaction-group.entity.ts
+++ b/back-end/libs/common/src/database/entities/transaction-group.entity.ts
@@ -1,12 +1,15 @@
 import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { TransactionGroupItem } from './';
 
+export const MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH = 256;
+
 @Entity()
 export class TransactionGroup {
   @PrimaryGeneratedColumn()
   id: number;
 
   @Column()
+  // @Column({ length: MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH })
   description: string;
 
   @Column({ default: false })

--- a/back-end/libs/common/src/database/entities/transaction.entity.ts
+++ b/back-end/libs/common/src/database/entities/transaction.entity.ts
@@ -65,6 +65,8 @@ export const MAX_TRANSACTION_BYTE_SIZE = 6_144;
 // increased transaction size limit of 128 KB to accommodate council signatures.
 export const MAX_PRIVILEGED_TRANSACTION_BYTE_SIZE = 131_072;
 
+export const MAX_TRANSACTION_DESCRIPTION_LENGTH = 256;
+
 @Entity()
 @Index(['status', 'mirrorNetwork'])
 @Index(['creatorKeyId'])
@@ -82,7 +84,7 @@ export class Transaction {
   @Column()
   type: TransactionType;
 
-  @Column({ length: 256 })
+  @Column({ length: MAX_TRANSACTION_DESCRIPTION_LENGTH })
   description: string;
 
   @Column()


### PR DESCRIPTION
**Description**:
Changes below enforce description length to 256 characters in the following REST endpoints:
- `POST transactions` (ie `CreateTransactionDto`)
- `POST transaction-groups` (ie `CreateTransactionGroupDto`)

**Related issue(s)**:

Contributes to #2937

**Notes for reviewer**:
```
M   back-end/apps/api/src/transactions/dto/create-transaction.dto.ts
M   back-end/apps/api/src/transactions/dto/create-transaction.dto.spec.ts
M   back-end/libs/common/src/database/entities/transaction.entity.ts
    # CreateTransactionDto now enforces @MaxLength(256) on description.
    # It uses MAX_TRANSACTION_DESCRIPTION_LENGTH = 256 from transaction.entity.ts.

M   back-end/apps/api/src/transactions/dto/create-transaction-group.dto.ts
M   back-end/apps/api/src/transactions/dto/create-transaction-group.dto.spec.ts
M   back-end/libs/common/src/database/entities/transaction-group.entity.ts
    # CreateTransactionGroupDto declaration now enforces @MaxLength(256) on description.
    # It uses MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH = 256 from transaction-group.entity.ts.
```
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
