### PR TITLE
feat: CSV import should interpret times using the app's display timezone, with optional offset support

### DIFF
--- a/front-end/src/renderer/pages/CreateTransactionGroup/ImportCSVController.vue
+++ b/front-end/src/renderer/pages/CreateTransactionGroup/ImportCSVController.vue
@@ -9,6 +9,7 @@ import { AppCache } from '@renderer/caches/AppCache';
 import useNetworkStore from '@renderer/stores/storeNetwork.ts';
 import useAccountId from '@renderer/composables/useAccountId.ts';
 import type { ActionReport } from '@renderer/components/ActionController/ActionReport.ts';
+import { parseDateTime } from '@renderer/utils/parseDateTime.ts';
 
 const logger = createLogger('renderer.page.importCSVController');
 
@@ -112,7 +113,7 @@ async function handleImportCsv(): Promise<ActionReport | null> {
           // Create the new validStart value, or add 1 millisecond to the existing one for subsequent transactions
           if (!validStart) {
             const startDate = rowInfo[2];
-            validStart = new Date(`${startDate} ${sendingTime}`);
+            validStart = await parseDateTime(startDate, sendingTime);
             if (validStart < new Date()) {
               validStart = new Date();
             }

--- a/front-end/src/renderer/utils/parseDateTime.ts
+++ b/front-end/src/renderer/utils/parseDateTime.ts
@@ -1,0 +1,67 @@
+import useDateTimeSetting, {
+  DateTimeOptions,
+} from '@renderer/composables/user/useDateTimeSetting.ts';
+
+/**
+ * Parses a date and time string with optional timezone offset.
+ *
+ * Date format: MM/DD/YY
+ * Time format: HH:MM[Z|±HH:MM]
+ *   - Z: Designates UTC time
+ *   - +HH:MM or -HH:MM: Timezone offset
+ *
+ * When no offset is provided, use the tool's settings for Date/Time Format
+ * When an offset is provided, it overrides the tool's setting.
+ *
+ * Note: to remain compatible with existing CSV file syntax (pre-timezone support):
+ *   - time with optional seconds are accepted
+ *   - single digit months, days, hours, minutes, seconds are accepted (e.g., 1/2/27, 3:4:5)
+ *   - 4 digit years are accepted (e.g., 1/2/2027)
+ */
+export async function parseDateTime(date: string, time: string): Promise<Date> {
+  const DATE_RE = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/;
+  const TIME_RE = /^(\d{1,2}):(\d{1,2})(?::(\d{1,2}))?(Z|[+-]\d{2}:\d{2})?$/;
+
+  const matchDate = DATE_RE.exec(date);
+  if (!matchDate) {
+    throw new Error(`Invalid date format: ${date}`);
+  }
+  const matchTime = TIME_RE.exec(time);
+  if (!matchTime) {
+    throw new Error(`Invalid time format: ${time}`);
+  }
+
+  const [, dateMonth, dateDay, dateYear] = matchDate;
+  const [, timeHour, timeMinute, timeSecond, timezone] = matchTime;
+
+  const monthNum = Number(dateMonth);
+  const dayNum = Number(dateDay);
+
+  // Handle year: if 2 digits, assume > 2000 and < 2100, otherwise use as is
+  const fullYear = dateYear.length === 2 ? 2000 + Number(dateYear) : Number(dateYear);
+
+  const hour = Number(timeHour);
+  const minute = Number(timeMinute);
+  const second = timeSecond ? Number(timeSecond) : 0;
+
+  // Pad for ISO string formatting
+  const paddedMonth = String(monthNum).padStart(2, '0');
+  const paddedDay = String(dayNum).padStart(2, '0');
+  const paddedHour = String(hour).padStart(2, '0');
+  const paddedMinute = String(minute).padStart(2, '0');
+  const paddedSecond = String(second).padStart(2, '0');
+
+  // If timezone (offset or Z) is provided, use it directly
+  if (timezone) {
+    return new Date(
+      `${fullYear}-${paddedMonth}-${paddedDay}T${paddedHour}:${paddedMinute}:${paddedSecond}${timezone}`,
+    );
+  }
+
+  // Otherwise, use the app's Date/Time Format setting
+  const settings = await useDateTimeSetting().getDateTimeSetting();
+
+  return settings === DateTimeOptions.UTC_TIME
+    ? new Date(Date.UTC(fullYear, monthNum - 1, dayNum, hour, minute, second))
+    : new Date(fullYear, monthNum - 1, dayNum, hour, minute, second);
+}

--- a/front-end/src/renderer/utils/parseDateTime.ts
+++ b/front-end/src/renderer/utils/parseDateTime.ts
@@ -6,7 +6,7 @@ import useDateTimeSetting, {
  * Parses a date and time string with optional timezone offset.
  *
  * Date format: MM/DD/YY
- * Time format: HH:MM[Z|±HH:MM]
+ * Time format: HH:MM[:SS][Z|±HH:MM]
  *   - Z: Designates UTC time
  *   - +HH:MM or -HH:MM: Timezone offset
  *

--- a/front-end/src/renderer/utils/parseDateTime.ts
+++ b/front-end/src/renderer/utils/parseDateTime.ts
@@ -44,6 +44,15 @@ export async function parseDateTime(date: string, time: string): Promise<Date> {
   const minute = Number(timeMinute);
   const second = timeSecond ? Number(timeSecond) : 0;
 
+  // Validate ranges to avoid Date overflow
+  const maxDay = new Date(Date.UTC(fullYear, monthNum, 0)).getUTCDate();
+  if (monthNum < 1 || monthNum > 12 || dayNum < 1 || dayNum > maxDay) {
+    throw new Error(`Invalid date value: ${date}`);
+  }
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 59) {
+    throw new Error(`Invalid time value: ${time}`);
+  }
+
   // Pad for ISO string formatting
   const paddedMonth = String(monthNum).padStart(2, '0');
   const paddedDay = String(dayNum).padStart(2, '0');
@@ -51,17 +60,26 @@ export async function parseDateTime(date: string, time: string): Promise<Date> {
   const paddedMinute = String(minute).padStart(2, '0');
   const paddedSecond = String(second).padStart(2, '0');
 
+  let result: Date;
+
   // If timezone (offset or Z) is provided, use it directly
   if (timezone) {
-    return new Date(
+    result = new Date(
       `${fullYear}-${paddedMonth}-${paddedDay}T${paddedHour}:${paddedMinute}:${paddedSecond}${timezone}`,
     );
+  } else {
+    // Otherwise, use the app's Date/Time Format setting
+    const settings = await useDateTimeSetting().getDateTimeSetting();
+
+    result = settings === DateTimeOptions.UTC_TIME
+      ? new Date(Date.UTC(fullYear, monthNum - 1, dayNum, hour, minute, second))
+      : new Date(fullYear, monthNum - 1, dayNum, hour, minute, second);
   }
 
-  // Otherwise, use the app's Date/Time Format setting
-  const settings = await useDateTimeSetting().getDateTimeSetting();
+  // Validate the resulting date
+  if (Number.isNaN(result.getTime())) {
+    throw new Error(`Invalid date/time value: ${date} ${time}`);
+  }
 
-  return settings === DateTimeOptions.UTC_TIME
-    ? new Date(Date.UTC(fullYear, monthNum - 1, dayNum, hour, minute, second))
-    : new Date(fullYear, monthNum - 1, dayNum, hour, minute, second);
+  return result;
 }

--- a/front-end/src/tests/renderer/pages/CreateTransactionGroup/ImportCSVController.spec.ts
+++ b/front-end/src/tests/renderer/pages/CreateTransactionGroup/ImportCSVController.spec.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { DateTimeOptions } from '@renderer/composables/user/useDateTimeSetting';
-import { parseDateTime } from '@renderer/utils/parseDateTime';
+import { DateTimeOptions } from '@renderer/composables/user/useDateTimeSetting.ts';
+import { parseDateTime } from '@renderer/utils/parseDateTime.ts';
 
 const mocks = vi.hoisted(() => ({
   getDateTimeSetting: vi.fn(),
 }));
 
-vi.mock('@renderer/composables/user/useDateTimeSetting', () => ({
+vi.mock('@renderer/composables/user/useDateTimeSetting.ts', () => ({
   default: () => ({
     getDateTimeSetting: () => mocks.getDateTimeSetting(),
   }),

--- a/front-end/src/tests/renderer/pages/CreateTransactionGroup/ImportCSVController.spec.ts
+++ b/front-end/src/tests/renderer/pages/CreateTransactionGroup/ImportCSVController.spec.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { DateTimeOptions } from '@renderer/composables/user/useDateTimeSetting';
+import { parseDateTime } from '@renderer/utils/parseDateTime';
+
+const mocks = vi.hoisted(() => ({
+  getDateTimeSetting: vi.fn(),
+}));
+
+vi.mock('@renderer/composables/user/useDateTimeSetting', () => ({
+  default: () => ({
+    getDateTimeSetting: () => mocks.getDateTimeSetting(),
+  }),
+  DateTimeOptions: {
+    UTC_TIME: 'utc-time',
+    LOCAL_TIME: 'local-time',
+  },
+}));
+
+describe('ImportCSVController - parseDateTime', () => {
+  beforeEach(() => {
+    mocks.getDateTimeSetting.mockReset();
+  });
+
+  describe('Date parsing', () => {
+    test('parses 2-digit year format MM/DD/YY', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      const result = await parseDateTime('01/15/27', '10:30');
+      expect(result.getUTCFullYear()).toBe(2027);
+      expect(result.getUTCMonth()).toBe(0); // January
+      expect(result.getUTCDate()).toBe(15);
+    });
+
+    test('parses 4-digit year format MM/DD/YYYY', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      const result = await parseDateTime('01/15/2027', '10:30');
+      expect(result.getUTCFullYear()).toBe(2027);
+      expect(result.getUTCMonth()).toBe(0); // January
+      expect(result.getUTCDate()).toBe(15);
+    });
+
+    test('parses single-digit month and day M/D/YY', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      const result = await parseDateTime('4/5/27', '10:30');
+      expect(result.getUTCFullYear()).toBe(2027);
+      expect(result.getUTCMonth()).toBe(3); // April
+      expect(result.getUTCDate()).toBe(5);
+    });
+
+    test('rejects invalid date with wrong separator', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      await expect(parseDateTime('01-15-26', '10:30')).rejects.toThrow(
+        'Invalid date format: 01-15-26',
+      );
+    });
+
+    test('rejects invalid date with 1-digit year', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      await expect(parseDateTime('01/15/6', '10:30')).rejects.toThrow(
+        'Invalid date format: 01/15/6',
+      );
+    });
+
+    test('rejects empty date components', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      await expect(parseDateTime('//26', '10:30')).rejects.toThrow('Invalid date format: //26');
+    });
+  });
+
+  describe('Time parsing', () => {
+    test('parses time without seconds HH:MM', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      const result = await parseDateTime('01/15/27', '14:30');
+      expect(result.getUTCHours()).toBe(14);
+      expect(result.getUTCMinutes()).toBe(30);
+      expect(result.getUTCSeconds()).toBe(0);
+    });
+
+    test('parses time with seconds HH:MM:SS', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      const result = await parseDateTime('01/15/27', '14:30:45');
+      expect(result.getUTCHours()).toBe(14);
+      expect(result.getUTCMinutes()).toBe(30);
+      expect(result.getUTCSeconds()).toBe(45);
+    });
+
+    test('parses time with single digit parts H:M:S', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      const result = await parseDateTime('01/15/27', '5:9:3');
+      expect(result.getUTCHours()).toBe(5);
+      expect(result.getUTCMinutes()).toBe(9);
+      expect(result.getUTCSeconds()).toBe(3);
+    });
+
+    test('handles midnight 0:0:0', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      const result = await parseDateTime('01/15/27', '0:0:0');
+      expect(result.getUTCHours()).toBe(0);
+      expect(result.getUTCMinutes()).toBe(0);
+      expect(result.getUTCSeconds()).toBe(0);
+    });
+
+    test('handles end of day 23:59:59', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      const result = await parseDateTime('01/15/27', '23:59:59');
+      expect(result.getUTCHours()).toBe(23);
+      expect(result.getUTCMinutes()).toBe(59);
+      expect(result.getUTCSeconds()).toBe(59);
+    });
+
+    test('rejects empty time components', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      await expect(parseDateTime('01/15/26', '::30')).rejects.toThrow('Invalid time format: ::30');
+    });
+  });
+
+  describe('Time parsing with timezone offset', () => {
+    test('parses time with Z suffix H:M:SZ', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.LOCAL_TIME);
+      const result = await parseDateTime('01/15/27', '5:9:3Z');
+      expect(result.getUTCHours()).toBe(5);
+      expect(result.getUTCMinutes()).toBe(9);
+      expect(result.getUTCSeconds()).toBe(3);
+
+      expect(mocks.getDateTimeSetting).not.toHaveBeenCalled();
+    });
+
+    test('parses time with positive offset HH:MM:SS+HH:MM', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.LOCAL_TIME);
+      const result = await parseDateTime('01/15/27', '21:30:45+05:30');
+      expect(result.getUTCHours()).toBe(16);
+      expect(result.getUTCMinutes()).toBe(0);
+      expect(result.getUTCSeconds()).toBe(45);
+
+      expect(mocks.getDateTimeSetting).not.toHaveBeenCalled();
+    });
+
+    test('parses time with negative offset HH:MM-HH:MM', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.LOCAL_TIME);
+      const result = await parseDateTime('01/15/27', '21:30-06:00');
+      expect(result.getUTCHours()).toBe(3);
+      expect(result.getUTCMinutes()).toBe(30);
+      expect(result.getUTCSeconds()).toBe(0);
+
+      expect(mocks.getDateTimeSetting).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Real-world scenarios', () => {
+    test('uses UTC_TIME setting when no offset provided', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      const result = await parseDateTime('01/15/27', '14:30');
+      expect(result.getUTCFullYear()).toBe(2027);
+      expect(result.getUTCMonth()).toBe(0);
+      expect(result.getUTCDate()).toBe(15);
+      expect(result.getUTCHours()).toBe(14);
+      expect(result.getUTCMinutes()).toBe(30);
+    });
+
+    test('uses LOCAL_TIME setting when no offset provided', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.LOCAL_TIME);
+      const result = await parseDateTime('3/15/27', '14:30');
+      expect(result.getFullYear()).toBe(2027);
+      expect(result.getMonth()).toBe(2);
+      expect(result.getDate()).toBe(15);
+      expect(result.getHours()).toBe(14);
+      expect(result.getMinutes()).toBe(30);
+    });
+
+    test('interpret as UTC when Z offset provided, ignoring the settings', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.LOCAL_TIME);
+      const result = await parseDateTime('03/15/27', '14:30Z');
+      expect(result.getUTCFullYear()).toBe(2027);
+      expect(result.getUTCMonth()).toBe(2);
+      expect(result.getUTCDate()).toBe(15);
+      expect(result.getUTCHours()).toBe(14);
+      expect(result.getUTCMinutes()).toBe(30);
+    });
+
+    test('apply specified offset, ignoring the settings', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.LOCAL_TIME);
+      const result = await parseDateTime('03/15/27', '14:30+02:00');
+      expect(result.getUTCFullYear()).toBe(2027);
+      expect(result.getUTCMonth()).toBe(2);
+      expect(result.getUTCDate()).toBe(15);
+      expect(result.getUTCHours()).toBe(12);
+      expect(result.getUTCMinutes()).toBe(30);
+    });
+  });
+});

--- a/front-end/src/tests/renderer/pages/CreateTransactionGroup/ImportCSVController.spec.ts
+++ b/front-end/src/tests/renderer/pages/CreateTransactionGroup/ImportCSVController.spec.ts
@@ -60,6 +60,20 @@ describe('ImportCSVController - parseDateTime', () => {
       );
     });
 
+    test('rejects invalid date with invalid month', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      await expect(parseDateTime('13/15/26', '10:30')).rejects.toThrow(
+        'Invalid date value: 13/15/26',
+      );
+    });
+
+    test('rejects invalid date with invalid day of month', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      await expect(parseDateTime('02/30/26', '10:30')).rejects.toThrow(
+        'Invalid date value: 02/30/26',
+      );
+    });
+
     test('rejects empty date components', async () => {
       mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
       await expect(parseDateTime('//26', '10:30')).rejects.toThrow('Invalid date format: //26');
@@ -110,6 +124,21 @@ describe('ImportCSVController - parseDateTime', () => {
     test('rejects empty time components', async () => {
       mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
       await expect(parseDateTime('01/15/26', '::30')).rejects.toThrow('Invalid time format: ::30');
+    });
+
+    test('rejects time with invalid hours', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      await expect(parseDateTime('01/15/26', '25:30')).rejects.toThrow('Invalid time value: 25:30');
+    });
+
+    test('rejects time with invalid minutes', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      await expect(parseDateTime('01/15/26', '10:60')).rejects.toThrow('Invalid time value: 10:60');
+    });
+
+    test('rejects time with invalid seconds', async () => {
+      mocks.getDateTimeSetting.mockResolvedValue(DateTimeOptions.UTC_TIME);
+      await expect(parseDateTime('01/15/26', '10:30:60')).rejects.toThrow('Invalid time value: 10:30:60');
     });
   });
 


### PR DESCRIPTION
**Description**:

- Improve date/time parsing in CSV file import
- extract this functionality as a `parseDateTime` utility 
- support time zone as follows:
  - consider date/time as UTC when `21:30Z` format is used
  - apply time offset when `21:30-06:00` format is used
  - use application settings for Date & Time format when no timezone information is provided
- add unit test coverage for `parseDateTime`

**Related issue(s)**:

Fixes #3037

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
