### PR TITLE
fix: adding content-security-policy to front-end/index.html

### DIFF
--- a/front-end/index.html
+++ b/front-end/index.html
@@ -9,6 +9,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap"
       rel="stylesheet"
     />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
**Description**:
Changes below fix security warning reported by ElectronJS.
They update `front-end/index.html` as recommended in ElectronJS security [instructions](https://www.electronjs.org/docs/latest/tutorial/security#7-define-a-content-security-policy).

Warning reported in Chromium console at startup:
```
VM3496 renderer_init:2 Electron Security Warning (Insecure Content-Security-Policy) This renderer process has either no Content Security
  Policy set or a policy with "unsafe-eval" enabled. This exposes users of
  this app to unnecessary security risks.

For more information and help, consult
https://electronjs.org/docs/tutorial/security.
This warning will not show up
once the app is packaged.
```

**Related issue(s)**:

Contributes to #2937

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
