### PR TITLE
fix: file create/update/append transaction "file contents" not persisting across draft saves

### DIFF
--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseDraftLoad.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseDraftLoad.vue
@@ -1,11 +1,6 @@
-<script setup lang="ts">
+<script lang="ts" setup>
 import { onMounted } from 'vue';
-import {
-  FileAppendTransaction,
-  FileCreateTransaction,
-  FileUpdateTransaction,
-  type Transaction,
-} from '@hiero-ledger/sdk';
+import { type Transaction } from '@hiero-ledger/sdk';
 
 import useTransactionGroupStore from '@renderer/stores/storeTransactionGroup';
 
@@ -47,14 +42,6 @@ const handleLoadFromDraft = async () => {
 
   if (transactionBytes) {
     const transaction = getTransactionFromBytes(transactionBytes);
-    if (
-      transaction instanceof FileCreateTransaction ||
-      transaction instanceof FileUpdateTransaction ||
-      (transaction instanceof FileAppendTransaction && transaction.contents?.length === 0)
-    ) {
-      //@ts-expect-error - contents should be null
-      transaction.setContents(null);
-    }
     emit('draft-loaded', transaction);
   }
 };

--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+<script lang="ts" setup>
 import type { TransactionApproverDto } from '@shared/interfaces/organization/approvers';
 import {
   applyNanoOffset,
@@ -18,8 +18,6 @@ import type { CreateTransactionFunc } from '.';
 
 import { computed, onMounted, reactive, ref, toRaw, watch } from 'vue';
 import {
-  FileAppendTransaction,
-  FileUpdateTransaction,
   Hbar,
   KeyList,
   NodeCreateTransaction,
@@ -327,13 +325,6 @@ const saveDraft = async (): Promise<void> => {
 
 const getTransactionBytes = () => {
   const transaction = createTransaction({ ...data } as TransactionCommonData);
-  if (
-    transaction instanceof FileUpdateTransaction ||
-    transaction instanceof FileAppendTransaction
-  ) {
-    //@ts-expect-error - contents should be null
-    transaction.setContents(null);
-  }
   return transaction.toBytes();
 };
 

--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransactionModal.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransactionModal.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
-import {
-  FileAppendTransaction,
-  FileCreateTransaction,
-  FileUpdateTransaction,
-  type Transaction,
-} from '@hiero-ledger/sdk';
+import { type Transaction } from '@hiero-ledger/sdk';
 
 import { computed, ref } from 'vue';
 
@@ -87,14 +82,6 @@ function handleEditGroupItem() {
 function getTransactionBytes() {
   if (!props.getTransaction) return;
   const transaction = props.getTransaction();
-  if (
-    transaction instanceof FileCreateTransaction ||
-    transaction instanceof FileUpdateTransaction ||
-    transaction instanceof FileAppendTransaction
-  ) {
-    //@ts-expect-error - contents should be null
-    transaction.setContents(null);
-  }
   return transaction.toBytes();
 }
 

--- a/front-end/src/renderer/components/Transaction/Create/FileData/FileContentFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileData/FileContentFormData.vue
@@ -70,11 +70,12 @@ watch(
       manualContent.value = '';
       file.value = null;
     } else if (typeof contents === 'string') {
-      file.value = null;
       manualContent.value = contents;
+      file.value = null;
     } else {
-      // contents is Uint8Array, meaning user just loaded a File
+      // contents is Uint8Array, meaning user has uploaded a file
       manualContent.value = '';
+      // we don't set file.value here because the file is already set when user uploads a file
     }
   },
   { immediate: true },

--- a/front-end/src/renderer/components/Transaction/Create/FileData/FileContentFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/FileData/FileContentFormData.vue
@@ -62,6 +62,23 @@ watch([file, manualContent], () => {
     manualContent.value.length > 0 ? manualContent.value : file.value?.content || null,
   );
 });
+
+watch(
+  () => props.contents,
+  contents => {
+    if (contents === null) {
+      manualContent.value = '';
+      file.value = null;
+    } else if (typeof contents === 'string') {
+      file.value = null;
+      manualContent.value = contents;
+    } else {
+      // contents is Uint8Array, meaning user just loaded a File
+      manualContent.value = '';
+    }
+  },
+  { immediate: true },
+);
 </script>
 <template>
   <div class="mt-6 form-group">

--- a/front-end/src/tests/renderer/components/Transaction/Create/BaseTransaction/BaseDraftLoad.spec.ts
+++ b/front-end/src/tests/renderer/components/Transaction/Create/BaseTransaction/BaseDraftLoad.spec.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+import {
+  FileAppendTransaction,
+  FileCreateTransaction,
+  FileUpdateTransaction,
+} from '@hiero-ledger/sdk';
+
+const mocks = vi.hoisted(() => ({
+  routeQuery: {} as Record<string, string | undefined>,
+  groupItems: [] as Array<{ transactionBytes: Uint8Array }>,
+  getDraft: vi.fn(),
+  getTransactionFromBytes: vi.fn(),
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: mocks.routeQuery }),
+}));
+
+vi.mock('@renderer/stores/storeTransactionGroup', () => ({
+  default: () => ({ groupItems: mocks.groupItems }),
+}));
+
+vi.mock('@renderer/services/transactionDraftsService', () => ({
+  getDraft: mocks.getDraft,
+}));
+
+vi.mock('@renderer/utils', () => ({
+  getTransactionFromBytes: mocks.getTransactionFromBytes,
+}));
+
+import BaseDraftLoad from '@renderer/components/Transaction/Create/BaseTransaction/BaseDraftLoad.vue';
+
+function makeNonEmptyFileTransaction(
+  TransactionType:
+    | typeof FileAppendTransaction
+    | typeof FileCreateTransaction
+    | typeof FileUpdateTransaction,
+): FileAppendTransaction | FileCreateTransaction | FileUpdateTransaction {
+  const transaction = new TransactionType();
+  transaction.setContents(new Uint8Array([1, 2, 3]));
+  return transaction;
+}
+
+describe('BaseDraftLoad', () => {
+  beforeEach(() => {
+    mocks.routeQuery = {};
+    mocks.groupItems = [];
+    mocks.getDraft.mockReset();
+    mocks.getTransactionFromBytes.mockReset();
+  });
+
+  test.each([
+    ['FileCreateTransaction', FileCreateTransaction],
+    ['FileUpdateTransaction', FileUpdateTransaction],
+    ['FileAppendTransaction', FileAppendTransaction],
+  ])('preserves non-empty %s contents when loading a draft', async (_label, TransactionType) => {
+    const transaction = makeNonEmptyFileTransaction(TransactionType);
+    const setContentsSpy = vi.spyOn(transaction, 'setContents');
+
+    mocks.routeQuery = { draftId: 'draft-1' };
+    mocks.getDraft.mockResolvedValue({ transactionBytes: '0x1234' });
+    mocks.getTransactionFromBytes.mockReturnValue(transaction);
+
+    const wrapper = mount(BaseDraftLoad);
+    await flushPromises();
+
+    expect(mocks.getDraft).toHaveBeenCalledWith('draft-1');
+    expect(mocks.getTransactionFromBytes).toHaveBeenCalledWith('0x1234');
+    expect(setContentsSpy).not.toHaveBeenCalled();
+    expect(Array.from(transaction.contents ?? [])).toEqual([1, 2, 3]);
+    expect(wrapper.emitted('draft-loaded')?.[0]).toEqual([transaction]);
+  });
+});

--- a/front-end/src/tests/renderer/components/Transaction/Create/FileData/FileContentFormData.spec.ts
+++ b/front-end/src/tests/renderer/components/Transaction/Create/FileData/FileContentFormData.spec.ts
@@ -41,6 +41,74 @@ describe('FileContentFormData', () => {
     vi.clearAllMocks();
   });
 
+  describe('persisted contents props', () => {
+    test('displays existing string file content loaded from a pre-existing draft', async () => {
+      const draftContents = 'persisted text contents from draft';
+
+      const wrapper = mount(FileContentFormData, {
+        props: { fileId: '0.0.12345', contents: draftContents },
+      });
+
+      await flushPromises();
+
+      const manualTextarea = wrapper.find<HTMLTextAreaElement>(
+        '[data-testid="textarea-file-content"]',
+      );
+
+      expect(wrapper.find('[data-testid="textarea-file-read-content"]').exists()).toBe(false);
+      expect(manualTextarea.exists()).toBe(true);
+      expect(manualTextarea.element.value).toBe(draftContents);
+    });
+
+    test('does not restore Uint8Array contents as uploaded file state', async () => {
+      const wrapper = mount(FileContentFormData, {
+        props: { fileId: '0.0.101', contents: BIN_BYTES },
+      });
+
+      await flushPromises();
+
+      expect(decodeProtoMock).not.toHaveBeenCalled();
+      expect(wrapper.find('[data-testid="textarea-file-read-content"]').exists()).toBe(false);
+      expect(
+        wrapper.find<HTMLTextAreaElement>('[data-testid="textarea-file-content"]').element.value,
+      ).toBe('');
+    });
+
+    test('does not emit restored Uint8Array contents from props', async () => {
+      const wrapper = mount(FileContentFormData, {
+        props: { fileId: '0.0.12345', contents: TXT_BYTES },
+      });
+
+      await flushPromises();
+
+      expect(wrapper.emitted('update:contents')).toBeUndefined();
+      expect(wrapper.find('[data-testid="textarea-file-read-content"]').exists()).toBe(false);
+      expect(
+        wrapper.find<HTMLTextAreaElement>('[data-testid="textarea-file-content"]').element.value,
+      ).toBe('');
+    });
+
+    test('clears displayed content when persisted contents are null', async () => {
+      const wrapper = mount(FileContentFormData, {
+        props: { fileId: '0.0.12345', contents: 'persisted text contents' },
+      });
+
+      await flushPromises();
+
+      expect(
+        wrapper.find<HTMLTextAreaElement>('[data-testid="textarea-file-content"]').element.value,
+      ).toBe('persisted text contents');
+
+      await wrapper.setProps({ contents: null });
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="textarea-file-read-content"]').exists()).toBe(false);
+      expect(
+        wrapper.find<HTMLTextAreaElement>('[data-testid="textarea-file-content"]').element.value,
+      ).toBe('');
+    });
+  });
+
   describe('Order 1: set fileId first, then upload file', () => {
     test('special fileId + .bin file → protobuf decoded content displayed', async () => {
       const wrapper = mount(FileContentFormData, {

--- a/front-end/src/tests/renderer/utils/sdk/createTransactions.spec.ts
+++ b/front-end/src/tests/renderer/utils/sdk/createTransactions.spec.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+import { describe, expect, test } from 'vitest';
+import { Hbar } from '@hiero-ledger/sdk';
+
+import {
+  createFileAppendTransaction,
+  createFileCreateTransaction,
+  createFileUpdateTransaction,
+  type FileAppendData,
+  type FileData,
+  type FileUpdateData,
+  type TransactionCommonData,
+} from '@renderer/utils/sdk/createTransactions';
+
+const commonData: TransactionCommonData = {
+  payerId: '0.0.1001',
+  validStart: new Date(Date.now() + 60_000),
+  maxTransactionFee: new Hbar(2),
+  transactionMemo: '',
+};
+
+function fileData(contents: string | Uint8Array): FileData {
+  return {
+    ownerKey: null,
+    fileMemo: '',
+    expirationTime: null,
+    contents,
+  };
+}
+
+describe('createTransactions file contents', () => {
+
+  test('sets string contents on file create transactions', () => {
+    const contents = 'hello world';
+
+    const transaction = createFileCreateTransaction({
+      ...commonData,
+      ...fileData(contents),
+    });
+
+    expect(Array.from(transaction.contents ?? [])).toEqual(
+      Array.from(new TextEncoder().encode(contents)),
+    );
+  });
+
+  test('sets string contents on file update transactions', () => {
+    const contents = 'hello world';
+    const data: TransactionCommonData & FileUpdateData = {
+      ...commonData,
+      ...fileData(contents),
+      fileId: '0.0.150',
+    };
+
+    const transaction = createFileUpdateTransaction(data);
+
+    expect(Array.from(transaction.contents ?? [])).toEqual(
+      Array.from(new TextEncoder().encode(contents)),
+    );
+  });
+
+  test('sets string contents on file append transactions', () => {
+    const contents = 'hello world';
+    const data: TransactionCommonData & FileAppendData = {
+      ...commonData,
+      fileId: '0.0.150',
+      chunkSize: 1024,
+      maxChunks: 1,
+      contents,
+    };
+
+    const transaction = createFileAppendTransaction(data);
+
+    expect(Array.from(transaction.contents ?? [])).toEqual(
+      Array.from(new TextEncoder().encode(contents)),
+    );
+  });
+});


### PR DESCRIPTION
**Description**:

These changes enable any existing file contents in drafts of _FileCreate_, _FileUpdate_ and _FileAppend_ transactions to properly initialize the `File Contents` text area in the transaction creation form.

**Related issue(s)**:

Fixes #2987

**Notes for reviewer**:
 
Related unit tests added.
