### PR TITLE
fix: enforcing 4000 characters in TransactionGroup.description db column

### DIFF
--- a/back-end/libs/common/src/database/entities/transaction-group.entity.ts
+++ b/back-end/libs/common/src/database/entities/transaction-group.entity.ts
@@ -1,15 +1,14 @@
 import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { TransactionGroupItem } from './';
 
-export const MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH = 256;
+export const MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH = 4000;
 
 @Entity()
 export class TransactionGroup {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
-  // @Column({ length: MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH })
+  @Column({ length: MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH })
   description: string;
 
   @Column({ default: false })

--- a/back-end/typeorm/migrations/1783680807000-TransactionGroupDescriptionMaxLength.ts
+++ b/back-end/typeorm/migrations/1783680807000-TransactionGroupDescriptionMaxLength.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class TransactionGroupDescriptionMaxLength1783680807000 implements MigrationInterface {
+  name = 'TransactionGroupDescriptionMaxLength1783680807000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "transaction_group" ALTER COLUMN "description" TYPE character varying(256)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "transaction_group" ALTER COLUMN "description" TYPE character varying`,
+    );
+  }
+}

--- a/back-end/typeorm/migrations/1783680807000-TransactionGroupDescriptionMaxLength.ts
+++ b/back-end/typeorm/migrations/1783680807000-TransactionGroupDescriptionMaxLength.ts
@@ -5,7 +5,7 @@ export class TransactionGroupDescriptionMaxLength1783680807000 implements Migrat
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "transaction_group" ALTER COLUMN "description" TYPE character varying(256)`,
+      `ALTER TABLE "transaction_group" ALTER COLUMN "description" TYPE character varying(4000)`,
     );
   }
 

--- a/front-end/src/shared/interfaces/organization/transactions/index.ts
+++ b/front-end/src/shared/interfaces/organization/transactions/index.ts
@@ -120,4 +120,4 @@ export interface SignatureImportResultDto {
 }
 
 export const MAX_TRANSACTION_DESCRIPTION_LENGTH = 256;
-export const MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH = 256;
+export const MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH = 4000;

--- a/front-end/src/tests/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.spec.ts
+++ b/front-end/src/tests/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.spec.ts
@@ -269,7 +269,7 @@ describe('CreateTransactionGroup.vue', () => {
     const element = wrapper.find('[data-testid="input-transaction-group-description"]').element;
     expect(element instanceof HTMLInputElement).toBe(true);
     const input = element as HTMLInputElement;
-    expect(input.maxLength).toBe(256);
+    expect(input.maxLength).toBe(4000);
   })
 
   describe('group item row', () => {


### PR DESCRIPTION
**Description**:

Changes below enforce 4000 characters 
- in `TransactionGroup.description` db column and add the matching migration
- in `Transaction Group Description` field input validation on front-end side

**Related issue(s)**:

Contributes to #2937 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
