### PR TITLE
fix: false "unsaved changes" prompt when leaving unmodified draft

### DIFF
--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseDraftLoad.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseDraftLoad.vue
@@ -12,7 +12,7 @@ import { getTransactionFromBytes } from '@renderer/utils';
 
 /* Emits */
 const emit = defineEmits<{
-  (event: 'draft-loaded', transaction: Transaction): void;
+  (event: 'draft-loaded', transaction: Transaction, description: string): void;
 }>();
 
 /* Stores */
@@ -32,17 +32,21 @@ const handleLoadFromDraft = async () => {
   }
 
   let transactionBytes: string | null = null;
+  let description = '';
 
   if (!group) {
     const draft = await getDraft(draftId);
     transactionBytes = draft.transactionBytes;
+    description = draft.description || '';
   } else if (groupIndex) {
-    transactionBytes = transactionGroup.groupItems[Number(groupIndex)].transactionBytes.toString();
+    const groupItem = transactionGroup.groupItems[Number(groupIndex)];
+    transactionBytes = groupItem.transactionBytes.toString();
+    description = groupItem.description || '';
   }
 
   if (transactionBytes) {
     const transaction = getTransactionFromBytes(transactionBytes);
-    emit('draft-loaded', transaction);
+    emit('draft-loaded', transaction, description);
   }
 };
 

--- a/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
+++ b/front-end/src/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue
@@ -151,7 +151,7 @@ const hasTransactionChanged = computed(() => {
     ) {
       result = true; // startTimestamp was manually updated to a future time
     } else {
-      // whether tx data match, excluding validStart and startTimestamp
+      // whether tx data match, excluding validStart, startTimestamp and expirationTime
       result = !transactionsDataMatch(initialTransaction.value as Transaction, transaction.value);
     }
   } else {
@@ -174,8 +174,10 @@ const isNodeCreationPrivRequired = computed(() => {
 });
 
 /* Handlers */
-const handleDraftLoaded = async (transaction: Transaction) => {
+const handleDraftLoaded = async (transaction: Transaction, loadedDescription: string) => {
   initialTransaction.value = transaction;
+  description.value = loadedDescription;
+  initialDescription.value = loadedDescription;
 
   const txData = getTransactionCommonData(transaction);
   payerData.accountId.value = txData.payerId;

--- a/front-end/src/renderer/utils/sdk/getData.ts
+++ b/front-end/src/renderer/utils/sdk/getData.ts
@@ -632,10 +632,10 @@ export function hasStartTimestampChanged(
 export function transactionsDataMatch(t1: Transaction, t2: Transaction): boolean {
   const t1Data = getAllData(t1);
   const t2Data = getAllData(t2);
-  t1Data.validStart = undefined
-  t2Data.validStart = undefined
-  t1Data.startTimestamp = undefined;
-  t2Data.startTimestamp = undefined;
+
+  clearComparisonFields(t1Data);
+  clearComparisonFields(t2Data);
+
   // Defensive: `uiId` is a render-side stable key for endpoint rows and must
   // never affect the "has the user edited anything?" comparison. The current
   // `getRegisteredNodeData` does not emit it, but strip here too so that any
@@ -644,6 +644,14 @@ export function transactionsDataMatch(t1: Transaction, t2: Transaction): boolean
   stripUiIds(t2Data);
   return JSON.stringify(t1Data) === JSON.stringify(t2Data);
 }
+
+const comparisonIgnoreFields = ['validStart', 'startTimestamp', 'expirationTime'];
+
+const clearComparisonFields = (data: Record<string, unknown>) => {
+  for (const field of comparisonIgnoreFields) {
+    data[field] = undefined;
+  }
+};
 
 const stripUiIds = (data: Record<string, unknown>) => {
   const endpoints = data['serviceEndpoints'];

--- a/front-end/src/tests/renderer/components/Transaction/Create/BaseTransaction/BaseDraftLoad.spec.ts
+++ b/front-end/src/tests/renderer/components/Transaction/Create/BaseTransaction/BaseDraftLoad.spec.ts
@@ -60,7 +60,7 @@ describe('BaseDraftLoad', () => {
     const setContentsSpy = vi.spyOn(transaction, 'setContents');
 
     mocks.routeQuery = { draftId: 'draft-1' };
-    mocks.getDraft.mockResolvedValue({ transactionBytes: '0x1234' });
+    mocks.getDraft.mockResolvedValue({ transactionBytes: '0x1234', description: 'draft description' });
     mocks.getTransactionFromBytes.mockReturnValue(transaction);
 
     const wrapper = mount(BaseDraftLoad);
@@ -70,6 +70,6 @@ describe('BaseDraftLoad', () => {
     expect(mocks.getTransactionFromBytes).toHaveBeenCalledWith('0x1234');
     expect(setContentsSpy).not.toHaveBeenCalled();
     expect(Array.from(transaction.contents ?? [])).toEqual([1, 2, 3]);
-    expect(wrapper.emitted('draft-loaded')?.[0]).toEqual([transaction]);
+    expect(wrapper.emitted('draft-loaded')?.[0]).toEqual([transaction, 'draft description']);
   });
 });

--- a/front-end/src/tests/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.spec.ts
+++ b/front-end/src/tests/renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.spec.ts
@@ -1,11 +1,18 @@
 // @vitest-environment happy-dom
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { ref } from 'vue';
+import { AccountId, Hbar, Timestamp, TransactionId, TransferTransaction } from '@hiero-ledger/sdk';
 
 // Module-level route query the mocked `useRoute` reads. Each test sets this
 // before mounting so getInitialValidStart() sees the desired param.
 let mockRouteQuery: Record<string, string | undefined> = {};
+const mocks = vi.hoisted(() => ({
+  loadedDraftTransaction: null as TransferTransaction | null,
+  loadedDraftDescription: '',
+  infoControlsDescription: null as string | null,
+  infoControlsDelayMs: 0,
+}));
 
 vi.mock('vue-router', () => ({
   useRoute: () => ({ query: mockRouteQuery }),
@@ -58,7 +65,21 @@ vi.mock('@renderer/components/Transaction/TransactionHeaderControls.vue', () => 
   default: { name: 'TransactionHeaderControls', props: ['validStart'], template: '<div></div>' },
 }));
 vi.mock('@renderer/components/Transaction/TransactionInfoControls.vue', () => ({
-  default: { name: 'TransactionInfoControls', template: '<div></div>' },
+  default: {
+    name: 'TransactionInfoControls',
+    mounted(
+      this: {
+        $emit: (event: 'update:description', description: string) => void;
+      },
+    ) {
+      if (mocks.infoControlsDescription !== null) {
+        setTimeout(() => {
+          this.$emit('update:description', mocks.infoControlsDescription as string);
+        }, mocks.infoControlsDelayMs);
+      }
+    },
+    template: '<div></div>',
+  },
 }));
 vi.mock('@renderer/components/Transaction/TransactionIdControls.vue', () => ({
   default: {
@@ -68,7 +89,23 @@ vi.mock('@renderer/components/Transaction/TransactionIdControls.vue', () => ({
   },
 }));
 vi.mock('@renderer/components/Transaction/Create/BaseTransaction/BaseDraftLoad.vue', () => ({
-  default: { name: 'BaseDraftLoad', template: '<div></div>' },
+  default: {
+    name: 'BaseDraftLoad',
+    mounted(
+      this: {
+        $emit: (
+          event: 'draft-loaded',
+          tx: TransferTransaction,
+          description: string,
+        ) => void;
+      },
+    ) {
+      if (mocks.loadedDraftTransaction) {
+        this.$emit('draft-loaded', mocks.loadedDraftTransaction, mocks.loadedDraftDescription);
+      }
+    },
+    template: '<div></div>',
+  },
 }));
 vi.mock('@renderer/components/Transaction/Create/BaseTransaction/BaseGroupHandler.vue', () => ({
   default: { name: 'BaseGroupHandler', template: '<div></div>' },
@@ -78,7 +115,11 @@ vi.mock(
   () => ({ default: { name: 'BaseApproversObserverData', template: '<div></div>' } }),
 );
 vi.mock('@renderer/components/Transaction/Create/BaseTransaction/BaseTransactionModal.vue', () => ({
-  default: { name: 'BaseTransactionModal', template: '<div></div>' },
+  default: {
+    name: 'BaseTransactionModal',
+    props: ['hasDataChanged'],
+    template: '<div></div>',
+  },
 }));
 vi.mock('@renderer/components/ui/AppInput.vue', () => ({
   default: { name: 'AppInput', template: '<div></div>' },
@@ -91,11 +132,20 @@ vi.mock('@renderer/components/Transaction/TransactionProcessor', () => ({
 
 import BaseTransaction from '@renderer/components/Transaction/Create/BaseTransaction/BaseTransaction.vue';
 
+function createTransferTransaction(validStart: Date, memo = '', payer = '0.0.2') {
+  return new TransferTransaction()
+    .setTransactionMemo(memo)
+    .setMaxTransactionFee(new Hbar(2))
+    .setTransactionId(
+      TransactionId.withValidStart(AccountId.fromString(payer), Timestamp.fromDate(validStart)),
+    );
+}
+
 function mountBase() {
   return mount(BaseTransaction, {
     props: {
-      // Minimal transaction stub: only toBytes/transactionId are touched during render.
-      createTransaction: () => ({ toBytes: () => new Uint8Array(), transactionId: null }) as never,
+      createTransaction: ({ validStart, transactionMemo, payerId }) =>
+        createTransferTransaction(validStart, transactionMemo, payerId || '0.0.2'),
     },
   });
 }
@@ -107,6 +157,10 @@ function seededValidStart(wrapper: ReturnType<typeof mountBase>): Date {
 describe('BaseTransaction.vue – initial valid start', () => {
   beforeEach(() => {
     mockRouteQuery = {};
+    mocks.loadedDraftTransaction = null;
+    mocks.loadedDraftDescription = '';
+    mocks.infoControlsDescription = null;
+    mocks.infoControlsDelayMs = 0;
   });
 
   test('seeds validStart from the initialValidStart query param (epoch ms)', () => {
@@ -134,5 +188,72 @@ describe('BaseTransaction.vue – initial valid start', () => {
 
     expect(validStart.getTime()).toBeGreaterThanOrEqual(before);
     expect(validStart.getTime()).toBeLessThanOrEqual(Date.now());
+  });
+
+  test('keeps hasDataChanged false when leaving a freshly created form untouched', async () => {
+    vi.useFakeTimers();
+    const wrapper = mountBase();
+    try {
+      // BaseTransaction snapshots initialTransaction after mount for new forms.
+      await vi.advanceTimersByTimeAsync(550);
+
+      const hasDataChanged = wrapper
+        .findComponent({ name: 'BaseTransactionModal' })
+        .props('hasDataChanged');
+      expect(hasDataChanged).toBe(false);
+    } finally {
+      wrapper.unmount();
+      vi.useRealTimers();
+    }
+  });
+
+  test('keeps hasDataChanged false after loading an existing draft and not modifying it', async () => {
+    mocks.loadedDraftTransaction = createTransferTransaction(
+      new Date('2026-01-02T00:00:00.000Z'),
+      'loaded memo',
+      '0.0.5',
+    );
+    mocks.loadedDraftDescription = 'loaded draft description';
+
+    const wrapper = mountBase();
+    await flushPromises();
+
+    const hasDataChanged = wrapper
+      .findComponent({ name: 'BaseTransactionModal' })
+      .props('hasDataChanged');
+    expect(hasDataChanged).toBe(false);
+  });
+
+  test('keeps hasDataChanged false when description arrives asynchronously from info controls', async () => {
+    vi.useFakeTimers();
+    mocks.loadedDraftTransaction = createTransferTransaction(
+      new Date('2026-01-02T00:00:00.000Z'),
+      'loaded memo',
+      '0.0.5',
+    );
+    mocks.loadedDraftDescription = 'loaded draft description';
+    mocks.infoControlsDescription = 'loaded draft description';
+    mocks.infoControlsDelayMs = 25;
+
+    const wrapper = mountBase();
+    try {
+      await flushPromises();
+
+      const beforeAsyncDescription = wrapper
+        .findComponent({ name: 'BaseTransactionModal' })
+        .props('hasDataChanged');
+      expect(beforeAsyncDescription).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(30);
+      await flushPromises();
+
+      const afterAsyncDescription = wrapper
+        .findComponent({ name: 'BaseTransactionModal' })
+        .props('hasDataChanged');
+      expect(afterAsyncDescription).toBe(false);
+    } finally {
+      wrapper.unmount();
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
**Description**:

Existing logic was intended to prevent the `Save Draft?` modal from appearing when leaving a transaction form without user edits, but some false positives remained.

This PR fixes those cases by:
1. Properly saving the initial description fetched from an existing draft and eliminating race conditions:
   - `BaseDraftLoad` now emits both transaction and description
   - `BaseTransaction` snapshots `initialDescription` from that same payload.
 2. Refactoring `transactionsDataMatch` and making it ignore `expirationTime` (in addition to dynamic fields already excluded), to prevent fresh transactions (_File Create_ in particular) from being marked changed due to auto-updated timestamps.
3. Adding/updating `BaseDraftLoad` and `BaseTransaction` unit tests accordingly.

**Related issue(s)**:

Fixes #2985 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
