### PR TITLE
fix: draft editor now limits group description length to 256

### DIFF
--- a/front-end/src/renderer/components/Transaction/TransactionInfoControls.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionInfoControls.vue
@@ -5,6 +5,7 @@ import { onMounted } from 'vue';
 import { getDraft } from '@renderer/services/transactionDraftsService';
 
 import AppTextArea from '@renderer/components/ui/AppTextArea.vue';
+import { MAX_TRANSACTION_DESCRIPTION_LENGTH } from '@shared/interfaces';
 
 /* Props */
 defineProps<{
@@ -41,7 +42,7 @@ onMounted(async () => {
         :model-value="description"
         @update:model-value="v => $emit('update:description', v)"
         :filled="true"
-        :limit="256"
+        :limit="MAX_TRANSACTION_DESCRIPTION_LENGTH"
         placeholder="Enter a description for the transaction"
         data-testid="input-transaction-description"
       />

--- a/front-end/src/renderer/components/ui/AppInput.vue
+++ b/front-end/src/renderer/components/ui/AppInput.vue
@@ -9,6 +9,7 @@ export type Props = {
   size?: 'small' | 'large' | undefined;
   autoTrim?: boolean;
   htmlTooltip?: boolean;
+  limit?: number;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -65,5 +66,6 @@ defineExpose({
     @input="handleInput"
     @blur="handleBlur"
     :class="[sizeClass, fillClass]"
+    :maxlength="limit || undefined"
   />
 </template>

--- a/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
+++ b/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
@@ -37,6 +37,7 @@ import ImportCSVController from '@renderer/pages/CreateTransactionGroup/ImportCS
 import useNextTransactionV2, {
   type TransactionNodeId,
 } from '@renderer/stores/storeNextTransactionV2.ts';
+import { MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH } from '@shared/interfaces';
 
 /* Injected */
 const toastManager = ToastManager.inject();
@@ -302,6 +303,7 @@ onBeforeRouteLeave(async to => {
               filled
               placeholder="Enter Description"
               data-testid="input-transaction-group-description"
+              :limit="MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH"
             />
           </div>
           <div class="mt-4 align-self-end">

--- a/front-end/src/shared/interfaces/organization/transactions/index.ts
+++ b/front-end/src/shared/interfaces/organization/transactions/index.ts
@@ -118,3 +118,6 @@ export interface SignatureImportResultDto {
   id: number; // The database ID of the transaction
   error?: string;
 }
+
+export const MAX_TRANSACTION_DESCRIPTION_LENGTH = 256;
+export const MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH = 256;

--- a/front-end/src/tests/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.spec.ts
+++ b/front-end/src/tests/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.spec.ts
@@ -140,9 +140,9 @@ describe('CreateTransactionGroup.vue', () => {
           AppInput: {
             emits: ['update:modelValue'],
             inheritAttrs: false,
-            props: ['modelValue'],
+            props: ['modelValue', 'limit'],
             template:
-              '<input v-bind="$attrs" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+              '<input v-bind="$attrs" :value="modelValue" :maxlength="limit" @input="$emit(\'update:modelValue\', $event.target.value)" />',
           },
           AppModal: {
             inheritAttrs: false,
@@ -263,6 +263,14 @@ describe('CreateTransactionGroup.vue', () => {
 
     expect(mocks.transactionGroupStore.clearGroup).toHaveBeenCalled();
   });
+
+  test('check maxLength is set on description <input>', () => {
+    const wrapper = mountCreateTransactionGroup();
+    const element = wrapper.find('[data-testid="input-transaction-group-description"]').element;
+    expect(element instanceof HTMLInputElement).toBe(true);
+    const input = element as HTMLInputElement;
+    expect(input.maxLength).toBe(256);
+  })
 
   describe('group item row', () => {
     const baseItem = {


### PR DESCRIPTION
**Description**:

Changes below:
- enforce `description` max length in `CreateTransactionGroup` view
- constant definitions that mirror the ones from backend side (`transaction.entity.ts` and `transaction-group.entity.ts`)

**Related issue(s)**:

Contributes to #2937

**Notes for reviewer**:
```
M   front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
M   front-end/src/shared/interfaces/organization/transactions/index.ts
    # Now uses AppInput.props.limit to enforce description max length.
    # It uses MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH definition.

M   front-end/src/renderer/components/Transaction/TransactionInfoControls.vue
    # Now uses MAX_TRANSACTION_DESCRIPTION_LENGTH in place of hardcodng 256.

M   front-end/src/renderer/components/ui/AppInput.vue
    # Added AppInput.props.limit
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
