### PR TITLE
fix: notification badge inflated count

### DIFF
--- a/front-end/src/renderer/stores/storeNotifications.ts
+++ b/front-end/src/renderer/stores/storeNotifications.ts
@@ -109,6 +109,7 @@ const useNotificationsStore = defineStore('notifications', () => {
   });
 
   let notificationsQueue = Promise.resolve();
+  let notificationListenerDisposers: (() => void)[] = [];
 
   /** Preferences **/
   async function fetchPreferences() {
@@ -162,21 +163,28 @@ const useNotificationsStore = defineStore('notifications', () => {
   }
 
   function listenForUpdates() {
+    notificationListenerDisposers.forEach(d => d());
+    notificationListenerDisposers = [];
+
     const serverUrls = organizationServerUrls.value;
     for (const serverUrl of serverUrls) {
-      ws.on(serverUrl, NOTIFICATIONS_NEW, e => {
-        const newNotifications: INotificationReceiver[] = e;
+      notificationListenerDisposers.push(
+        ws.on(serverUrl, NOTIFICATIONS_NEW, e => {
+          const newNotifications: INotificationReceiver[] = e;
 
-        notifications.value[serverUrl] = [...notifications.value[serverUrl], ...newNotifications];
-        notifications.value = { ...notifications.value };
-      });
+          notifications.value[serverUrl] = [...notifications.value[serverUrl], ...newNotifications];
+          notifications.value = { ...notifications.value };
+        }),
+      );
 
-      ws.on(serverUrl, NOTIFICATIONS_INDICATORS_DELETE, e => {
-        const deleteNotifications: {notificationReceiverIds: number}[] = e;
-        const notificationReceiverIds = deleteNotifications.flatMap(item => item.notificationReceiverIds || []);
+      notificationListenerDisposers.push(
+        ws.on(serverUrl, NOTIFICATIONS_INDICATORS_DELETE, e => {
+          const deleteNotifications: {notificationReceiverIds: number}[] = e;
+          const notificationReceiverIds = deleteNotifications.flatMap(item => item.notificationReceiverIds || []);
 
-        dismissNotifications(serverUrl, notificationReceiverIds);
-      });
+          dismissNotifications(serverUrl, notificationReceiverIds);
+        }),
+      );
     }
   }
 


### PR DESCRIPTION
**Description**:

When a transaction expires, the notification badge incremented by 2–3 instead of 1. This was most visible for the transaction creator, whose badge starts at 0 before the expiry event, making the inflation unmistakable.

`listenForUpdates()` in `storeNotifications.ts` registers socket.io listeners for `notifications:new` and `notifications:indicators:delete` on every `ws.setup()` call without removing the previous ones — the disposer functions returned by `ws.on()` were being discarded. `ws.setup()` fires 3 times during a normal login/startup sequence, so two copies of each listener ended up on the same socket. One backend event fired both, doubling (or tripling) the badge increment.

Fix: save the disposers returned by `ws.on()` and call them at the top of `listenForUpdates()` before re-registering, making the function idempotent regardless of how many times `ws.setup()` fires. The underlying socket connection is unaffected — no open/close occurs between the redundant setup calls, so there is no message-loss window.

**Related issue(s)**:

Fixes #3098