### PR TITLE
chore:  now passing Organization in place of serverUrl

### DIFF
--- a/front-end/src/renderer/App.vue
+++ b/front-end/src/renderer/App.vue
@@ -87,10 +87,9 @@ useWebsocketSubscription(TRANSACTION_ACTION, async (payload?: unknown) => {
   } // Legacy fallback
 
   if (isLoggedInOrganization(user.selectedOrganization)) {
-    const serverUrl = user.selectedOrganization.serverUrl;
     for (const transactionId of parsed.transactionIds) {
       // We clear cache with strict==false to keep young data
-      appCache.backendTransaction.forget(transactionId, serverUrl, false);
+      appCache.backendTransaction.forget(transactionId, user.selectedOrganization, false);
     }
   }
 });

--- a/front-end/src/renderer/caches/backend/BackendTransactionCache.ts
+++ b/front-end/src/renderer/caches/backend/BackendTransactionCache.ts
@@ -2,39 +2,47 @@ import { TransactionId } from '@hiero-ledger/sdk';
 import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
 import { getTransactionById } from '@renderer/services/organization';
 import type { ITransactionFull } from '@shared/interfaces';
+import type { Organization } from '@prisma/client';
 
-export class BackendTransactionCache extends EntityCache<number | string, ITransactionFull> {
+export class BackendTransactionCache extends EntityCache<number | string, ITransactionFull, Organization> {
   //
   // Public
   //
 
-  public forgetTransaction(transaction: ITransactionFull, serverUrl: string): void {
-    this.forget(transaction.id, serverUrl);
-    this.forget(transaction.transactionId, serverUrl);
+  public forgetTransaction(transaction: ITransactionFull, organization: Organization): void {
+    this.forget(transaction.id, organization);
+    this.forget(transaction.transactionId, organization);
   }
 
   //
   // EntityCache
   //
 
-  protected override async load(id: number | string, serverUrl: string): Promise<ITransactionFull> {
+  protected override async load(
+    id: number | string,
+    organization: Organization,
+  ): Promise<ITransactionFull> {
     const tid = typeof id === 'string' ? TransactionId.fromString(id) : id;
-    return await getTransactionById(serverUrl, tid);
+    return await getTransactionById(organization, tid);
+  }
+
+  override makeRecordKey(key: string | number, organization: Organization): string {
+    return key.toString() + '/' + organization.serverUrl;
   }
 
   public override async lookup(
     id: number | string,
-    serverUrl: string,
+    context: Organization,
     forceLoad = false,
   ): Promise<ITransactionFull> {
-    const p = super.lookup(id, serverUrl, forceLoad);
+    const p = super.lookup(id, context, forceLoad);
     const result = await p;
     if (typeof id === 'number') {
       // We insert an entry with the string key
-      this.mutate(result.transactionId, serverUrl, p);
+      this.mutate(result.transactionId, context, p);
     } else {
       // We insert an entry with number key
-      this.mutate(result.id, serverUrl, p);
+      this.mutate(result.id, context, p);
     }
     return result;
   }

--- a/front-end/src/renderer/caches/backend/PublicKeyOwnerCache.ts
+++ b/front-end/src/renderer/caches/backend/PublicKeyOwnerCache.ts
@@ -1,12 +1,20 @@
 import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
 import { getPublicKeyOwner } from '@renderer/services/organization';
+import type { Organization } from '@prisma/client';
 
-export class PublicKeyOwnerCache extends EntityCache<string, string | null> {
+export class PublicKeyOwnerCache extends EntityCache<string, string | null, Organization> {
   //
   // EntityCache
   //
 
-  protected override async load(publicKey: string, serverUrl: string): Promise<string | null> {
-    return await getPublicKeyOwner(serverUrl, publicKey);
+  protected override async load(
+    publicKey: string,
+    organization: Organization,
+  ): Promise<string | null> {
+    return await getPublicKeyOwner(organization, publicKey);
+  }
+
+  override makeRecordKey(key: string | number, organization: Organization): string {
+    return key.toString() + '/' + organization.serverUrl;
   }
 }

--- a/front-end/src/renderer/caches/base/EntityCache.ts
+++ b/front-end/src/renderer/caches/base/EntityCache.ts
@@ -1,4 +1,4 @@
-export abstract class EntityCache<K extends string | number, E> {
+export abstract class EntityCache<K extends string | number, E, C> {
   public static readonly FRESH_DURATION = 500; // ms
   private readonly records = new Map<string, EntityRecord<E>>();
 
@@ -10,26 +10,26 @@ export abstract class EntityCache<K extends string | number, E> {
     public readonly youngDuration: number = 10 * 60_000, // ms
   ) {}
 
-  public async lookup(key: K, mirrorNodeUrl: string, forceLoad = false): Promise<E> {
+  public async lookup(key: K, context: C, forceLoad = false): Promise<E> {
     let result: Promise<E>;
 
-    const recordKey = this.makeRecordKey(key, mirrorNodeUrl);
+    const recordKey = this.makeRecordKey(key, context);
     const currentRecord = this.records.get(recordKey);
     if (currentRecord && currentRecord.isUsable(forceLoad, this)) {
       // cache hit
       result = currentRecord.promise;
     } else {
       // cache miss or reload
-      const newPromise = this.load(key, mirrorNodeUrl);
-      this.mutate(key, mirrorNodeUrl, newPromise);
+      const newPromise = this.load(key, context);
+      this.mutate(key, context, newPromise);
       result = newPromise;
     }
 
     return result;
   }
 
-  public forget(key: K, mirrorNodeUrl: string, strict = true): void {
-    const recordKey = this.makeRecordKey(key, mirrorNodeUrl);
+  public forget(key: K, context: C, strict = true): void {
+    const recordKey = this.makeRecordKey(key, context);
     const currentRecord = this.records.get(recordKey);
     if (currentRecord) {
       // When strict is off, we forget only if data is 1s old (help for notification mgt)
@@ -57,21 +57,19 @@ export abstract class EntityCache<K extends string | number, E> {
   // Protected (to be subclassed)
   //
 
-  protected async load(key: K, mirrorNodeUrl: string): Promise<E> {
-    throw new Error('Must be subclassed to load ' + key + ' with ' + mirrorNodeUrl);
+  protected async load(key: K, context: C): Promise<E> {
+    throw new Error('Must be subclassed to load ' + key + ' with ' + context);
   }
+
+  abstract makeRecordKey(key: K, context: C): string;
 
   //
   // Protected (for subclasses only)
   //
 
-  protected mutate(key: K, mirrorNodeUrl: string, promise: Promise<E>): void {
-    const recordKey = this.makeRecordKey(key, mirrorNodeUrl);
+  protected mutate(key: K, context: C, promise: Promise<E>): void {
+    const recordKey = this.makeRecordKey(key, context);
     this.records.set(recordKey, new EntityRecord(promise));
-  }
-
-  protected makeRecordKey(key: K, mirrorNodeUrl: string): string {
-    return key.toString() + '/' + mirrorNodeUrl;
   }
 }
 
@@ -84,7 +82,7 @@ class EntityRecord<E> {
     this.time = Date.now();
   }
 
-  isUsable(forceLoad: boolean, cache: EntityCache<any, E>): boolean {
+  isUsable(forceLoad: boolean, cache: EntityCache<any, E, any>): boolean {
     let result: boolean;
     if (forceLoad) {
       result = this.age() < EntityCache.FRESH_DURATION; // ms

--- a/front-end/src/renderer/caches/mirrorNode/AccountByIdCache.ts
+++ b/front-end/src/renderer/caches/mirrorNode/AccountByIdCache.ts
@@ -5,7 +5,7 @@ import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
 import type { IAccountInfoParsed } from '@shared/interfaces';
 import { getAccountInfo } from '@renderer/services/mirrorNodeDataService.ts';
 
-export class AccountByIdCache extends EntityCache<string, IAccountInfoParsed | null> {
+export class AccountByIdCache extends EntityCache<string, IAccountInfoParsed | null, string> {
   //
   // EntityCache
   //
@@ -25,5 +25,9 @@ export class AccountByIdCache extends EntityCache<string, IAccountInfoParsed | n
       }
     }
     return result;
+  }
+
+  override makeRecordKey(key: string | number, mirrorNodeUrl: string): string {
+    return key.toString() + '/' + mirrorNodeUrl;
   }
 }

--- a/front-end/src/renderer/caches/mirrorNode/AccountByPublicKeyCache.ts
+++ b/front-end/src/renderer/caches/mirrorNode/AccountByPublicKeyCache.ts
@@ -2,7 +2,7 @@ import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
 import type { AccountInfo } from '@shared/interfaces';
 import { getAccountsByPublicKey } from '@renderer/services/mirrorNodeDataService.ts';
 
-export class AccountByPublicKeyCache extends EntityCache<string, AccountInfo[]> {
+export class AccountByPublicKeyCache extends EntityCache<string, AccountInfo[], string> {
   //
   // Public
   //
@@ -27,5 +27,9 @@ export class AccountByPublicKeyCache extends EntityCache<string, AccountInfo[]> 
 
   protected override async load(publicKey: string, mirrorNodeLink: string): Promise<AccountInfo[]> {
     return getAccountsByPublicKey(mirrorNodeLink, publicKey);
+  }
+
+  override makeRecordKey(key: string | number, mirrorNodeUrl: string): string {
+    return key.toString() + '/' + mirrorNodeUrl;
   }
 }

--- a/front-end/src/renderer/caches/mirrorNode/NodeByIdCache.ts
+++ b/front-end/src/renderer/caches/mirrorNode/NodeByIdCache.ts
@@ -3,7 +3,7 @@ import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
 import type { INodeInfoParsed } from '@shared/interfaces';
 import { getNodeInfo } from '@renderer/services/mirrorNodeDataService.ts';
 
-export class NodeByIdCache extends EntityCache<number, INodeInfoParsed | null> {
+export class NodeByIdCache extends EntityCache<number, INodeInfoParsed | null, string> {
   //
   // EntityCache
   //
@@ -23,5 +23,9 @@ export class NodeByIdCache extends EntityCache<number, INodeInfoParsed | null> {
       }
     }
     return result;
+  }
+
+  override makeRecordKey(key: string | number, mirrorNodeUrl: string): string {
+    return key.toString() + '/' + mirrorNodeUrl;
   }
 }

--- a/front-end/src/renderer/caches/mirrorNode/RegisteredNodeByIdCache.ts
+++ b/front-end/src/renderer/caches/mirrorNode/RegisteredNodeByIdCache.ts
@@ -7,7 +7,11 @@ import type {
 } from '@shared/interfaces';
 import { parseRegisteredNode } from '@renderer/services/mirrorNodeDataService';
 
-export class RegisteredNodeByIdCache extends EntityCache<number, IRegisteredNodeInfoParsed | null> {
+export class RegisteredNodeByIdCache extends EntityCache<
+  number,
+  IRegisteredNodeInfoParsed | null,
+  string
+> {
   //
   // EntityCache
   //
@@ -29,5 +33,9 @@ export class RegisteredNodeByIdCache extends EntityCache<number, IRegisteredNode
     }
 
     return result !== null ? parseRegisteredNode(result) : null;
+  }
+
+  override makeRecordKey(key: string | number, mirrorNodeURL: string): string {
+    return key.toString() + '/' + mirrorNodeURL;
   }
 }

--- a/front-end/src/renderer/caches/mirrorNode/TokenByIdCache.ts
+++ b/front-end/src/renderer/caches/mirrorNode/TokenByIdCache.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
 import type { ITokenInfo } from '@shared/interfaces/ITokenInfo';
 
-export class TokenByIdCache extends EntityCache<string, ITokenInfo | null> {
+export class TokenByIdCache extends EntityCache<string, ITokenInfo | null, string> {
   //
   // EntityCache
   //
@@ -24,6 +24,10 @@ export class TokenByIdCache extends EntityCache<string, ITokenInfo | null> {
       }
     }
     return result;
+  }
+
+  override makeRecordKey(key: string | number, mirrorNodeURL: string): string {
+    return key.toString() + '/' + mirrorNodeURL;
   }
 }
 

--- a/front-end/src/renderer/caches/mirrorNode/TransactionByIdCache.ts
+++ b/front-end/src/renderer/caches/mirrorNode/TransactionByIdCache.ts
@@ -3,7 +3,7 @@ import type { TransactionByIdResponse } from '@shared/interfaces';
 import { getTransactionInfo } from '@renderer/services/mirrorNodeDataService.ts';
 import axios from 'axios';
 
-export class TransactionByIdCache extends EntityCache<string, TransactionByIdResponse | null> {
+export class TransactionByIdCache extends EntityCache<string, TransactionByIdResponse | null, string> {
   //
   // EntityCache
   //
@@ -23,5 +23,9 @@ export class TransactionByIdCache extends EntityCache<string, TransactionByIdRes
       }
     }
     return result;
+  }
+
+  override makeRecordKey(key: string | number, mirrorNodeURL: string): string {
+    return key.toString() + '/' + mirrorNodeURL;
   }
 }

--- a/front-end/src/renderer/components/Contacts/ContactDetails.vue
+++ b/front-end/src/renderer/components/Contacts/ContactDetails.vue
@@ -137,7 +137,7 @@ const handleResend = async () => {
   try {
     if (user.selectedOrganization?.serverUrl) {
       const email = props.contact.user.email;
-      await signUp(user.selectedOrganization.serverUrl, email);
+      await signUp(user.selectedOrganization, email);
     }
     toastManager.success('Email sent successfully');
   } catch (error) {

--- a/front-end/src/renderer/components/ExternalSigning/ExportTransactionsModal.vue
+++ b/front-end/src/renderer/components/ExternalSigning/ExportTransactionsModal.vue
@@ -55,7 +55,7 @@ async function handleExport() {
 
   let collectionTransactions: ITransaction[] = await flattenNodeCollection(
     collectionNodes,
-    user.selectedOrganization.serverUrl,
+    user.selectedOrganization,
     appCache.backendTransaction,
   );
   logger.debug('Flattened transactions', { count: collectionTransactions.length });
@@ -114,7 +114,7 @@ async function fetchNodes(): Promise<ITransactionNode[]> {
   if (isLoggedInOrganization(user.selectedOrganization)) {
     try {
       nodes = await getTransactionNodes(
-        user.selectedOrganization.serverUrl,
+        user.selectedOrganization,
         TransactionNodeCollection.IN_PROGRESS,
         network.network,
         [],

--- a/front-end/src/renderer/components/ForgotPasswordModal.vue
+++ b/front-end/src/renderer/components/ForgotPasswordModal.vue
@@ -94,7 +94,7 @@ async function handleEmailEnter() {
   if (!user.selectedOrganization) throw new Error('Please select organization');
 
   try {
-    token.value = await resetPassword(user.selectedOrganization.serverUrl, email.value);
+    token.value = await resetPassword(user.selectedOrganization, email.value);
 
     shouldEnterToken.value = true;
     setTimeout(() => otpInputRef.value?.focus(), 100);
@@ -110,7 +110,7 @@ async function handleTokenEnter() {
 
   try {
     token.value = await verifyReset(
-      user.selectedOrganization.serverUrl,
+      user.selectedOrganization,
       otp.value.value,
       token.value,
     );
@@ -142,7 +142,7 @@ async function handleNewPassword() {
 
   try {
     !user.personal.useKeychain && user.setPassword(personalPassword.value);
-    await setPassword(user.selectedOrganization.serverUrl, newPassword.value, token.value);
+    await setPassword(user.selectedOrganization, newPassword.value, token.value);
 
     // Update organization credentials, if they exist.
     // If not, ignore as the password has already been submitted to the backend

--- a/front-end/src/renderer/components/GlobalAppProcesses/components/MandatoryUpgrade.vue
+++ b/front-end/src/renderer/components/GlobalAppProcesses/components/MandatoryUpgrade.vue
@@ -143,7 +143,7 @@ const handleDisconnect = async () => {
       await disconnectOrganization(org.serverUrl, 'upgradeRequired');
 
       try {
-        await logout(org.serverUrl);
+        await logout(org);
       } catch (logoutError) {
         logger.warn('Logout failed (may already be disconnected)', { error: logoutError });
       }

--- a/front-end/src/renderer/components/Organization/AutoLoginInOrganization.vue
+++ b/front-end/src/renderer/components/Organization/AutoLoginInOrganization.vue
@@ -76,10 +76,10 @@ watch(
       // Run a single consolidated version check across every org now that
       // org-level auto-signin (if any) has finished. Drives the upgrade
       // modals via the pending flag — they wait until every org reports in.
-      const eligibleServerUrls = user.organizations
-        .filter(o => orgConnection.getConnectionStatus(o.serverUrl) !== 'disconnected')
-        .map(o => o.serverUrl);
-      void performInitialVersionCheck(eligibleServerUrls);
+      const eligibleOrganizations = user.organizations.filter(
+        o => orgConnection.getConnectionStatus(o.serverUrl) !== 'disconnected',
+      );
+      void performInitialVersionCheck(eligibleOrganizations);
     }
   },
 );

--- a/front-end/src/renderer/components/Organization/ConnectionToggle.vue
+++ b/front-end/src/renderer/components/Organization/ConnectionToggle.vue
@@ -66,7 +66,7 @@ const handleToggle = async (checked: boolean) => {
 };
 
 const handleReconnect = async () => {
-  const result = await reconnectOrganization(props.organization.serverUrl);
+  const result = await reconnectOrganization(props.organization);
 
   if (result.success) {
     if (isLoggedOutOrganization(props.organization)) {

--- a/front-end/src/renderer/components/Transaction/TransactionGroupProcessor.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionGroupProcessor.vue
@@ -343,14 +343,14 @@ async function sendSignedTransactionsToOrganization() {
   }
 
   const { id, transactionBytes } = await submitTransactionGroup(
-    user.selectedOrganization.serverUrl,
+    user.selectedOrganization,
     transactionGroup.description,
     false,
     transactionGroup.sequential,
     apiGroupItems,
   );
 
-  const group: IGroup = await getTransactionGroupById(user.selectedOrganization.serverUrl, id, false);
+  const group: IGroup = await getTransactionGroupById(user.selectedOrganization, id, false);
 
   toastManager.success('Transaction submitted successfully');
 
@@ -381,7 +381,7 @@ async function uploadObservers(transactionId: number, seqId: number) {
     throw new Error('User is not logged in organization');
 
   await addObservers(
-    user.selectedOrganization.serverUrl,
+    user.selectedOrganization,
     transactionId,
     transactionGroup.groupItems[seqId].observers,
   );
@@ -398,7 +398,7 @@ async function uploadApprovers(transactionId: number, seqId: number) {
     throw new Error('User is not logged in organization');
 
   await addApprovers(
-    user.selectedOrganization.serverUrl,
+    user.selectedOrganization,
     transactionId,
     transactionGroup.groupItems[seqId].approvers,
   );

--- a/front-end/src/renderer/components/Transaction/TransactionProcessor/components/BigFileOrganizationRequestHandler.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionProcessor/components/BigFileOrganizationRequestHandler.vue
@@ -134,9 +134,7 @@ function createAppendTransaction() {
   // the partial-upload failure mode where many sub-calls can't all execute
   // within a single transaction's valid window. `getMaxChunkSize` subtracts a
   // reserve for protobuf/signature overhead.
-  const chunkSize = getMaxChunkSize(
-    originalTransaction.transactionId?.accountId ?? null,
-  );
+  const chunkSize = getMaxChunkSize(originalTransaction.transactionId?.accountId ?? null);
 
   const append = createFileAppendTransaction({
     payerId,
@@ -224,13 +222,13 @@ async function submitGroup(groupItems: GroupItem[], signature: string[], keyToSi
 
   try {
     const { id } = await submitTransactionGroup(
-      user.selectedOrganization.serverUrl,
+      user.selectedOrganization,
       'Automatically created group for large file update',
       false,
       true,
       apiGroupItems,
     );
-    const group = await getTransactionGroupById(user.selectedOrganization.serverUrl, id, false);
+    const group = await getTransactionGroupById(user.selectedOrganization, id, false);
     await safeAwait(submitApproversObservers(group));
     emit('transaction:group:submit:success', id);
   } catch (error) {
@@ -241,17 +239,17 @@ async function submitGroup(groupItems: GroupItem[], signature: string[], keyToSi
 
 async function submitApproversObservers(group: IGroup) {
   assertIsLoggedInOrganization(user.selectedOrganization);
-  const serverUrl = user.selectedOrganization.serverUrl;
+  const organization = user.selectedOrganization;
 
   const promises = group.groupItems.map(groupItem => {
     const observerPromise =
       props.observers?.length > 0
-        ? addObservers(serverUrl, groupItem.transactionId, props.observers)
+        ? addObservers(organization, groupItem.transactionId, props.observers)
         : Promise.resolve();
 
     const approverPromise =
       props.approvers?.length > 0
-        ? addApprovers(serverUrl, groupItem.transactionId, props.approvers)
+        ? addApprovers(organization, groupItem.transactionId, props.approvers)
         : Promise.resolve();
 
     return Promise.allSettled([observerPromise, approverPromise]);

--- a/front-end/src/renderer/components/Transaction/TransactionProcessor/components/MultipleAccountUpdateRequestHandler.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionProcessor/components/MultipleAccountUpdateRequestHandler.vue
@@ -303,13 +303,13 @@ async function submitGroup(
 
   try {
     const { id } = await submitTransactionGroup(
-      user.selectedOrganization.serverUrl,
+      user.selectedOrganization,
       description || 'Automatically created group for multiple accounts update',
       false,
       true,
       apiGroupItems,
     );
-    const group = await getTransactionGroupById(user.selectedOrganization.serverUrl, id, false);
+    const group = await getTransactionGroupById(user.selectedOrganization, id, false);
     await safeAwait(submitApproversObservers(group));
     emit('transaction:group:submit:success', id);
   } catch (error) {
@@ -320,17 +320,17 @@ async function submitGroup(
 
 async function submitApproversObservers(group: IGroup) {
   assertIsLoggedInOrganization(user.selectedOrganization);
-  const serverUrl = user.selectedOrganization.serverUrl;
+  const organization = user.selectedOrganization;
 
   const promises = group.groupItems.map(groupItem => {
     const observerPromise =
       props.observers?.length > 0
-        ? addObservers(serverUrl, groupItem.transactionId, props.observers)
+        ? addObservers(organization, groupItem.transactionId, props.observers)
         : Promise.resolve();
 
     const approverPromise =
       props.approvers?.length > 0
-        ? addApprovers(serverUrl, groupItem.transactionId, props.approvers)
+        ? addApprovers(organization, groupItem.transactionId, props.approvers)
         : Promise.resolve();
 
     return Promise.allSettled([observerPromise, approverPromise]);

--- a/front-end/src/renderer/components/Transaction/TransactionProcessor/components/OrganizationRequestHandler.vue
+++ b/front-end/src/renderer/components/Transaction/TransactionProcessor/components/OrganizationRequestHandler.vue
@@ -178,7 +178,7 @@ async function submit(publicKey: string, signature: string) {
   const hexTransactionBytes = uint8ToHex(request.value.transactionBytes);
 
   return await submitTransaction(
-    user.selectedOrganization.serverUrl,
+    user.selectedOrganization,
     request.value?.name || '',
     request.value?.description || '',
     hexTransactionBytes,
@@ -200,9 +200,9 @@ async function upload(type: 'observers' | 'approvers', id: number) {
   assertIsLoggedInOrganization(user.selectedOrganization);
 
   if (type === 'observers') {
-    await addObservers(user.selectedOrganization.serverUrl, id, props.observers);
+    await addObservers(user.selectedOrganization, id, props.observers);
   } else {
-    await addApprovers(user.selectedOrganization.serverUrl, id, props.approvers);
+    await addApprovers(user.selectedOrganization, id, props.approvers);
   }
 }
 

--- a/front-end/src/renderer/components/TransactionImportModal.vue
+++ b/front-end/src/renderer/components/TransactionImportModal.vue
@@ -141,21 +141,15 @@ const importSelectedCandidates = async (): Promise<void> => {
       );
     } else if (rejectedCount == 1) {
       const transactionId = rejectedTransactionIds[0];
-      toastManager.error(
-        'Transaction ' + transactionId + ' does not exist or is not accessible',
-      );
+      toastManager.error('Transaction ' + transactionId + ' does not exist or is not accessible');
     } else {
       // successCount == 1
       const [transactionId] = successResults.entries().next().value!;
-      toastManager.success(
-        'Imported transaction ' + transactionId + ' successfully.',
-      );
+      toastManager.success('Imported transaction ' + transactionId + ' successfully.');
     }
   } else {
     if (successCount >= 1) {
-      toastManager.success(
-        'Imported ' + successCount + ' transaction(s) successfully.',
-      );
+      toastManager.success('Imported ' + successCount + ' transaction(s) successfully.');
     }
     if (errorCount >= 1) {
       toastManager.error('Failed to import ' + errorCount + ' transaction(s)');
@@ -181,15 +175,17 @@ const formatError = (r: SignatureImportResultDto): string => {
 };
 
 const candidatesDidChange = async (newValue: V1ImportCandidate[]) => {
-  const serverUrl = user.selectedOrganization?.serverUrl;
 
   // 1) Retrieves transaction info from backend
   transactionMap.value.clear();
-  if (serverUrl) {
+  if (user.selectedOrganization) {
     for (const candidate of newValue) {
       if (transactionMap.value.get(candidate.transactionId) === undefined) {
         try {
-          const t = await transactionCache.lookup(candidate.transactionId, serverUrl);
+          const t = await transactionCache.lookup(
+            candidate.transactionId,
+            user.selectedOrganization,
+          );
           transactionMap.value.set(candidate.transactionId, t);
         } catch (error) {
           logger.error('Failed to fetch transaction by id', { error });

--- a/front-end/src/renderer/components/modals/DeleteAllKeysRequiringHashMigrationModal.vue
+++ b/front-end/src/renderer/components/modals/DeleteAllKeysRequiringHashMigrationModal.vue
@@ -50,7 +50,7 @@ const handleDelete = async () => {
 
         if (organizationKeyPair) {
           await deleteKey(
-            user.selectedOrganization.serverUrl,
+            user.selectedOrganization,
             user.selectedOrganization.userId,
             organizationKeyPair.id,
           );

--- a/front-end/src/renderer/composables/useMatchRecoveryPhrase.ts
+++ b/front-end/src/renderer/composables/useMatchRecoveryPhrase.ts
@@ -76,7 +76,7 @@ export default function useMatchRecoveryPrase() {
       );
       if (organizationKeyPair) {
         await updateOrganizationKey(
-          user.selectedOrganization.serverUrl,
+          user.selectedOrganization,
           user.selectedOrganization.userId,
           organizationKeyPair.id,
           user.recoveryPhrase.hash,

--- a/front-end/src/renderer/composables/useRecoveryPhraseHashMigrate.ts
+++ b/front-end/src/renderer/composables/useRecoveryPhraseHashMigrate.ts
@@ -84,7 +84,7 @@ export default function useRecoveryPhraseHashMigrate() {
         );
         if (organizationKeyPair) {
           await updateOrganizationKey(
-            user.selectedOrganization.serverUrl,
+            user.selectedOrganization,
             user.selectedOrganization.userId,
             organizationKeyPair.id,
             recoveryPhraseHash,

--- a/front-end/src/renderer/composables/useTransactionAudit.ts
+++ b/front-end/src/renderer/composables/useTransactionAudit.ts
@@ -35,7 +35,7 @@ export default function useTransactionAudit(transactionId: Ref<number | null>): 
       try {
         result = await appCache.backendTransaction.lookup(
           transactionId.value,
-          user.selectedOrganization.serverUrl,
+          user.selectedOrganization,
         );
       } catch {
         result = null;

--- a/front-end/src/renderer/composables/useVersionCheck.ts
+++ b/front-end/src/renderer/composables/useVersionCheck.ts
@@ -18,6 +18,7 @@ import {
   initialVersionCheckState,
   type VersionStatus,
 } from '@renderer/stores/versionState';
+import type { Organization } from '@prisma/client';
 
 const isDismissed = ref(
   typeof sessionStorage !== 'undefined'
@@ -29,17 +30,17 @@ const isDismissed = ref(
 const orgChecks = ref<Record<string, boolean>>({});
 
 export default function useVersionCheck() {
-  const performVersionCheck = async (serverUrl: string): Promise<void> => {
-    if (orgChecks.value[serverUrl]) {
+  const performVersionCheck = async (organization: Organization): Promise<void> => {
+    if (orgChecks.value[organization.serverUrl]) {
       return;
     }
 
     try {
-      orgChecks.value[serverUrl] = true;
+      orgChecks.value[organization.serverUrl] = true;
 
-      const response = await checkVersion(serverUrl, FRONTEND_VERSION);
+      const response = await checkVersion(organization, FRONTEND_VERSION);
 
-      setVersionDataForOrg(serverUrl, {
+      setVersionDataForOrg(organization.serverUrl, {
         latestSupportedVersion: response.latestSupportedVersion,
         minimumSupportedVersion: response.minimumSupportedVersion,
         updateUrl: response.updateUrl,
@@ -52,7 +53,7 @@ export default function useVersionCheck() {
       // or earlier successful check) is preserved automatically.
       logger.error('Version check failed', { error });
     } finally {
-      orgChecks.value[serverUrl] = false;
+      orgChecks.value[organization.serverUrl] = false;
     }
   };
 
@@ -61,12 +62,12 @@ export default function useVersionCheck() {
   // on 'done') start rendering. Single entry point for both auto-login
   // and manual-login startup paths. Concurrent re-entry is dropped: the
   // 'running' state bars a second batch from racing the first into 'done'.
-  const performInitialVersionCheck = async (serverUrls: string[]): Promise<void> => {
+  const performInitialVersionCheck = async (organizations: Organization[]): Promise<void> => {
     if (initialVersionCheckState.value !== 'idle') return;
 
     initialVersionCheckState.value = 'running';
     try {
-      await Promise.allSettled(serverUrls.map(url => performVersionCheck(url)));
+      await Promise.allSettled(organizations.map(org => performVersionCheck(org)));
     } finally {
       initialVersionCheckState.value = 'done';
     }

--- a/front-end/src/renderer/pages/AccountSetup/components/NewPassword.vue
+++ b/front-end/src/renderer/pages/AccountSetup/components/NewPassword.vue
@@ -69,7 +69,7 @@ const handleChangePassword = async () => {
       isLoading.value = true;
 
       await changePassword(
-        user.selectedOrganization.serverUrl,
+        user.selectedOrganization,
         currentPassword.value,
         newPassword.value,
       );

--- a/front-end/src/renderer/pages/ContactList/ContactList.vue
+++ b/front-end/src/renderer/pages/ContactList/ContactList.vue
@@ -108,7 +108,7 @@ async function handleRemove() {
   if (!contact.value) throw new Error('Contact is not selected');
 
   if (isLoggedInOrganization(user.selectedOrganization) && user.selectedOrganization.admin) {
-    await deleteUser(user.selectedOrganization.serverUrl, contact.value.user.id);
+    await deleteUser(user.selectedOrganization, contact.value.user.id);
     contact.value.nicknameId && (await removeContact(user.personal.id, contact.value.nicknameId));
   }
 
@@ -125,7 +125,7 @@ async function handleElevate() {
     throw new Error('User is not an admin');
   }
 
-  await elevateUserToAdmin(user.selectedOrganization.serverUrl, contact.value.user.id);
+  await elevateUserToAdmin(user.selectedOrganization, contact.value.user.id);
 
   toastManager.success('User elevate to admin successfully');
   selectedId.value = null;

--- a/front-end/src/renderer/pages/ContactList/SignUpUser/SignUpUser.vue
+++ b/front-end/src/renderer/pages/ContactList/SignUpUser/SignUpUser.vue
@@ -120,7 +120,7 @@ const signUpUser = async (email: string) => {
     throw new Error('Please select organization');
   if (!user.selectedOrganization.admin) throw new Error('Only admin can register users');
 
-  const { id } = await signUp(user.selectedOrganization.serverUrl, email);
+  const { id } = await signUp(user.selectedOrganization, email);
 
   return id;
 };

--- a/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
+++ b/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
@@ -55,7 +55,7 @@ const concludeSetup = async (importedKeyCount: number, error: unknown) => {
 
 const setupOrganization = async (setup: ModelValue) => {
   // 1) Add organization
-  const { id: organizationId } = await addOrganization({
+  const addedOrg = await addOrganization({
     nickname: setup.organizationNickname,
     serverUrl: setup.organizationURL,
     key: '',
@@ -71,7 +71,7 @@ const setupOrganization = async (setup: ModelValue) => {
 
   // 3) Set new password
   await changePassword(
-    setup.organizationURL,
+    addedOrg,
     setup.temporaryOrganizationPassword,
     setup.newOrganizationPassword,
   );
@@ -80,7 +80,7 @@ const setupOrganization = async (setup: ModelValue) => {
   await addOrganizationCredentials(
     email,
     setup.newOrganizationPassword,
-    organizationId,
+    addedOrg.id,
     props.personalUser.personalId,
     jwtToken,
     props.personalUser.password,
@@ -158,7 +158,7 @@ const restoreExistingKeys = async () => {
   if (!isLoggedInOrganization(user.selectedOrganization))
     throw new Error('(BUG) Organization user id not set');
 
-  const { userKeys } = await getUserState(user.selectedOrganization.serverUrl);
+  const { userKeys } = await getUserState(user.selectedOrganization);
   const userKeysWithMnemonic = userKeys.filter(userKeyHasMnemonic);
 
   await restoreOnEmpty(userKeysWithMnemonic);

--- a/front-end/src/renderer/pages/Migrate/components/Summary.vue
+++ b/front-end/src/renderer/pages/Migrate/components/Summary.vue
@@ -43,7 +43,7 @@ const handleFinishMigration = async () => {
   await router.push({ name: 'settingsKeys' });
   // Now fully out of migration — check for optional updates.
   if (isLoggedInOrganization(user.selectedOrganization)) {
-    performVersionCheck(user.selectedOrganization.serverUrl);
+    await performVersionCheck(user.selectedOrganization);
   }
 };
 

--- a/front-end/src/renderer/pages/Settings/components/KeysTab/components/DeleteKeyPairsController.vue
+++ b/front-end/src/renderer/pages/Settings/components/KeysTab/components/DeleteKeyPairsController.vue
@@ -75,7 +75,7 @@ const deleteOneKey = async (keyInfo: KeyInfo): Promise<void> => {
   if (keyInfo.userKey !== null) {
     assertIsLoggedInOrganization(user.selectedOrganization);
     await deleteKey(
-      user.selectedOrganization.serverUrl,
+      user.selectedOrganization,
       user.selectedOrganization.userId,
       keyInfo.userKey.id,
     )

--- a/front-end/src/renderer/pages/Settings/components/KeysTab/components/ReUploadKeyPairController.vue
+++ b/front-end/src/renderer/pages/Settings/components/KeysTab/components/ReUploadKeyPairController.vue
@@ -25,7 +25,7 @@ const handleReUpload = async (): Promise<ActionReport | null> => {
   const keyPair = props.keyInfo?.keyPair;
   if (keyPair && isLoggedInOrganization(user.selectedOrganization)) {
     try {
-      await uploadKey(user.selectedOrganization.serverUrl, user.selectedOrganization.userId, {
+      await uploadKey(user.selectedOrganization, user.selectedOrganization.userId, {
         publicKey: keyPair.public_key,
         index: keyPair.index != -1 ? keyPair.index : undefined,
         mnemonicHash: keyPair.secret_hash ?? undefined,

--- a/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/ProfileTab.vue
@@ -102,7 +102,7 @@ const handleChangePassword = async () => {
       );
 
       await organizationChangePassword(
-        user.selectedOrganization.serverUrl,
+        user.selectedOrganization,
         currentPassword.value,
         newPassword.value,
       );
@@ -152,7 +152,7 @@ const handleLogout = async () => {
     if (!isUserLoggedIn(user.personal)) return;
 
     const { id, nickname, serverUrl, key } = user.selectedOrganization;
-    await logout(serverUrl);
+    await logout(user.selectedOrganization);
     await updateOrganizationCredentials(id, user.personal.id, undefined, '', null);
     await user.selectOrganization({ id, nickname, serverUrl, key });
   } else {
@@ -187,7 +187,9 @@ watch(newPassword, pass => {
       </div>
       <AppButton
         v-if="
-          (isUserLoggedIn(user.personal) && !user.personal.useKeychain && !user.selectedOrganization) ||
+          (isUserLoggedIn(user.personal) &&
+            !user.personal.useKeychain &&
+            !user.selectedOrganization) ||
           isLoggedInOrganization(user.selectedOrganization)
         "
         color="primary"
@@ -292,5 +294,4 @@ watch(newPassword, pass => {
     </form>
     <ResetDataModal v-model:show="isResetDataModalShown" @data:reset="handleResetData" />
   </div>
-
 </template>

--- a/front-end/src/renderer/pages/Settings/components/PublicKeysTab/PublicKeysTab.vue
+++ b/front-end/src/renderer/pages/Settings/components/PublicKeysTab/PublicKeysTab.vue
@@ -76,7 +76,7 @@ const getOwnersFromOrganization = async () => {
   const publicKeys = user.publicKeyMappings.map(mapping => mapping.public_key);
 
   const ownerPromises = publicKeys.map(async key => {
-    return { [key]: await publicKeyOwnerCache.lookup(key, user.selectedOrganization!.serverUrl) };
+    return { [key]: await publicKeyOwnerCache.lookup(key, user.selectedOrganization!) };
   });
   const results: Record<string, string | null>[] = await Promise.all(ownerPromises);
 
@@ -89,7 +89,7 @@ const addOwners = async (newMappings: PublicKeyMapping[], oldMappings: PublicKey
   );
   const newPublicKeys = newItems.map(mapping => mapping.public_key);
   const ownerPromises = newPublicKeys.map(async key => {
-    return { [key]: await publicKeyOwnerCache.lookup(key, user.selectedOrganization!.serverUrl) };
+    return { [key]: await publicKeyOwnerCache.lookup(key, user.selectedOrganization!) };
   });
   const results: Record<string, string | null>[] = await Promise.all(ownerPromises);
   Object.assign(ownersMapping.value, ...results);

--- a/front-end/src/renderer/pages/TransactionDetails/ApproveTransactionController.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/ApproveTransactionController.vue
@@ -70,7 +70,7 @@ const handleApproveTransaction = async (
   } finally {
     // 1) we clear transaction cache
     if (props.transaction && user.selectedOrganization) {
-      transactionCache.forgetTransaction(props.transaction, user.selectedOrganization.serverUrl);
+      transactionCache.forgetTransaction(props.transaction, user.selectedOrganization);
     }
     // 2) we run callback (that will get fresh data from cache)
     await props.callback();
@@ -99,7 +99,7 @@ const performApprove = async (
   const signature = getTransactionBodySignatureWithoutNodeAccountId(privateKey, sdkTransaction);
 
   await sendApproverChoice(
-    user.selectedOrganization.serverUrl,
+    user.selectedOrganization,
     transaction.id,
     orgKey.id,
     signature,

--- a/front-end/src/renderer/pages/TransactionDetails/ArchiveTransactionController.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/ArchiveTransactionController.vue
@@ -35,13 +35,12 @@ const progressText = computed(() =>
 /* Handlers */
 const handleArchiveTransaction = async (): Promise<ActionReport | null> => {
   assertIsLoggedInOrganization(user.selectedOrganization);
-  const serverUrl = user.selectedOrganization.serverUrl;
 
   let result: ActionReport | null;
   try {
     if (props.transaction !== null) {
       const transactionId = props.transaction.id;
-      const done = await archiveTransaction(serverUrl, transactionId);
+      const done = await archiveTransaction(user.selectedOrganization, transactionId);
       if (done) {
         result = null;
         toastManager.success('Transaction archived successfully');
@@ -59,7 +58,7 @@ const handleArchiveTransaction = async (): Promise<ActionReport | null> => {
   } finally {
     // 1) we clear transaction cache
     if (props.transaction) {
-      transactionCache.forgetTransaction(props.transaction, serverUrl);
+      transactionCache.forgetTransaction(props.transaction, user.selectedOrganization);
     }
     // 2) we run callback (that will get fresh data from cache)
     await props.callback();

--- a/front-end/src/renderer/pages/TransactionDetails/CancelTransactionController.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/CancelTransactionController.vue
@@ -34,13 +34,12 @@ const progressText = computed(() =>
 /* Handlers */
 const handleCancelTransaction = async (): Promise<ActionReport | null> => {
   assertIsLoggedInOrganization(user.selectedOrganization);
-  const serverUrl = user.selectedOrganization.serverUrl;
 
   let result: ActionReport | null;
   try {
     if (props.transaction !== null) {
       const transactionId = props.transaction.id;
-      await cancelTransaction(serverUrl, transactionId);
+      await cancelTransaction(user.selectedOrganization, transactionId);
       result = null;
       toastManager.success('Transaction canceled successfully');
     } else {
@@ -49,7 +48,7 @@ const handleCancelTransaction = async (): Promise<ActionReport | null> => {
   } finally {
     // 1) we clear transaction cache
     if (props.transaction && user.selectedOrganization) {
-      transactionCache.forgetTransaction(props.transaction, serverUrl);
+      transactionCache.forgetTransaction(props.transaction, user.selectedOrganization);
     }
     // 2) we run callback (that will get fresh data from cache)
     await props.callback();

--- a/front-end/src/renderer/pages/TransactionDetails/RemindSignersController.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/RemindSignersController.vue
@@ -34,12 +34,12 @@ const handleRemindSigners = async (): Promise<ActionReport | null> => {
   assertIsLoggedInOrganization(user.selectedOrganization);
 
   if (props.transaction !== null) {
-    const serverUrl = user.selectedOrganization.serverUrl;
+    const org = user.selectedOrganization;
     const transactionId = props.transaction.id;
 
     await executeTransactionActionFlow({
       execute: async () => {
-        await remindSigners(serverUrl, transactionId);
+        await remindSigners(org, transactionId);
       },
       refresh: props.callback,
       onSuccess: () => {

--- a/front-end/src/renderer/pages/TransactionDetails/ScheduleTransactionController.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/ScheduleTransactionController.vue
@@ -34,13 +34,12 @@ const progressText = computed(() =>
 /* Handlers */
 const handleScheduleTransaction = async (): Promise<ActionReport | null> => {
   assertIsLoggedInOrganization(user.selectedOrganization);
-  const serverUrl = user.selectedOrganization.serverUrl;
 
   let result: ActionReport | null;
   try {
     if (props.transaction !== null) {
       const transactionId = props.transaction.id;
-      await executeTransaction(serverUrl, transactionId);
+      await executeTransaction(user.selectedOrganization, transactionId);
       toastManager.success('Transaction scheduled successfully');
       result = null;
     } else {
@@ -49,7 +48,7 @@ const handleScheduleTransaction = async (): Promise<ActionReport | null> => {
   } finally {
     // 1) we clear transaction cache
     if (props.transaction && user.selectedOrganization) {
-      transactionCache.forgetTransaction(props.transaction, serverUrl);
+      transactionCache.forgetTransaction(props.transaction, user.selectedOrganization);
     }
     // 2) we run callback (that will get fresh data from cache)
     await props.callback();

--- a/front-end/src/renderer/pages/TransactionDetails/SignTransactionController.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/SignTransactionController.vue
@@ -51,7 +51,7 @@ const handleSign = async (personalPassword: string | null): Promise<ActionReport
     if (props.transaction && user.selectedOrganization) {
       appCache.backendTransaction.forgetTransaction(
         props.transaction,
-        user.selectedOrganization.serverUrl,
+        user.selectedOrganization,
       );
     }
     await props.callback(result === null);

--- a/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
+++ b/front-end/src/renderer/pages/TransactionDetails/TransactionDetails.vue
@@ -162,7 +162,7 @@ async function fetchTransaction() {
     if (isLoggedInOrganization(user.selectedOrganization) && !isNaN(Number(id))) {
       orgTransaction.value = await appCache.backendTransaction.lookup(
         Number(id),
-        user.selectedOrganization?.serverUrl || '',
+        user.selectedOrganization,
       );
       transactionBytes = hexToUint8Array(orgTransaction.value.transactionBytes);
 
@@ -173,9 +173,9 @@ async function fetchTransaction() {
           groupDescription.value = groupItem.group.description;
         } else if (groupItem.groupId) {
           // Backwards compatibility for older organization servers where groupItem.group is not populated
-          if (user.selectedOrganization?.serverUrl) {
+          if (user.selectedOrganization) {
             const orgGroup = await getTransactionGroupById(
-              user.selectedOrganization?.serverUrl,
+              user.selectedOrganization,
               groupItem.groupId,
               false,
             );
@@ -240,7 +240,7 @@ async function fetchTransactionOnNotif(): Promise<void> {
   const id = Number(formattedId.value);
   if (isLoggedInOrganization(user.selectedOrganization) && !isNaN(id)) {
     // We clear cache with strict==false to keep young data
-    appCache.backendTransaction.forget(id, user.selectedOrganization.serverUrl, false);
+    appCache.backendTransaction.forget(id, user.selectedOrganization, false);
   }
   // 2) Now fetch transaction
   await fetchTransaction();

--- a/front-end/src/renderer/pages/TransactionGroupDetails/ApproveAllController.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/ApproveAllController.vue
@@ -65,8 +65,7 @@ const handleApproveAll = async (personalPassword: string | null): Promise<Action
     try {
       let group: IGroup;
       if (typeof props.groupOrId === 'number') {
-        const serverUrl = user.selectedOrganization.serverUrl;
-        group = await getTransactionGroupById(serverUrl, props.groupOrId);
+        group = await getTransactionGroupById(user.selectedOrganization, props.groupOrId);
       } else {
         group = props.groupOrId;
       }
@@ -87,7 +86,7 @@ const handleApproveAll = async (personalPassword: string | null): Promise<Action
           );
 
           await sendApproverChoice(
-            user.selectedOrganization.serverUrl,
+            user.selectedOrganization,
             item.transaction.id,
             user.selectedOrganization.userKeys[0].id,
             signature,

--- a/front-end/src/renderer/pages/TransactionGroupDetails/CancelAllController.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/CancelAllController.vue
@@ -42,8 +42,7 @@ const handleCancelAll = async (): Promise<ActionReport | null> => {
     try {
       let group: IGroup;
       if (typeof props.groupOrId === 'number') {
-        const serverUrl = user.selectedOrganization.serverUrl;
-        group = await getTransactionGroupById(serverUrl, props.groupOrId);
+        group = await getTransactionGroupById(user.selectedOrganization, props.groupOrId);
       } else {
         group = props.groupOrId;
       }
@@ -55,7 +54,7 @@ const handleCancelAll = async (): Promise<ActionReport | null> => {
       }
       progressText.value = `Canceling ${itemsToCancel.length} transactions`;
       const results = await cancelTransactionGroup(
-        user.selectedOrganization.serverUrl,
+        user.selectedOrganization,
         group.id,
         itemsToCancel,
       );

--- a/front-end/src/renderer/pages/TransactionGroupDetails/ExportAllController.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/ExportAllController.vue
@@ -50,8 +50,7 @@ const handleExportAll = async (personalPassword: string | null): Promise<ActionR
     try {
       let group: IGroup;
       if (typeof props.groupOrId === 'number') {
-        const serverUrl = user.selectedOrganization.serverUrl;
-        group = await getTransactionGroupById(serverUrl, props.groupOrId);
+        group = await getTransactionGroupById(user.selectedOrganization, props.groupOrId);
       } else {
         group = props.groupOrId;
       }
@@ -74,7 +73,7 @@ const handleExportAll = async (personalPassword: string | null): Promise<ActionR
       for (const item of group.groupItems as IGroupItem[]) {
         const orgTransaction = await transactionCache.lookup(
           item.transactionId,
-          user.selectedOrganization.serverUrl,
+          user.selectedOrganization,
         );
 
         const baseName = generateTransactionExportFileName(orgTransaction);

--- a/front-end/src/renderer/pages/TransactionGroupDetails/SignAllController.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/SignAllController.vue
@@ -62,9 +62,8 @@ const performSignAll = async (
     let group: IGroup;
     if (typeof props.groupOrId === 'number') {
       assertIsLoggedInOrganization(user.selectedOrganization);
-      const serverUrl = user.selectedOrganization.serverUrl;
       progressText.value = 'Loading group items…';
-      group = await getTransactionGroupById(serverUrl, props.groupOrId);
+      group = await getTransactionGroupById(user.selectedOrganization, props.groupOrId);
     } else {
       group = props.groupOrId;
     }

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -336,7 +336,7 @@ async function fetchGroup(id: string | number) {
   fullyLoaded.value = false;
   if (isLoggedInOrganization(user.selectedOrganization) && !isNaN(Number(id))) {
     try {
-      group.value = await getTransactionGroupById(user.selectedOrganization.serverUrl, Number(id));
+      group.value = await getTransactionGroupById(user.selectedOrganization, Number(id));
       isVersionMismatch.value = false;
 
       if (group.value?.groupItems != undefined) {
@@ -391,10 +391,9 @@ async function fetchGroup(id: string | number) {
 async function fetchGroupOnNotif(groupId: string | number) {
   // 1) Before calling fetchGroup(), we clear transaction cache
   if (isLoggedInOrganization(user.selectedOrganization) && group.value !== null) {
-    const serverUrl = user.selectedOrganization.serverUrl;
     for (const item of group.value.groupItems) {
       // We clear cache with strict==false to keep young data
-      appCache.backendTransaction.forget(item.transactionId, serverUrl, false);
+      appCache.backendTransaction.forget(item.transactionId, user.selectedOrganization, false);
     }
   }
   // 2) Now fetch group

--- a/front-end/src/renderer/pages/Transactions/Transactions.vue
+++ b/front-end/src/renderer/pages/Transactions/Transactions.vue
@@ -217,7 +217,6 @@ async function handleTransactionFileAction(action: string) {
 /* Functions */
 async function importSignaturesFromV2File(filePath: string) {
   assertIsLoggedInOrganization(user.selectedOrganization);
-  const serverUrl = user.selectedOrganization.serverUrl;
 
   const transactionFile = await readTransactionFile(filePath);
   const importInputs: ISignatureImport[] = [];
@@ -231,7 +230,10 @@ async function importSignaturesFromV2File(filePath: string) {
 
     const transactionId = sdkTransaction.transactionId;
     try {
-      const transaction = await transactionCache.lookup(transactionId!.toString(), serverUrl);
+      const transaction = await transactionCache.lookup(
+        transactionId!.toString(),
+        user.selectedOrganization,
+      );
       importInputs.push({
         id: transaction.id,
         signatureMap: map,
@@ -272,7 +274,7 @@ async function importSignaturesFromV2File(filePath: string) {
 
   for (const i of importInputs) {
     // We forget cached data for transaction i.id
-    transactionCache.forget(i.id, serverUrl);
+    transactionCache.forget(i.id, user.selectedOrganization);
   }
 }
 
@@ -321,7 +323,7 @@ async function findPrimaryTabTitle(): Promise<string> {
   if (user.selectedOrganization.isPasswordTemporary) return historyTitle;
 
   const nodes = await getTransactionNodes(
-    user.selectedOrganization.serverUrl,
+    user.selectedOrganization,
     TransactionNodeCollection.READY_FOR_REVIEW,
     network.network,
     [],

--- a/front-end/src/renderer/pages/Transactions/components/History.vue
+++ b/front-end/src/renderer/pages/Transactions/components/History.vue
@@ -241,7 +241,7 @@ async function fetchTransactions(options?: { silent?: boolean }) {
       if (user.selectedOrganization.isPasswordTemporary) return;
 
       const { totalItems: totalItemsCount, items: rawTransactions } = await getHistoryTransactions(
-        user.selectedOrganization.serverUrl,
+        user.selectedOrganization,
         currentPage.value,
         pageSize.value,
         orgFilters.value,
@@ -269,10 +269,9 @@ async function fetchTransactions(options?: { silent?: boolean }) {
 async function fetchTransactionsOnNotif(options?: { silent?: boolean }) {
   // 1) Before calling fetchTransactions(), we clear transaction cache
   if (isLoggedInOrganization(user.selectedOrganization)) {
-    const serverUrl = user.selectedOrganization.serverUrl;
     for (const t of organizationTransactions.value) {
       // We clear cache with strict==false to keep young data
-      transactionCache.forget(t.transactionRaw.transactionId, serverUrl, false);
+      transactionCache.forget(t.transactionRaw.transactionId, user.selectedOrganization, false);
     }
   }
   // 2) Now fetch group

--- a/front-end/src/renderer/pages/Transactions/components/SignSingleButton.vue
+++ b/front-end/src/renderer/pages/Transactions/components/SignSingleButton.vue
@@ -34,7 +34,7 @@ const handleClick = async () => {
 
   transaction.value = await transactionCache.lookup(
     props.transactionId,
-    user.selectedOrganization.serverUrl,
+    user.selectedOrganization,
   );
 
   signStarted.value = true;
@@ -46,7 +46,7 @@ const didSign = async () => {
 
     const newTransaction = await transactionCache.lookup(
       props.transactionId,
-      user.selectedOrganization.serverUrl,
+      user.selectedOrganization,
     );
     emit('transactionSigned', { transaction: newTransaction });
   } else {

--- a/front-end/src/renderer/pages/Transactions/components/TransactionNodeTable.vue
+++ b/front-end/src/renderer/pages/Transactions/components/TransactionNodeTable.vue
@@ -2,7 +2,10 @@
 import { computed, onMounted, ref, watch } from 'vue';
 import { ToastManager } from '@renderer/utils/ToastManager';
 
-import { type ITransactionNode, TransactionNodeCollection } from '../../../../../../shared/src/ITransactionNode.ts';
+import {
+  type ITransactionNode,
+  TransactionNodeCollection,
+} from '../../../../../../shared/src/ITransactionNode.ts';
 
 import { BackEndTransactionType, NotificationType, TransactionStatus } from '@shared/interfaces';
 
@@ -11,7 +14,9 @@ import useNetworkStore from '@renderer/stores/storeNetwork.ts';
 
 import useMarkNotifications from '@renderer/composables/useMarkNotifications';
 import useWebsocketSubscription from '@renderer/composables/useWebsocketSubscription';
-import useNextTransactionV2, { type TransactionNodeId } from '@renderer/stores/storeNextTransactionV2.ts';
+import useNextTransactionV2, {
+  type TransactionNodeId,
+} from '@renderer/stores/storeNextTransactionV2.ts';
 
 import AppLoader from '@renderer/components/ui/AppLoader.vue';
 import EmptyTransactions from '@renderer/components/EmptyTransactions.vue';
@@ -74,7 +79,8 @@ const nextTransaction = useNextTransactionV2();
 const router = useRouter();
 const toastManager = ToastManager.inject();
 const logger = createLogger('renderer.transactions.nodeTable');
-const { recentlyUpdatedTxIds, recentlyUpdatedGroupIds, highlightAndFetch } = useTransactionLiveHighlight();
+const { recentlyUpdatedTxIds, recentlyUpdatedGroupIds, highlightAndFetch } =
+  useTransactionLiveHighlight();
 
 useWebsocketSubscription(TRANSACTION_ACTION, async (payload?: unknown) => {
   const parsed = parseTransactionActionPayload(payload);
@@ -94,9 +100,8 @@ useWebsocketSubscription(TRANSACTION_ACTION, async (payload?: unknown) => {
   // For non-status updates, only refetch if current items are affected
   const txIds = new Set(parsed.transactionIds);
   const grpIds = new Set(parsed.groupIds);
-  const hasMatch = nodes.value.some(n =>
-    (n.transactionId && txIds.has(n.transactionId)) ||
-    (n.groupId && grpIds.has(n.groupId)),
+  const hasMatch = nodes.value.some(
+    n => (n.transactionId && txIds.has(n.transactionId)) || (n.groupId && grpIds.has(n.groupId)),
   );
   if (hasMatch) {
     await highlightAndFetch(parsed.transactionIds, parsed.groupIds, silentFetch);
@@ -114,11 +119,12 @@ const { oldNotifications } = useMarkNotifications(
 );
 
 const defaults = initialSort();
-const { initialPage, initialPageSize, initialSortField, initialSortDirection, syncToUrl } = useTableQueryState(
-  TRANSACTION_NODE_SORT_URL_VALUES,
-  sortFieldToUrl(defaults.field),
-  defaults.direction,
-);
+const { initialPage, initialPageSize, initialSortField, initialSortDirection, syncToUrl } =
+  useTableQueryState(
+    TRANSACTION_NODE_SORT_URL_VALUES,
+    sortFieldToUrl(defaults.field),
+    defaults.direction,
+  );
 
 /* State */
 const nodes = ref<ITransactionNode[]>([]);
@@ -231,7 +237,7 @@ async function fetchNodes(options?: { silent?: boolean }): Promise<void> {
     if (!options?.silent) isLoading.value = true;
     try {
       nodes.value = await getTransactionNodes(
-        user.selectedOrganization.serverUrl,
+        user.selectedOrganization,
         props.collection,
         network.network,
         statusFilter.value,
@@ -267,11 +273,10 @@ function clampPage(): void {
 async function fetchNodesOnNotif(options?: { silent?: boolean }): Promise<void> {
   // 1) Before calling fetchNodes(), we clear transaction cache
   if (isLoggedInOrganization(user.selectedOrganization)) {
-    const serverUrl = user.selectedOrganization.serverUrl;
     for (const node of nodes.value) {
       // We clear cache with strict==false to keep young data
       if (node.transactionId) {
-        transactionCache.forget(node.transactionId, serverUrl, false);
+        transactionCache.forget(node.transactionId, user.selectedOrganization, false);
       }
     }
   }
@@ -281,19 +286,27 @@ async function fetchNodesOnNotif(options?: { silent?: boolean }): Promise<void> 
 
 /* Watchers */
 watch(sort, () => {
-    currentPage.value = 1;
-    sortNodes();
-  },
-);
-
-watch([currentPage, pageSize], () => {
-  syncToUrl(currentPage.value, sortFieldToUrl(sort.value.field), sort.value.direction, pageSize.value);
+  currentPage.value = 1;
+  sortNodes();
 });
 
-watch([statusFilter, transactionTypeFilter], () => {
-  currentPage.value = 1;
-  fetchNodes();
-}, { deep: true });
+watch([currentPage, pageSize], () => {
+  syncToUrl(
+    currentPage.value,
+    sortFieldToUrl(sort.value.field),
+    sort.value.direction,
+    pageSize.value,
+  );
+});
+
+watch(
+  [statusFilter, transactionTypeFilter],
+  () => {
+    currentPage.value = 1;
+    fetchNodes();
+  },
+  { deep: true },
+);
 
 /* Hooks */
 onMounted(fetchNodes);

--- a/front-end/src/renderer/services/organization/auth.ts
+++ b/front-end/src/renderer/services/organization/auth.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 import { axiosWithCredentials, commonRequestHandler } from '@renderer/utils';
+import type { Organization } from '@prisma/client';
 
 /* Authentification service for organization */
 
@@ -14,7 +15,7 @@ export const login = async (
 ): Promise<{ id: number; jwtToken: string }> =>
   commonRequestHandler(
     async () => {
-      const { data } = await axiosWithCredentials.post(`${serverUrl}/${authController}/login`, {
+      const { data } = await axios.post(`${serverUrl}/${authController}/login`, {
         email,
         password,
       });
@@ -26,50 +27,40 @@ export const login = async (
   );
 
 /* Logout the user */
-export const logout = async (serverUrl: string): Promise<{ id: number }> =>
+export const logout = async (org: Organization): Promise<{ id: number }> =>
   commonRequestHandler(async () => {
-    const { data } = await axiosWithCredentials.post(`${serverUrl}/${authController}/logout`);
+    const { data } = await axiosWithCredentials.post(org, `${authController}/logout`);
     return { id: data.id };
   }, 'Failed to Log out of Organization');
 
 /* Changes the password */
 export const changePassword = async (
-  organizationServerUrl: string,
+  org: Organization,
   oldPassword: string,
   newPassword: string,
 ): Promise<void> =>
   commonRequestHandler(async () => {
-    const response = await axiosWithCredentials.patch(
-      `${organizationServerUrl}/${authController}/change-password`,
-      {
-        oldPassword,
-        newPassword,
-      },
-    );
+    const response = await axiosWithCredentials.patch(org, `${authController}/change-password`, {
+      oldPassword,
+      newPassword,
+    });
     return response.data;
   }, 'Failed to change user password');
 
 /* Sends a reset password request */
-export const resetPassword = async (
-  organizationServerUrl: string,
-  email: string,
-): Promise<string> =>
+export const resetPassword = async (org: Organization, email: string): Promise<string> =>
   commonRequestHandler(async () => {
-    const response = await axios.post(`${organizationServerUrl}/${authController}/reset-password`, {
+    const response = await axios.post(`${org.serverUrl}/${authController}/reset-password`, {
       email,
     });
     return response.data.token;
   }, 'Failed to request passoword reset');
 
 /* Sends the OTP in order to verify the password reset */
-export const verifyReset = async (
-  organizationServerUrl: string,
-  otp: string,
-  token: string,
-): Promise<string> =>
+export const verifyReset = async (org: Organization, otp: string, token: string): Promise<string> =>
   commonRequestHandler(async () => {
     const response = await axios.post(
-      `${organizationServerUrl}/${authController}/verify-reset`,
+      `${org.serverUrl}/${authController}/verify-reset`,
       {
         token: otp,
       },
@@ -83,14 +74,10 @@ export const verifyReset = async (
   }, 'Failed to verify password reset');
 
 /* Sets new password after being OTP verified */
-export const setPassword = async (
-  organizationServerUrl: string,
-  password: string,
-  token: string,
-): Promise<void> =>
+export const setPassword = async (org: Organization, password: string, token: string): Promise<void> =>
   commonRequestHandler(async () => {
     const response = await axios.patch(
-      `${organizationServerUrl}/${authController}/set-password`,
+      `${org.serverUrl}/${authController}/set-password`,
       {
         password,
       },
@@ -105,7 +92,7 @@ export const setPassword = async (
 
 /* ADMIN ONLY: Signs a user to the organization */
 export const signUp = (
-  organizationServerUrl: string,
+  org: Organization,
   email: string,
 ): Promise<{
   id: number;
@@ -113,19 +100,16 @@ export const signUp = (
   createdAt: string;
 }> =>
   commonRequestHandler(async () => {
-    const response = await axiosWithCredentials.post(
-      `${organizationServerUrl}/${authController}/signup`,
-      {
-        email,
-      },
-    );
+    const response = await axiosWithCredentials.post(org, `${authController}/signup`, {
+      email,
+    });
     return response.data;
   }, 'Failed to sign up the user');
 
 /* ADMIN ONLY: elevate a user to admin */
-export const elevateUserToAdmin = (organizationServerUrl: string, id: number) =>
+export const elevateUserToAdmin = (  org: Organization, id: number) =>
   commonRequestHandler(async () => {
-    await axiosWithCredentials.patch(`${organizationServerUrl}/${authController}/elevate-admin`, {
+    await axiosWithCredentials.patch(org, `${authController}/elevate-admin`, {
       id,
     });
   }, 'Failed to assign user as admin');

--- a/front-end/src/renderer/services/organization/cancelGroupFallback.ts
+++ b/front-end/src/renderer/services/organization/cancelGroupFallback.ts
@@ -2,11 +2,12 @@ import { TransactionStatus } from '@shared/interfaces';
 import type { IGroupItem, CancelGroupResult } from './transactionGroup';
 import { CancelFailureCode } from './transactionGroup';
 import { isInProgressStatus } from '@renderer/utils/transactionStatusGuards';
+import type { Organization } from '@prisma/client';
 
 export async function cancelGroupFallback(
-  serverUrl: string,
+  organization: Organization,
   groupItems: IGroupItem[],
-  cancelOne: (serverUrl: string, id: number) => Promise<boolean>,
+  cancelOne: (organization: Organization, id: number) => Promise<boolean>,
 ): Promise<CancelGroupResult> {
   const canceled: number[] = [];
   const alreadyCanceled: number[] = [];
@@ -31,7 +32,7 @@ export async function cancelGroupFallback(
     }
 
     try {
-      await cancelOne(serverUrl, txId);
+      await cancelOne(organization, txId);
       canceled.push(txId);
     } catch (error) {
       failed.push({

--- a/front-end/src/renderer/services/organization/notificationPreferences.ts
+++ b/front-end/src/renderer/services/organization/notificationPreferences.ts
@@ -4,6 +4,7 @@ import type {
 } from '@shared/interfaces';
 
 import { axiosWithCredentials, commonRequestHandler } from '@renderer/utils';
+import type { Organization } from '@prisma/client';
 
 /* Notification preferences service for organization */
 
@@ -11,22 +12,19 @@ const controller = 'notification-preferences';
 
 /* Get keys for a user from organization */
 export const getUserNotificationPreferences = async (
-  organizationServerUrl: string,
+  org: Organization,
 ): Promise<INotificationPreferencesCore[]> =>
   commonRequestHandler(async () => {
-    const response = await axiosWithCredentials.get(`${organizationServerUrl}/${controller}`);
+    const response = await axiosWithCredentials.get(org, `${controller}`);
     return response.data;
   }, 'Failed to get user notification preferences');
 
 /* Uploads a key to the organization */
 export const updateUserNotificationPreferences = async (
-  organizationServerUrl: string,
+  org: Organization,
   preferences: IUpdateNotificationPreferencesDto,
 ): Promise<INotificationPreferencesCore> =>
   commonRequestHandler(async () => {
-    const response = await axiosWithCredentials.patch(
-      `${organizationServerUrl}/${controller}`,
-      preferences,
-    );
+    const response = await axiosWithCredentials.patch(org, `${controller}`, preferences);
     return response.data;
   }, 'Failed to update user notification preferences');

--- a/front-end/src/renderer/services/organization/notifications.ts
+++ b/front-end/src/renderer/services/organization/notifications.ts
@@ -2,6 +2,7 @@ import type { INotificationReceiver, IUpdateNotificationReceiver } from '@shared
 
 import { axiosWithCredentials, commonRequestHandler } from '@renderer/utils';
 import { createLogger } from '@renderer/utils/logger';
+import type { Organization } from '@prisma/client';
 
 const logger = createLogger('renderer.organization.notifications');
 
@@ -11,7 +12,7 @@ const controller = 'notifications';
 
 /* Get keys for a user from organization */
 export const getAllInAppNotifications = async (
-  organizationServerUrl: string,
+  organization: Organization,
   onlyNew: boolean,
 ): Promise<INotificationReceiver[]> =>
   commonRequestHandler(async () => {
@@ -30,7 +31,8 @@ export const getAllInAppNotifications = async (
         }
 
         const { data } = await axiosWithCredentials.get(
-          `${organizationServerUrl}/${controller}?${paginationQuery}&${filterQuery}`,
+          organization,
+          `${controller}?${paginationQuery}&${filterQuery}`,
         );
         const totalItems = data.totalItems;
 
@@ -46,7 +48,7 @@ export const getAllInAppNotifications = async (
 
 /* Update notification */
 export const updateNotifications = async (
-  organizationServerUrl: string,
+  organization: Organization,
   notificationsToUpdate: IUpdateNotificationReceiver[],
 ): Promise<void> =>
   commonRequestHandler(async () => {
@@ -54,7 +56,7 @@ export const updateNotifications = async (
       const batchSize = 500;
       for (let i = 0; i < notificationsToUpdate.length; i += batchSize) {
         const batch = notificationsToUpdate.slice(i, i + batchSize);
-        await axiosWithCredentials.patch(`${organizationServerUrl}/${controller}`, batch);
+        await axiosWithCredentials.patch(organization, `${controller}`, batch);
       }
     } catch (error) {
       logger.error('Failed to update notifications', { error });
@@ -62,9 +64,13 @@ export const updateNotifications = async (
   }, 'Failed to update notifications');
 
 /* Sends email to the required signers  */
-export const remindSigners = async (serverUrl: string, transactionId: number): Promise<void> =>
+export const remindSigners = async (
+  organization: Organization,
+  transactionId: number,
+): Promise<void> =>
   commonRequestHandler(async () => {
     await axiosWithCredentials.post(
-      `${serverUrl}/${controller}/remind-signers?transactionId=${transactionId}`,
+      organization,
+      `${controller}/remind-signers?transactionId=${transactionId}`,
     );
   }, `Failed to remind signers for transaction transaction with id ${transactionId}`);

--- a/front-end/src/renderer/services/organization/reconnect.ts
+++ b/front-end/src/renderer/services/organization/reconnect.ts
@@ -3,10 +3,7 @@ import useVersionCheck from '@renderer/composables/useVersionCheck';
 import useUserStore from '@renderer/stores/storeUser';
 import useWebsocketConnection from '@renderer/stores/storeWebsocketConnection';
 import useOrganizationConnection from '@renderer/stores/storeOrganizationConnection';
-import {
-  getVersionStatusForOrg,
-  organizationVersionData,
-} from '@renderer/stores/versionState';
+import { getVersionStatusForOrg, organizationVersionData } from '@renderer/stores/versionState';
 
 import { getLocalWebsocketPath } from '@renderer/services/organizationsService';
 import { isVersionBelowMinimum } from '@renderer/services/organization/versionCompatibility';
@@ -19,24 +16,22 @@ import {
   getOrganizationCredentials,
   updateOrganizationCredentials,
 } from '../organizationCredentials';
+import type{ Organization } from '@prisma/client';
+import type { ConnectedOrganization } from '@renderer/types';
 
 const logger = createLogger('renderer.organization.reconnect');
 
-export async function reconnectOrganization(serverUrl: string): Promise<{
+export async function reconnectOrganization(org: Organization): Promise<{
   success: boolean;
   requiresUpdate?: boolean;
 }> {
+  const serverUrl = org.serverUrl;
   const userStore = useUserStore();
   const ws = useWebsocketConnection();
   const orgConnection = useOrganizationConnection();
   const { performVersionCheck } = useVersionCheck();
 
-  const org = userStore.organizations.find(o => o.serverUrl === serverUrl);
   const user = userStore.personal;
-  if (!org) {
-    logger.error('Organization not found during reconnect', { serverUrl });
-    throw new Error('Organization not found');
-  }
 
   try {
     let sawLogin426 = false;
@@ -86,7 +81,7 @@ export async function reconnectOrganization(serverUrl: string): Promise<{
 
     // performVersionCheck stores fresh version data via setVersionDataForOrg;
     // status and compat are derived from that data automatically.
-    await performVersionCheck(serverUrl);
+    await performVersionCheck(org);
 
     const versionStatus = getVersionStatusForOrg(serverUrl);
     const versionData = organizationVersionData.value[serverUrl];
@@ -122,11 +117,9 @@ export async function reconnectOrganization(serverUrl: string): Promise<{
 
     orgConnection.setConnectionStatus(serverUrl, 'connected');
 
-    if (org) {
-      org.connectionStatus = 'connected';
-      delete org.disconnectReason;
-      delete org.lastDisconnectedAt;
-    }
+    (org as ConnectedOrganization).connectionStatus = 'connected';
+    delete (org as ConnectedOrganization).disconnectReason;
+    delete (org as ConnectedOrganization).lastDisconnectedAt;
 
     logger.info('Organization reconnected successfully', {
       organization: org.nickname || serverUrl,

--- a/front-end/src/renderer/services/organization/transaction.ts
+++ b/front-end/src/renderer/services/organization/transaction.ts
@@ -28,7 +28,7 @@ const controller = 'transactions';
 
 /* Submits a transaction to the back end */
 export const submitTransaction = async (
-  serverUrl: string,
+  organization: Organization,
   name: string,
   description: string,
   transactionBytes: string,
@@ -39,7 +39,7 @@ export const submitTransaction = async (
   reminderMillisecondsBefore?: number | null,
 ): Promise<{ id: number; transactionBytes: string }> =>
   commonRequestHandler(async () => {
-    const { data } = await axiosWithCredentials.post(`${serverUrl}/${controller}`, {
+    const { data } = await axiosWithCredentials.post(organization, `${controller}`, {
       name,
       description,
       transactionBytes,
@@ -54,25 +54,31 @@ export const submitTransaction = async (
   }, 'Failed submit transaction');
 
 /* Cancel a transaction  */
-export const cancelTransaction = async (serverUrl: string, id: number): Promise<boolean> =>
+export const cancelTransaction = async (organization: Organization, id: number): Promise<boolean> =>
   commonRequestHandler(async () => {
-    const { data } = await axiosWithCredentials.patch(`${serverUrl}/${controller}/cancel/${id}`);
+    const { data } = await axiosWithCredentials.patch(organization, `${controller}/cancel/${id}`);
 
     return data;
   }, `Failed to cancel transaction with id ${id}`);
 
 /* Archive a transaction  */
-export const archiveTransaction = async (serverUrl: string, id: number): Promise<boolean> =>
+export const archiveTransaction = async (
+  organization: Organization,
+  id: number,
+): Promise<boolean> =>
   commonRequestHandler(async () => {
-    const { data } = await axiosWithCredentials.patch(`${serverUrl}/${controller}/archive/${id}`);
+    const { data } = await axiosWithCredentials.patch(organization, `${controller}/archive/${id}`);
 
     return data;
   }, `Failed to archive transaction with id ${id}`);
 
 /* Executes the manual transaction  */
-export const executeTransaction = async (serverUrl: string, id: number): Promise<boolean> =>
+export const executeTransaction = async (
+  organization: Organization,
+  id: number,
+): Promise<boolean> =>
   commonRequestHandler(async () => {
-    const { data } = await axiosWithCredentials.patch(`${serverUrl}/${controller}/execute/${id}`);
+    const { data } = await axiosWithCredentials.patch(organization, `${controller}/execute/${id}`);
 
     return data;
   }, `Failed to execute transaction with id ${id}`);
@@ -120,7 +126,8 @@ export const uploadSignatures = async (
 
   return await commonRequestHandler(async () => {
     return await axiosWithCredentials.post(
-      `${organization.serverUrl}/${controller}/signers?includeNotifications=true`,
+      organization,
+      `${controller}/signers?includeNotifications=true`,
       formattedMaps,
     );
   }, 'Failed upload signatures');
@@ -147,7 +154,8 @@ export const importSignatures = async (
   }
   return commonRequestHandler(async () => {
     const { data } = await axiosWithCredentials.post(
-      `${organization.serverUrl}/${controller}/signatures/import`,
+      organization,
+      `${controller}/signatures/import`,
       formattedMaps,
     );
     return data;
@@ -176,20 +184,24 @@ export const getUserShouldApprove = async (
 
 /* Get the count of the transactions to sign */
 export const getTransactionById = async (
-  serverUrl: string,
+  organization: Organization,
   id: number | TransactionId,
 ): Promise<ITransactionFull> =>
   commonRequestHandler(async () => {
-    const { data } = await axiosWithCredentials.get(`${serverUrl}/${controller}/${id.toString()}`, {
-      withCredentials: true,
-    });
+    const { data } = await axiosWithCredentials.get(
+      organization,
+      `${controller}/${id.toString()}`,
+      {
+        withCredentials: true,
+      },
+    );
 
     return data;
   }, `Failed to get transaction with id ${id}`);
 
 /* Get history transactions */
 export const getHistoryTransactions = async (
-  serverUrl: string,
+  organization: Organization,
   page: number,
   size: number,
   filter: {
@@ -204,17 +216,22 @@ export const getHistoryTransactions = async (
     const filtering = filter.map(f => `&filter=${f.property}:${f.rule}:${f.value}`).join('');
 
     const { data } = await axiosWithCredentials.get(
-      `${serverUrl}/${controller}/history?page=${page}&size=${size}${sorting}${filtering}`,
+      organization,
+      `${controller}/history?page=${page}&size=${size}${sorting}${filtering}`,
     );
 
     return data;
   }, 'Failed to get history transactions');
 
 /* Adds observers */
-export const addObservers = async (serverUrl: string, transactionId: number, userIds: number[]) =>
+export const addObservers = async (
+  organization: Organization,
+  transactionId: number,
+  userIds: number[],
+) =>
   commonRequestHandler(async () => {
     const { data } = await axiosWithCredentials.post(
-      `${serverUrl}/${controller}/${transactionId}/observers`,
+      organization, `${controller}/${transactionId}/observers`,
       {
         userIds,
       },
@@ -225,13 +242,14 @@ export const addObservers = async (serverUrl: string, transactionId: number, use
 
 /* Adds approvers */
 export const addApprovers = async (
-  serverUrl: string,
+  organization: Organization,
   transactionId: number,
   approvers: TransactionApproverDto[],
 ) =>
   commonRequestHandler(async () => {
     const { data } = await axiosWithCredentials.post(
-      `${serverUrl}/${controller}/${transactionId}/approvers`,
+      organization,
+      `${controller}/${transactionId}/approvers`,
       {
         approversArray: approvers,
       },
@@ -242,7 +260,7 @@ export const addApprovers = async (
 
 /* Sends approver's choice */
 export const sendApproverChoice = async (
-  serverUrl: string,
+  organization: Organization,
   transactionId: number,
   userKeyId: number,
   signature: string,
@@ -250,7 +268,8 @@ export const sendApproverChoice = async (
 ) =>
   commonRequestHandler(async () => {
     const { data } = await axiosWithCredentials.post(
-      `${serverUrl}/${controller}/${transactionId}/approvers/approve`,
+      organization,
+      `${controller}/${transactionId}/approvers/approve`,
       {
         userKeyId: userKeyId,
         signature: signature,

--- a/front-end/src/renderer/services/organization/transactionGroup.ts
+++ b/front-end/src/renderer/services/organization/transactionGroup.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { axiosWithCredentials, commonRequestHandler } from '@renderer/utils';
 import { cancelTransaction } from './transaction';
 import { cancelGroupFallback } from './cancelGroupFallback';
+import type { Organization } from '@prisma/client';
 
 export interface ApiGroupItem {
   seq: number;
@@ -26,7 +27,7 @@ export interface IGroup {
 }
 
 export const submitTransactionGroup = async (
-  serverUrl: string,
+  organization: Organization,
   description: string,
   atomic: boolean,
   sequential: boolean,
@@ -34,7 +35,8 @@ export const submitTransactionGroup = async (
 ): Promise<{ id: number; transactionBytes: string }> => {
   return commonRequestHandler(async () => {
     const { data } = await axiosWithCredentials.post(
-      `${serverUrl}/transaction-groups`,
+      organization,
+      `transaction-groups`,
       {
         description,
         atomic,
@@ -76,21 +78,22 @@ export interface CancelGroupResult {
 }
 
 export const cancelTransactionGroup = async (
-  serverUrl: string,
+  organization: Organization,
   groupId: number,
   groupItems: IGroupItem[],
 ): Promise<CancelGroupResult> => {
   return commonRequestHandler(async () => {
     try {
       const { data } = await axiosWithCredentials.patch<CancelGroupResult>(
-        `${serverUrl}/transaction-groups/${groupId}/cancel`,
+        organization,
+        `transaction-groups/${groupId}/cancel`,
         undefined,
         { withCredentials: true },
       );
       return data;
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.status === 404) {
-        return cancelGroupFallback(serverUrl, groupItems, cancelTransaction);
+        return cancelGroupFallback(organization, groupItems, cancelTransaction);
       }
       // Let commonRequestHandler handle non-404 errors and map them consistently.
       throw error;
@@ -99,15 +102,12 @@ export const cancelTransactionGroup = async (
 };
 
 /* Get transaction groups */
-export const getTransactionGroupById = async (serverUrl: string, id: number, full?: boolean) => {
+export const getTransactionGroupById = async (org: Organization, id: number, full?: boolean) => {
   return commonRequestHandler(async () => {
-    const { data } = await axiosWithCredentials.get<IGroup>(
-      `${serverUrl}/transaction-groups/${id}`,
-      {
-        withCredentials: true,
-        params: full !== undefined ? { full } : undefined,
-      },
-    );
+    const { data } = await axiosWithCredentials.get<IGroup>(org, `transaction-groups/${id}`, {
+      withCredentials: true,
+      params: full !== undefined ? { full } : undefined,
+    });
 
     return data;
   }, 'Failed to get transaction groups');

--- a/front-end/src/renderer/services/organization/transactionNode.ts
+++ b/front-end/src/renderer/services/organization/transactionNode.ts
@@ -10,9 +10,10 @@ import {
   TRANSACTION_NODE_STATUS_MESSAGES,
   SESSION_EXPIRED_MESSAGE,
 } from './errorMessages';
+import type { Organization } from '@prisma/client';
 
 export const getTransactionNodes = async (
-  serverUrl: string,
+  organization: Organization,
   collection: TransactionNodeCollection,
   network: Network,
   statusFilter: TransactionStatus[],
@@ -32,7 +33,9 @@ export const getTransactionNodes = async (
     if (transactionTypeFilter.length > 0) {
       params.transactionType = `${transactionTypeFilter}`;
     }
-    const r = await axiosWithCredentials.get(`${serverUrl}/transaction-nodes`, { params });
+    const r = await axiosWithCredentials.get(organization, `transaction-nodes`, {
+      params,
+    });
 
     return r.data;
   },

--- a/front-end/src/renderer/services/organization/user.ts
+++ b/front-end/src/renderer/services/organization/user.ts
@@ -4,14 +4,18 @@ import { axiosWithCredentials, commonRequestHandler } from '@renderer/utils';
 
 import { getUserKeys } from './userKeys';
 
-import { PUBLIC_KEY_OWNER_DEFAULT_MESSAGE, PUBLIC_KEY_OWNER_STATUS_MESSAGES } from './errorMessages';
+import {
+  PUBLIC_KEY_OWNER_DEFAULT_MESSAGE,
+  PUBLIC_KEY_OWNER_STATUS_MESSAGES,
+} from './errorMessages';
+import type { Organization } from '@prisma/client';
 
 /* User service for organization */
 const controller = 'users';
 
 /* Get information about current user */
-export const getUserState = async (organizationServerUrl: string) => {
-  const { id, status, email, admin, keys } = await getMe(organizationServerUrl);
+export const getUserState = async (organization: Organization) => {
+  const { id, status, email, admin, keys } = await getMe(organization);
 
   const user: {
     id: number;
@@ -34,7 +38,7 @@ export const getUserState = async (organizationServerUrl: string) => {
   /* Backward compatibility */
   let userKeys: IUserKey[] = keys;
   if (!userKeys) {
-    userKeys = await getUserKeys(organizationServerUrl, id);
+    userKeys = await getUserKeys(organization, id);
   }
 
   user.userKeys.push(...userKeys);
@@ -51,39 +55,38 @@ export const getUserState = async (organizationServerUrl: string) => {
 };
 
 /* Get information about current user */
-export const getMe = async (organizationServerUrl: string): Promise<IUser> =>
+export const getMe = async (organization: Organization): Promise<IUser> =>
   commonRequestHandler(async () => {
-    const response = await axiosWithCredentials.get(`${organizationServerUrl}/${controller}/me`);
+    const response = await axiosWithCredentials.get(organization, `${controller}/me`);
     return response.data;
   }, 'Failed to get user information');
 
 /* Get information about organization users */
-export const getUsers = (organizationServerUrl: string): Promise<IUser[]> =>
+export const getUsers = (organization: Organization): Promise<IUser[]> =>
   commonRequestHandler(async () => {
-    const response = await axiosWithCredentials.get(`${organizationServerUrl}/${controller}`);
+    const response = await axiosWithCredentials.get(organization, `${controller}`);
     return response.data;
   }, 'Failed to get organization users');
 
 /* ADMIN ONLY: Delete a user */
-export const deleteUser = (organizationServerUrl: string, id: number) =>
+export const deleteUser = (organization: Organization, id: number) =>
   commonRequestHandler(async () => {
-    const response = await axiosWithCredentials.delete(
-      `${organizationServerUrl}/${controller}/${id}`,
-    );
+    const response = await axiosWithCredentials.delete(organization, `${controller}/${id}`);
     return response.data;
   }, 'Failed to delete user');
 
 export const getPublicKeyOwner = async (
-  organizationServerUrl: string,
+  organization: Organization,
   publicKey: string,
 ): Promise<string | null> => {
   return commonRequestHandler(
     async () => {
       const response = await axiosWithCredentials.get(
-        `${organizationServerUrl}/${controller}/public-owner/${publicKey}`,
+        organization,
+        `${controller}/public-owner/${publicKey}`,
       );
       // response.data == "" when there is no matching user => fixing
-      return response.data === "" ? null : response.data;
+      return response.data === '' ? null : response.data;
     },
     PUBLIC_KEY_OWNER_DEFAULT_MESSAGE,
     PUBLIC_KEY_OWNER_STATUS_MESSAGES[401],

--- a/front-end/src/renderer/services/organization/userKeys.ts
+++ b/front-end/src/renderer/services/organization/userKeys.ts
@@ -1,6 +1,7 @@
 import type { IUserKey, PaginatedResourceDto } from '@shared/interfaces';
 
 import { axiosWithCredentials, commonRequestHandler, safeAwait } from '@renderer/utils';
+import type { Organization } from '@prisma/client';
 
 /* User keys service for organization */
 
@@ -8,12 +9,13 @@ const controller = ['user', 'keys'];
 
 /* Get keys for a user from organization */
 export const getUserKeys = async (
-  organizationServerUrl: string,
+  organization: Organization,
   organizationUserId: number,
 ): Promise<IUserKey[]> =>
   commonRequestHandler(async () => {
     const response = await axiosWithCredentials.get(
-      `${organizationServerUrl}/${controller[0]}/${organizationUserId}/${controller[1]}`,
+      organization,
+      `${controller[0]}/${organizationUserId}/${controller[1]}`,
     );
 
     return response.data;
@@ -21,32 +23,34 @@ export const getUserKeys = async (
 
 /* Uploads a key to the organization */
 export const uploadKey = async (
-  organizationServerUrl: string,
+  organization: Organization,
   organizationUserId: number,
   key: { publicKey: string; index?: number; mnemonicHash?: string },
 ) =>
   commonRequestHandler(async () => {
     await axiosWithCredentials.post(
-      `${organizationServerUrl}/${controller[0]}/${organizationUserId}/${controller[1]}`,
+      organization,
+      `${controller[0]}/${organizationUserId}/${controller[1]}`,
       key,
     );
   }, 'Failed to upload user key');
 
 /* Deletes a key from the organization */
 export const deleteKey = async (
-  organizationServerUrl: string,
+  organization: Organization,
   organizationUserId: number,
   keyId: number,
 ) =>
   commonRequestHandler(async () => {
     await axiosWithCredentials.delete(
-      `${organizationServerUrl}/${controller[0]}/${organizationUserId}/${controller[1]}/${keyId}`,
+      organization,
+      `${controller[0]}/${organizationUserId}/${controller[1]}/${keyId}`,
     );
   }, 'Failed to delete user key');
 
 /* Update key's recovery phrase hash and/or index from the organization */
 export const updateKey = async (
-  organizationServerUrl: string,
+  organization: Organization,
   organizationUserId: number,
   keyId: number,
   mnemonicHash: string,
@@ -54,7 +58,8 @@ export const updateKey = async (
 ) =>
   commonRequestHandler(async () => {
     await axiosWithCredentials.patch(
-      `${organizationServerUrl}/${controller[0]}/${organizationUserId}/${controller[1]}/${keyId}`,
+      organization,
+      `${controller[0]}/${organizationUserId}/${controller[1]}/${keyId}`,
       {
         mnemonicHash,
         index,
@@ -64,28 +69,27 @@ export const updateKey = async (
 
 /* Get all users keys from organization */
 export const getUserKeysPaginated = async (
-  organizationServerUrl: string,
+  organization: Organization,
   page: number,
   size: number,
 ): Promise<PaginatedResourceDto<IUserKey>> =>
   commonRequestHandler(async () => {
     const response = await axiosWithCredentials.get(
-      `${organizationServerUrl}/user-keys?page=${page}&size=${size}`,
+      organization,
+      `user-keys?page=${page}&size=${size}`,
     );
 
     return response.data;
   }, 'Failed to get user keys');
 
-export const getAllUserKeys = async (organizationServerUrl: string): Promise<IUserKey[]> => {
+export const getAllUserKeys = async (organization: Organization): Promise<IUserKey[]> => {
   let page = 1;
   const size = 100;
   let totalItems = 0;
   const allUserKeys: IUserKey[] = [];
 
   do {
-    const { data, error } = await safeAwait(
-      getUserKeysPaginated(organizationServerUrl, page, size),
-    );
+    const { data, error } = await safeAwait(getUserKeysPaginated(organization, page, size));
     if (data) {
       totalItems = data.totalItems;
       allUserKeys.push(...data.items);

--- a/front-end/src/renderer/services/organization/versionCheck.ts
+++ b/front-end/src/renderer/services/organization/versionCheck.ts
@@ -2,16 +2,18 @@ import type { IVersionCheckResponse } from '@shared/interfaces';
 import { VERSION_CHECK_TIMEOUT_MS } from '@shared/constants';
 
 import { axiosWithCredentials, commonRequestHandler } from '@renderer/utils';
+import type { Organization } from '@prisma/client';
 
 const controller = 'users';
 
 export const checkVersion = async (
-  serverUrl: string,
+  organization: Organization,
   version: string,
 ): Promise<IVersionCheckResponse> =>
   commonRequestHandler(async () => {
     const { data } = await axiosWithCredentials.post(
-      `${serverUrl}/${controller}/version-check`,
+      organization,
+      `${controller}/version-check`,
       { version },
       { timeout: VERSION_CHECK_TIMEOUT_MS },
     );

--- a/front-end/src/renderer/stores/storeContacts.ts
+++ b/front-end/src/renderer/stores/storeContacts.ts
@@ -61,7 +61,7 @@ const useContactsStore = defineStore('contacts', () => {
 
   async function fetchUserKeys(userId: number) {
     if (isLoggedInOrganization(user.selectedOrganization)) {
-      const keys = await getUserKeys(user.selectedOrganization.serverUrl, userId);
+      const keys = await getUserKeys(user.selectedOrganization, userId);
 
       const contactIndex = contacts.value.findIndex(c => c.user.id === userId);
       if (contactIndex === -1) return;
@@ -105,8 +105,7 @@ async function loadContacts(
   let result: Contact[];
 
   if (organization !== null) {
-    const serverUrl = organization.serverUrl;
-    const users = await getUsers(serverUrl);
+    const users = await getUsers(organization);
 
     const orgContacts = await getOrganizationContacts(
       user.id,
@@ -115,7 +114,7 @@ async function loadContacts(
     );
     result = [];
 
-    const allKeys = await getAllUserKeys(serverUrl);
+    const allKeys = await getAllUserKeys(organization);
     const userToKeys = new Map<number, IUserKey[]>();
     allKeys.forEach(k => {
       if (!userToKeys.has(k.userId)) userToKeys.set(k.userId, []);

--- a/front-end/src/renderer/stores/storeNextTransactionV2.ts
+++ b/front-end/src/renderer/stores/storeNextTransactionV2.ts
@@ -218,12 +218,14 @@ const useNextTransactionV2 = defineStore(
         const preloadCount = 5;
         const startIndex = Math.max(0, index - preloadCount);
         const endIndex = startIndex + 2 * preloadCount;
-        const serverUrl = user.selectedOrganization.serverUrl;
         const mirrorNodeLink = network.getMirrorNodeREST(network.network);
         for (const nodeId of nodeIds.slice(startIndex, endIndex)) {
           if (nodeId.transactionId) {
             const transactionId = Number(nodeId.transactionId);
-            const tx = await appCache.backendTransaction.lookup(transactionId, serverUrl);
+            const tx = await appCache.backendTransaction.lookup(
+              transactionId,
+              user.selectedOrganization,
+            );
             const sdkTransaction = SDKTransaction.fromBytes(hexToUint8Array(tx.transactionBytes));
             // Note: we spawn computeSignatureKey() to preload caches but we don't await for them
             appCache.computeSignatureKey(sdkTransaction, user.selectedOrganization, mirrorNodeLink);

--- a/front-end/src/renderer/stores/storeNotifications.ts
+++ b/front-end/src/renderer/stores/storeNotifications.ts
@@ -102,9 +102,10 @@ const useNotificationsStore = defineStore('notifications', () => {
     const allForOrg = notifications.value[key] || [];
 
     // keep the same network filter behavior as in markAsRead
-    return allForOrg.filter(n =>
-      !n.notification.additionalData?.network ||
-      n.notification.additionalData.network === network.network,
+    return allForOrg.filter(
+      n =>
+        !n.notification.additionalData?.network ||
+        n.notification.additionalData.network === network.network,
     );
   });
 
@@ -114,9 +115,7 @@ const useNotificationsStore = defineStore('notifications', () => {
   /** Preferences **/
   async function fetchPreferences() {
     if (loggedInOrganization.value !== null) {
-      const userPreferences = await getUserNotificationPreferences(
-        loggedInOrganization.value.serverUrl,
-      );
+      const userPreferences = await getUserNotificationPreferences(loggedInOrganization.value);
 
       const newPreferences = { ...notificationsPreferences.value };
 
@@ -134,7 +133,7 @@ const useNotificationsStore = defineStore('notifications', () => {
     }
 
     const newPreferences = await updateUserNotificationPreferences(
-      loggedInOrganization.value.serverUrl,
+      loggedInOrganization.value,
       data,
     );
 
@@ -149,7 +148,7 @@ const useNotificationsStore = defineStore('notifications', () => {
     notificationsQueue = notificationsQueue.then(async () => {
       const severUrls = organizationServerUrls.value;
       const results = await Promise.allSettled(
-        connectedOrganizations.value.map(o => getAllInAppNotifications(o.serverUrl, true)),
+        connectedOrganizations.value.map(o => getAllInAppNotifications(o, true)),
       );
 
       for (let i = 0; i < results.length; i++) {
@@ -179,8 +178,10 @@ const useNotificationsStore = defineStore('notifications', () => {
 
       notificationListenerDisposers.push(
         ws.on(serverUrl, NOTIFICATIONS_INDICATORS_DELETE, e => {
-          const deleteNotifications: {notificationReceiverIds: number}[] = e;
-          const notificationReceiverIds = deleteNotifications.flatMap(item => item.notificationReceiverIds || []);
+          const deleteNotifications: { notificationReceiverIds: number }[] = e;
+          const notificationReceiverIds = deleteNotifications.flatMap(
+            item => item.notificationReceiverIds || [],
+          );
 
           dismissNotifications(serverUrl, notificationReceiverIds);
         }),
@@ -196,9 +197,9 @@ const useNotificationsStore = defineStore('notifications', () => {
   }
 
   async function markAsRead(type: NotificationType) {
-    if (!isLoggedInOrganization(user.selectedOrganization)) {
-      throw new Error('No organization selected');
-    }
+    // if (!isLoggedInOrganization(user.selectedOrganization)) {
+    //   throw new Error('No organization selected');
+    // }
 
     const notificationsKey = currentNotificationsKey.value;
     if (!notificationsKey) return;
@@ -240,7 +241,10 @@ const useNotificationsStore = defineStore('notifications', () => {
 
       if (notificationsToUpdate.length === 0) return;
 
-      await updateNotifications(notificationsKey, notificationsToUpdate);
+      const organization = user.organizations.find(o => o.serverUrl == notificationsKey);
+      if (organization) {
+        await updateNotifications(organization, notificationsToUpdate);
+      }
 
       dismissNotifications(notificationsKey, notificationIds);
     });

--- a/front-end/src/renderer/stores/storeUser.ts
+++ b/front-end/src/renderer/stores/storeUser.ts
@@ -209,7 +209,7 @@ const useUserStore = defineStore('user', () => {
           }
         }
 
-        await reconnectOrganization(organization.serverUrl);
+        await reconnectOrganization(organization);
       }
     }
 

--- a/front-end/src/renderer/utils/axios.ts
+++ b/front-end/src/renderer/utils/axios.ts
@@ -11,6 +11,7 @@ import {
   setVersionDataForOrg,
 } from '@renderer/stores/versionState';
 import useUserStore from '@renderer/stores/storeUser';
+import type { Organization } from '@prisma/client';
 
 const isValidVersionPayload = (
   data?: Partial<IVersionCheckResponse>,
@@ -144,10 +145,9 @@ export const commonRequestHandler = async <T>(
   }
 };
 
-const getConfigWithAuthHeader = (config: AxiosRequestConfig, url: string) => {
+const getConfigWithAuthHeader = (config: AxiosRequestConfig, org: Organization) => {
   const userStore = useUserStore();
-  const org = userStore.organizations.find(o => url.startsWith(o.serverUrl));
-  const authToken = org?.id ? userStore.getJwtToken(org.id) : null;
+  const authToken = userStore.getJwtToken(org.id);
   return {
     ...config,
     headers: {
@@ -159,33 +159,37 @@ const getConfigWithAuthHeader = (config: AxiosRequestConfig, url: string) => {
 
 export const axiosWithCredentials = {
   get: <T = any, R = AxiosResponse<T>, D = any>(
-    url: string,
+    org: Organization,
+    path: string,
     config?: AxiosRequestConfig<D> | undefined,
   ) =>
-    axios.get<T, R>(url, {
-      ...getConfigWithAuthHeader(config || {}, url),
+    axios.get<T, R>(`${org.serverUrl}/${path}`, {
+      ...getConfigWithAuthHeader(config || {}, org),
     }),
   post: <T = any, R = AxiosResponse<T>, D = any>(
-    url: string,
+    org: Organization,
+    path: string,
     data?: any,
     config?: AxiosRequestConfig<D> | undefined,
   ) =>
-    axios.post<T, R>(url, data, {
-      ...getConfigWithAuthHeader(config || {}, url),
+    axios.post<T, R>(`${org.serverUrl}/${path}`, data, {
+      ...getConfigWithAuthHeader(config || {}, org),
     }),
   patch: <T = any, R = AxiosResponse<T>, D = any>(
-    url: string,
+    org: Organization,
+    path: string,
     data?: any,
     config?: AxiosRequestConfig<D> | undefined,
   ) =>
-    axios.patch<T, R>(url, data, {
-      ...getConfigWithAuthHeader(config || {}, url),
+    axios.patch<T, R>(`${org.serverUrl}/${path}`, data, {
+      ...getConfigWithAuthHeader(config || {}, org),
     }),
   delete: <T = any, R = AxiosResponse<T>, D = any>(
-    url: string,
+    org: Organization,
+    path: string,
     config?: AxiosRequestConfig<D> | undefined,
   ) =>
-    axios.delete<T, R>(url, {
-      ...getConfigWithAuthHeader(config || {}, url),
+    axios.delete<T, R>(`${org.serverUrl}/${path}`, {
+      ...getConfigWithAuthHeader(config || {}, org),
     }),
 };

--- a/front-end/src/renderer/utils/index.ts
+++ b/front-end/src/renderer/utils/index.ts
@@ -333,7 +333,7 @@ export const formatPublicKey = async (publicKey: string, publicKeyOwnerCache: Pu
   }
   const user = useUserStore();
   if (user.selectedOrganization) {
-    const owner = await publicKeyOwnerCache.lookup(publicKey, user.selectedOrganization!.serverUrl);
+    const owner = await publicKeyOwnerCache.lookup(publicKey, user.selectedOrganization);
     if (owner) {
       return `${owner} (${publicKey})`;
     }
@@ -348,7 +348,7 @@ export const findIdentifier = async (publicKey: string, publicKeyOwnerCache: Pub
   }
   const user = useUserStore();
   if (user.selectedOrganization) {
-    const owner = await publicKeyOwnerCache.lookup(publicKey, user.selectedOrganization!.serverUrl);
+    const owner = await publicKeyOwnerCache.lookup(publicKey, user.selectedOrganization);
     if (owner) {
       return owner as string;
     }

--- a/front-end/src/renderer/utils/transactionSignatureModels/transaction.model.ts
+++ b/front-end/src/renderer/utils/transactionSignatureModels/transaction.model.ts
@@ -193,7 +193,7 @@ export abstract class TransactionBaseModel<T extends SDKTransaction> {
       for (const key of signatureKeys) {
         const flatKeys = flattenKeyList(key);
         for (const flatKey of flatKeys) {
-          const o = await publicKeyOwnerCache.lookup(flatKey.toStringRaw(), organization.serverUrl);
+          const o = await publicKeyOwnerCache.lookup(flatKey.toStringRaw(), organization);
           if (o === null) {
             // flatKey has no matching user in organization
             // => flatKey is external

--- a/front-end/src/renderer/utils/userStoreHelpers.ts
+++ b/front-end/src/renderer/utils/userStoreHelpers.ts
@@ -384,7 +384,7 @@ export const getConnectedOrganization = async (
 
   try {
     const { id, email, admin, passwordTemporary, secretHashes, userKeys } = await getUserState(
-      organization.serverUrl,
+      organization,
     );
 
     const connectedOrganization: ConnectedOrganization = {
@@ -410,7 +410,7 @@ export const refetchUserState = async (organization: ConnectedOrganization | nul
 
   try {
     const { id, email, admin, userKeys, secretHashes, passwordTemporary } = await getUserState(
-      organization.serverUrl,
+      organization,
     );
 
     organization.userId = id;
@@ -574,7 +574,7 @@ export const safeDuplicateUploadKey = async (
     const keyUploaded = organization.userKeys.some(k => k.publicKey === key.publicKey);
 
     if (!keyUploaded) {
-      await uploadKey(organization.serverUrl, organization.userId, key);
+      await uploadKey(organization, organization.userId, key);
     }
   }
 };
@@ -593,7 +593,7 @@ export const updateOrganizationKeysHash = async (
 
   for (const key of keys) {
     await updateOrganizationKey(
-      organization.serverUrl,
+      organization,
       organization.userId,
       key.id,
       recoveryPhrase.hash,

--- a/front-end/src/shared/utils/transactionFile.ts
+++ b/front-end/src/shared/utils/transactionFile.ts
@@ -7,25 +7,26 @@ import { getTransactionGroupById } from '@renderer/services/organization';
 import { BackendTransactionCache } from '@renderer/caches/backend/BackendTransactionCache';
 import type { ITransactionNode } from '../../../../shared/src/ITransactionNode.ts';
 import { createLogger } from '@renderer/utils/logger';
+import type { Organization } from '@prisma/client';
 
 const logger = createLogger('renderer.transactionFile');
 
 export async function flattenNodeCollection(
   nodeCollection: ITransactionNode[],
-  serverUrl: string,
+  org: Organization,
   transactionCache: BackendTransactionCache,
 ): Promise<ITransaction[]> {
   const result: ITransaction[] = [];
 
   for (const node of nodeCollection) {
     if (node.groupId !== undefined) {
-      const group = await getTransactionGroupById(serverUrl, node.groupId, false);
+      const group = await getTransactionGroupById(org, node.groupId, false);
       for (const item of group.groupItems) {
         result.push(item.transaction);
       }
     } else {
       if (node.transactionId !== undefined) {
-        const transaction = await transactionCache.lookup(node.transactionId, serverUrl);
+        const transaction = await transactionCache.lookup(node.transactionId, org);
         result.push(transaction);
       }
     }

--- a/front-end/src/tests/renderer/composables/useVersionCheck.spec.ts
+++ b/front-end/src/tests/renderer/composables/useVersionCheck.spec.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { SESSION_STORAGE_DISMISSED_UPDATE_PROMPT } from '@shared/constants';
+import type { Organization } from '@prisma/client';
 
 // We mock the network call so the composable's orchestration is what's under
 // test, not the side effects of the version-check HTTP layer. The store
@@ -9,7 +10,20 @@ import { SESSION_STORAGE_DISMISSED_UPDATE_PROMPT } from '@shared/constants';
 // so asserting on `organizationVersionStatus` exercises the real pipeline.
 const checkVersionMock = vi.fn();
 
-const mockOrgs: Array<{ serverUrl: string; nickname?: string }> = [];
+const organizationA: Organization = {
+  id: 'id-a',
+  nickname: 'ACME A',
+  serverUrl: 'https://a.example.com',
+  key: '',
+};
+
+const organizationB: Organization = {
+  id: 'id-b',
+  nickname: 'ACME B',
+  serverUrl: 'https://b.example.com',
+  key: '',
+};
+const mockOrgs = [organizationA, organizationB];
 
 vi.mock('@renderer/services/organization', () => ({
   checkVersion: (...args: unknown[]) => checkVersionMock(...args),
@@ -26,8 +40,6 @@ vi.mock('@renderer/utils/version', () => ({
 describe('useVersionCheck', () => {
   beforeEach(() => {
     localStorage.clear();
-    sessionStorage.clear();
-    mockOrgs.length = 0;
     checkVersionMock.mockReset();
     vi.resetModules();
   });
@@ -43,11 +55,11 @@ describe('useVersionCheck', () => {
     checkVersionMock.mockResolvedValueOnce(response);
 
     const { performVersionCheck } = useVersionCheck();
-    await performVersionCheck('https://a');
+    await performVersionCheck(organizationA);
 
-    expect(checkVersionMock).toHaveBeenCalledWith('https://a', '1.0.0');
-    expect(state.organizationVersionData.value['https://a']).toEqual(response);
-    expect(state.organizationVersionStatus.value['https://a']).toBe('updateAvailable');
+    expect(checkVersionMock).toHaveBeenCalledWith(organizationA, '1.0.0');
+    expect(state.organizationVersionData.value[organizationA.serverUrl]).toEqual(response);
+    expect(state.organizationVersionStatus.value[organizationA.serverUrl]).toBe('updateAvailable');
   });
 
   test('performVersionCheck leaves status unset on error so the global aggregator stays null', async () => {
@@ -56,10 +68,10 @@ describe('useVersionCheck', () => {
     checkVersionMock.mockRejectedValueOnce(new Error('network down'));
 
     const { performVersionCheck } = useVersionCheck();
-    await performVersionCheck('https://offline');
+    await performVersionCheck(organizationA);
 
-    expect(state.organizationVersionStatus.value['https://offline']).toBeUndefined();
-    expect(state.organizationVersionData.value['https://offline']).toBeUndefined();
+    expect(state.organizationVersionStatus.value[organizationA.serverUrl]).toBeUndefined();
+    expect(state.organizationVersionData.value[organizationA.serverUrl]).toBeUndefined();
   });
 
   test('performVersionCheck dedupes concurrent calls for the same org', async () => {
@@ -73,8 +85,8 @@ describe('useVersionCheck', () => {
     );
 
     const { performVersionCheck } = useVersionCheck();
-    const first = performVersionCheck('https://a');
-    const second = performVersionCheck('https://a');
+    const first = performVersionCheck(organizationA);
+    const second = performVersionCheck(organizationA);
 
     resolve({
       latestSupportedVersion: '2.0.0',
@@ -114,7 +126,7 @@ describe('useVersionCheck', () => {
     );
 
     const { performInitialVersionCheck } = useVersionCheck();
-    const promise = performInitialVersionCheck(['https://a', 'https://b']);
+    const promise = performInitialVersionCheck([organizationA, organizationB]);
     // Still running while the batch is in flight — modals must stay hidden.
     expect(state.initialVersionCheckState.value).toBe('running');
 
@@ -136,12 +148,12 @@ describe('useVersionCheck', () => {
     checkVersionMock.mockRejectedValueOnce(new Error('boom'));
 
     const { performInitialVersionCheck } = useVersionCheck();
-    await performInitialVersionCheck(['https://a', 'https://b']);
+    await performInitialVersionCheck([organizationA, organizationB]);
 
     expect(state.initialVersionCheckState.value).toBe('done');
     // First org went through; second got no entry because it failed.
-    expect(state.organizationVersionData.value['https://a']).toBeDefined();
-    expect(state.organizationVersionData.value['https://b']).toBeUndefined();
+    expect(state.organizationVersionData.value[organizationA.serverUrl]).toBeDefined();
+    expect(state.organizationVersionData.value[organizationB.serverUrl]).toBeUndefined();
   });
 
   test('a second performInitialVersionCheck while one is running is a no-op and does not race the flag', async () => {
@@ -162,12 +174,12 @@ describe('useVersionCheck', () => {
     );
 
     const { performInitialVersionCheck } = useVersionCheck();
-    const first = performInitialVersionCheck(['https://a']);
+    const first = performInitialVersionCheck([organizationA]);
     expect(state.initialVersionCheckState.value).toBe('running');
 
     // Second call while the first is still in flight — must bail without
     // flipping the state to 'done' or invoking checkVersion again.
-    await performInitialVersionCheck(['https://a']);
+    await performInitialVersionCheck([organizationA]);
     expect(state.initialVersionCheckState.value).toBe('running');
     expect(checkVersionMock).toHaveBeenCalledTimes(1);
 
@@ -183,7 +195,7 @@ describe('useVersionCheck', () => {
     state.initialVersionCheckState.value = 'done';
 
     const { performInitialVersionCheck } = useVersionCheck();
-    await performInitialVersionCheck(['https://a', 'https://b']);
+    await performInitialVersionCheck([organizationA, organizationB]);
 
     expect(checkVersionMock).not.toHaveBeenCalled();
   });

--- a/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
+++ b/front-end/src/tests/renderer/pages/Settings/SettingsProfile.spec.ts
@@ -263,7 +263,7 @@ describe('settings profile coverage', () => {
 
       expect(mocks.encryptOrganizationPassword).toHaveBeenCalledWith(STRONG_NEW, undefined);
       expect(mocks.organizationChangePassword).toHaveBeenCalledWith(
-        ORG.serverUrl,
+        ORG,
         STRONG_OLD,
         STRONG_NEW,
       );
@@ -436,7 +436,7 @@ describe('settings profile coverage', () => {
         'entered-personal-password',
       );
       expect(mocks.organizationChangePassword).toHaveBeenCalledWith(
-        ORG.serverUrl,
+        ORG,
         STRONG_OLD,
         STRONG_NEW,
       );
@@ -529,7 +529,7 @@ describe('settings profile coverage', () => {
       await wrapper.find('[data-testid="button-logout"]').trigger('click');
       await flushPromises();
 
-      expect(mocks.organizationLogout).toHaveBeenCalledWith(ORG.serverUrl);
+      expect(mocks.organizationLogout).toHaveBeenCalledWith(ORG);
       expect(mocks.updateOrganizationCredentials).toHaveBeenCalledWith(
         ORG.id,
         'local-user-id',

--- a/front-end/src/tests/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.spec.ts
+++ b/front-end/src/tests/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.spec.ts
@@ -297,7 +297,7 @@ describe('TransactionGroupDetails.vue', () => {
     await confirmCancelAll(wrapper);
 
     expect(cancelTransactionGroup).toHaveBeenCalledTimes(1);
-    expect(cancelTransactionGroup).toHaveBeenCalledWith('https://org.example.com', 10, expect.any(Array));
+    expect(cancelTransactionGroup).toHaveBeenCalledWith(userStore.selectedOrganization, 10, expect.any(Array));
     expect(getTransactionGroupById).toHaveBeenCalledTimes(2);
     expect(toastError).toHaveBeenCalled();
   });

--- a/front-end/src/tests/renderer/services/organization/cancelGroupFallback.spec.ts
+++ b/front-end/src/tests/renderer/services/organization/cancelGroupFallback.spec.ts
@@ -16,8 +16,14 @@ import {
   CancelFailureCode,
   type IGroupItem,
 } from '@renderer/services/organization/transactionGroup';
+import type { Organization } from '@prisma/client';
 
-const serverUrl = 'https://org.example.com';
+const organization: Organization = {
+  id: 'id-a',
+  nickname: 'ACME A',
+  serverUrl: 'https://a.example.com',
+  key: '',
+};
 
 function makeGroupItem(
   transactionId: number,
@@ -31,10 +37,10 @@ function makeGroupItem(
 }
 
 describe('cancelGroupFallback', () => {
-  let cancelOne: Mock<(serverUrl: string, id: number) => Promise<boolean>>;
+  let cancelOne: Mock<(org: Organization, id: number) => Promise<boolean>>;
 
   beforeEach(() => {
-    cancelOne = vi.fn<(serverUrl: string, id: number) => Promise<boolean>>().mockResolvedValue(true);
+    cancelOne = vi.fn<(org: Organization, id: number) => Promise<boolean>>().mockResolvedValue(true);
   });
 
   test('cancels all in-progress items successfully', async () => {
@@ -44,7 +50,7 @@ describe('cancelGroupFallback', () => {
       makeGroupItem(3, TransactionStatus.NEW),
     ];
 
-    const result = await cancelGroupFallback(serverUrl, items, cancelOne);
+    const result = await cancelGroupFallback(organization, items, cancelOne);
 
     expect(result.canceled).toEqual([1, 2, 3]);
     expect(result.alreadyCanceled).toEqual([]);
@@ -65,7 +71,7 @@ describe('cancelGroupFallback', () => {
       makeGroupItem(3, TransactionStatus.EXECUTED),
     ];
 
-    const result = await cancelGroupFallback(serverUrl, items, cancelOne);
+    const result = await cancelGroupFallback(organization, items, cancelOne);
 
     expect(result.canceled).toEqual([1]);
     expect(result.alreadyCanceled).toEqual([2]);
@@ -78,7 +84,7 @@ describe('cancelGroupFallback', () => {
     ]);
     expect(result.summary.processedCount).toBe(3);
     expect(cancelOne).toHaveBeenCalledTimes(1);
-    expect(cancelOne).toHaveBeenCalledWith(serverUrl, 1);
+    expect(cancelOne).toHaveBeenCalledWith(organization, 1);
   });
 
   test('records partial failures', async () => {
@@ -91,7 +97,7 @@ describe('cancelGroupFallback', () => {
       makeGroupItem(2, TransactionStatus.WAITING_FOR_SIGNATURES),
     ];
 
-    const result = await cancelGroupFallback(serverUrl, items, cancelOne);
+    const result = await cancelGroupFallback(organization, items, cancelOne);
 
     expect(result.canceled).toEqual([1]);
     expect(result.failed).toEqual([
@@ -111,7 +117,7 @@ describe('cancelGroupFallback', () => {
       makeGroupItem(2, TransactionStatus.CANCELED),
     ];
 
-    const result = await cancelGroupFallback(serverUrl, items, cancelOne);
+    const result = await cancelGroupFallback(organization, items, cancelOne);
 
     expect(result.canceled).toEqual([]);
     expect(result.alreadyCanceled).toEqual([1, 2]);
@@ -121,7 +127,7 @@ describe('cancelGroupFallback', () => {
   });
 
   test('empty group returns empty result', async () => {
-    const result = await cancelGroupFallback(serverUrl, [], cancelOne);
+    const result = await cancelGroupFallback(organization, [], cancelOne);
 
     expect(result.canceled).toEqual([]);
     expect(result.alreadyCanceled).toEqual([]);
@@ -142,7 +148,7 @@ describe('cancelGroupFallback', () => {
       makeGroupItem(4, TransactionStatus.EXECUTED),
     ];
 
-    const result = await cancelGroupFallback(serverUrl, items, cancelOne);
+    const result = await cancelGroupFallback(organization, items, cancelOne);
 
     expect(result.summary.canceled).toBe(result.canceled.length);
     expect(result.summary.alreadyCanceled).toBe(result.alreadyCanceled.length);
@@ -155,7 +161,7 @@ describe('cancelGroupFallback', () => {
   test('uses fallback message when cancelOne rejects with a non-Error value', async () => {
     cancelOne.mockRejectedValueOnce('some string rejection');
     const items = [makeGroupItem(1, TransactionStatus.WAITING_FOR_SIGNATURES)];
-    const result = await cancelGroupFallback(serverUrl, items, cancelOne);
+    const result = await cancelGroupFallback(organization, items, cancelOne);
     expect(result.failed).toEqual([
       { id: 1, code: CancelFailureCode.INTERNAL_ERROR, message: 'Failed to cancel transaction' },
     ]);

--- a/front-end/src/tests/renderer/services/organization/reconnect.spec.ts
+++ b/front-end/src/tests/renderer/services/organization/reconnect.spec.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { Organization } from '@prisma/client';
 
 // reconnectOrganization sits on top of many dependencies. We mock everything
 // that touches IO or other modules and assert the orchestration: it routes
@@ -7,7 +8,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 // derive from it), inspects the resulting state, and returns
 // `requiresUpdate` when the org is belowMinimum.
 
-const performVersionCheckMock = vi.fn<(serverUrl: string) => unknown>();
+const performVersionCheckMock = vi.fn<(org: Organization) => unknown>();
 const loginMock = vi.fn<(...args: unknown[]) => unknown>();
 const wsConnectMock = vi.fn();
 const setConnectionStatusMock = vi.fn();
@@ -32,7 +33,7 @@ let mockPersonal: { isLoggedIn: boolean; id?: string; password?: string; useKeyc
 
 vi.mock('@renderer/composables/useVersionCheck', () => ({
   default: () => ({
-    performVersionCheck: (serverUrl: string) => performVersionCheckMock(serverUrl),
+    performVersionCheck: (org: Organization) => performVersionCheckMock(org),
   }),
 }));
 
@@ -70,6 +71,14 @@ vi.mock('@renderer/utils/version', () => ({
   FRONTEND_VERSION: '1.0.0',
 }));
 
+const organizationA: Organization = {
+  id: 'id-a',
+  nickname: 'ACME A',
+  serverUrl: 'https://a.example.com',
+  key: '',
+};
+
+
 describe('reconnectOrganization', () => {
   beforeEach(() => {
     performVersionCheckMock.mockReset();
@@ -89,88 +98,84 @@ describe('reconnectOrganization', () => {
   });
 
   test('returns success when version check passes and connects websocket', async () => {
-    mockOrgs.push({ id: '1', serverUrl: 'https://org', nickname: 'Org' });
+    mockOrgs.push(organizationA);
     const { reconnectOrganization } = await import('@renderer/services/organization/reconnect');
     const state = await import('@renderer/stores/versionState');
 
-    performVersionCheckMock.mockImplementation(async (url: string) => {
-      state.setVersionDataForOrg(url, {
+    performVersionCheckMock.mockImplementation(async (org: Organization) => {
+      state.setVersionDataForOrg(org.serverUrl, {
         latestSupportedVersion: '1.0.0',
         minimumSupportedVersion: '0.9.0',
         updateUrl: null,
       });
     });
 
-    const result = await reconnectOrganization('https://org');
+    const result = await reconnectOrganization(organizationA);
     expect(result).toEqual({ success: true });
     expect(wsConnectMock).toHaveBeenCalled();
-    expect(setConnectionStatusMock).toHaveBeenCalledWith('https://org', 'connected');
+    expect(setConnectionStatusMock).toHaveBeenCalledWith(organizationA.serverUrl, 'connected');
     expect(refetchUserStateMock).toHaveBeenCalled();
   });
 
   test('returns requiresUpdate when version check leaves org belowMinimum', async () => {
-    mockOrgs.push({ id: '1', serverUrl: 'https://org' });
+    mockOrgs.push(organizationA);
+
     const { reconnectOrganization } = await import('@renderer/services/organization/reconnect');
     const state = await import('@renderer/stores/versionState');
 
-    performVersionCheckMock.mockImplementation(async (url: string) => {
-      state.setVersionDataForOrg(url, {
+    performVersionCheckMock.mockImplementation(async (org: Organization) => {
+      state.setVersionDataForOrg(org.serverUrl, {
         latestSupportedVersion: '2.0.0',
         minimumSupportedVersion: '1.5.0',
         updateUrl: 'https://download',
       });
     });
 
-    const result = await reconnectOrganization('https://org');
+    const result = await reconnectOrganization(organizationA);
     expect(result).toEqual({ success: false, requiresUpdate: true });
     expect(wsConnectMock).not.toHaveBeenCalled();
     expect(setConnectionStatusMock).not.toHaveBeenCalled();
   });
 
   test('does not require update when performVersionCheck leaves no version state', async () => {
-    mockOrgs.push({ id: '1', serverUrl: 'https://org' });
+    mockOrgs.push(organizationA);
     const { reconnectOrganization } = await import('@renderer/services/organization/reconnect');
 
     performVersionCheckMock.mockResolvedValueOnce(undefined);
 
-    const result = await reconnectOrganization('https://org');
+    const result = await reconnectOrganization(organizationA);
     expect(result).toEqual({ success: true });
     expect(wsConnectMock).toHaveBeenCalled();
   });
 
-  test('throws when the org is not in the store so the caller can surface it', async () => {
-    const { reconnectOrganization } = await import('@renderer/services/organization/reconnect');
-    await expect(reconnectOrganization('https://missing')).rejects.toThrow('Organization not found');
-  });
-
   test('rethrows inner errors instead of toasting from this layer', async () => {
-    mockOrgs.push({ id: '1', serverUrl: 'https://org' });
+    mockOrgs.push(organizationA);
     performVersionCheckMock.mockRejectedValueOnce(new Error('boom'));
 
     const { reconnectOrganization } = await import('@renderer/services/organization/reconnect');
-    await expect(reconnectOrganization('https://org')).rejects.toThrow('boom');
+    await expect(reconnectOrganization(organizationA)).rejects.toThrow('boom');
   });
 
   test('return type no longer includes hasCompatibilityConflict', async () => {
-    mockOrgs.push({ id: '1', serverUrl: 'https://org' });
+    mockOrgs.push(organizationA);
     const { reconnectOrganization } = await import('@renderer/services/organization/reconnect');
     const state = await import('@renderer/stores/versionState');
 
-    performVersionCheckMock.mockImplementation(async (url: string) => {
-      state.setVersionDataForOrg(url, {
+    performVersionCheckMock.mockImplementation(async (org: Organization) => {
+      state.setVersionDataForOrg(org.serverUrl, {
         latestSupportedVersion: '2.0.0',
         minimumSupportedVersion: '1.5.0',
         updateUrl: 'https://download',
       });
     });
 
-    const result = await reconnectOrganization('https://org');
+    const result = await reconnectOrganization(organizationA);
     expect(Object.keys(result)).toEqual(expect.arrayContaining(['success', 'requiresUpdate']));
     expect(result).not.toHaveProperty('hasCompatibilityConflict');
   });
 
   test('treats login 426 without version metadata as reconnect failure', async () => {
-    mockOrgs.push({ id: '1', serverUrl: 'https://org' });
+    mockOrgs.push(organizationA);
     mockPersonal = { isLoggedIn: true, id: 'user-1', password: 'pw', useKeychain: false };
     getAuthTokenMock.mockReturnValue(''); // no token → login is attempted
     getOrganizationCredentialsMock.mockResolvedValue({ email: 'a@b', password: 'pw' });
@@ -183,7 +188,7 @@ describe('reconnectOrganization', () => {
     const { reconnectOrganization } = await import('@renderer/services/organization/reconnect');
     performVersionCheckMock.mockResolvedValueOnce(undefined);
 
-    const result = await reconnectOrganization('https://org');
+    const result = await reconnectOrganization(organizationA);
     expect(result).toEqual({ success: false });
     expect(wsConnectMock).not.toHaveBeenCalled();
     // Token storage must not have been touched since the login didn't succeed.
@@ -191,7 +196,7 @@ describe('reconnectOrganization', () => {
   });
 
   test('still propagates non-426 login errors', async () => {
-    mockOrgs.push({ id: '1', serverUrl: 'https://org' });
+    mockOrgs.push(organizationA);
     mockPersonal = { isLoggedIn: true, id: 'user-1', password: 'pw', useKeychain: false };
     getAuthTokenMock.mockReturnValue('');
     getOrganizationCredentialsMock.mockResolvedValue({ email: 'a@b', password: 'pw' });
@@ -200,6 +205,6 @@ describe('reconnectOrganization', () => {
     loginMock.mockRejectedValueOnce(new RequestError('Invalid email or password', undefined, 401));
 
     const { reconnectOrganization } = await import('@renderer/services/organization/reconnect');
-    await expect(reconnectOrganization('https://org')).rejects.toThrow('Invalid email or password');
+    await expect(reconnectOrganization(organizationA)).rejects.toThrow('Invalid email or password');
   });
 });

--- a/front-end/src/tests/renderer/services/organization/transactionGroup.spec.ts
+++ b/front-end/src/tests/renderer/services/organization/transactionGroup.spec.ts
@@ -25,6 +25,7 @@ vi.mock('@renderer/utils', () => ({
 }));
 
 import { cancelTransaction } from '@renderer/services/organization/transaction';
+import type { Organization } from '@prisma/client';
 
 vi.mock('@renderer/services/organization/transaction', () => ({
   cancelTransaction: vi.fn(),
@@ -33,10 +34,16 @@ vi.mock('@renderer/services/organization/transaction', () => ({
 const mockCancelGroupFallback = vi.fn();
 vi.mock('@renderer/services/organization/cancelGroupFallback', () => ({
   cancelGroupFallback: (...args: unknown[]) => mockCancelGroupFallback(...args),
-}));
+}))
+
+const organizationA: Organization = {
+  id: 'id-a',
+  nickname: 'ACME A',
+  serverUrl: 'https://a.example.com',
+  key: '',
+};
 
 describe('transactionGroup service', () => {
-  const serverUrl = 'https://org.example.com';
   const groupId = 123;
   const groupItems: IGroupItem[] = [];
 
@@ -59,9 +66,12 @@ describe('transactionGroup service', () => {
 
     vi.mocked(axiosWithCredentials.patch).mockResolvedValueOnce({ data: payload } as any);
 
-    await expect(cancelTransactionGroup(serverUrl, groupId, groupItems)).resolves.toEqual(payload);
+    await expect(cancelTransactionGroup(organizationA, groupId, groupItems)).resolves.toEqual(
+      payload,
+    );
     expect(axiosWithCredentials.patch).toHaveBeenCalledWith(
-      `${serverUrl}/transaction-groups/${groupId}/cancel`,
+      organizationA,
+      `transaction-groups/${groupId}/cancel`,
       undefined,
       { withCredentials: true },
     );
@@ -85,10 +95,10 @@ describe('transactionGroup service', () => {
     };
     mockCancelGroupFallback.mockResolvedValueOnce(fallbackResult);
 
-    const result = await cancelTransactionGroup(serverUrl, groupId, groupItems);
+    const result = await cancelTransactionGroup(organizationA, groupId, groupItems);
     expect(result).toEqual(fallbackResult);
     expect(mockCancelGroupFallback).toHaveBeenCalledWith(
-      serverUrl,
+      organizationA,
       groupItems,
       cancelTransaction,
     );
@@ -104,7 +114,7 @@ describe('transactionGroup service', () => {
     });
     vi.mocked(axiosWithCredentials.patch).mockRejectedValueOnce(axiosError);
 
-    await expect(cancelTransactionGroup(serverUrl, groupId, groupItems)).rejects.toThrow(
+    await expect(cancelTransactionGroup(organizationA, groupId, groupItems)).rejects.toThrow(
       'Failed to cancel transactions in group',
     );
     expect(mockCancelGroupFallback).not.toHaveBeenCalled();
@@ -113,7 +123,7 @@ describe('transactionGroup service', () => {
   test('cancelTransactionGroup throws on network error (no response)', async () => {
     vi.mocked(axiosWithCredentials.patch).mockRejectedValueOnce(new Error('network error'));
 
-    await expect(cancelTransactionGroup(serverUrl, groupId, groupItems)).rejects.toThrow(
+    await expect(cancelTransactionGroup(organizationA, groupId, groupItems)).rejects.toThrow(
       'Failed to cancel transactions in group',
     );
     expect(mockCancelGroupFallback).not.toHaveBeenCalled();

--- a/front-end/src/tests/renderer/services/organization/user.spec.ts
+++ b/front-end/src/tests/renderer/services/organization/user.spec.ts
@@ -10,6 +10,7 @@ import {
   PUBLIC_KEY_OWNER_STATUS_MESSAGES,
   SESSION_EXPIRED_MESSAGE,
 } from '@renderer/services/organization/errorMessages';
+import type { Organization } from '@prisma/client';
 
 // Replicate the real commonRequestHandler logic so we test the actual behavior
 // of getPublicKeyOwner with its messageOn401 and statusMessages params
@@ -66,7 +67,12 @@ const createAxiosError = (
 };
 
 describe('getPublicKeyOwner', () => {
-  const serverUrl = 'https://org.example.com';
+  const organization: Organization = {
+    id: 'dummy',
+    nickname: 'ACME',
+    serverUrl: 'https://org.example.com',
+    key: '',
+  }
   const publicKey = '2434cdf54e5f33570791bebdf3f0527347c2310c66f3db6799d64ed9b8666c39';
 
   beforeEach(() => {
@@ -80,11 +86,11 @@ describe('getPublicKeyOwner', () => {
       data: 'alice@example.com',
     } as any);
 
-    const result = await getPublicKeyOwner(serverUrl, publicKey);
+    const result = await getPublicKeyOwner(organization, publicKey);
 
     expect(result).toBe('alice@example.com');
     expect(axiosWithCredentials.get).toHaveBeenCalledWith(
-      `${serverUrl}/users/public-owner/${publicKey}`,
+      organization, `users/public-owner/${publicKey}`,
     );
   });
 
@@ -93,7 +99,7 @@ describe('getPublicKeyOwner', () => {
       data: '',
     } as any);
 
-    const result = await getPublicKeyOwner(serverUrl, publicKey);
+    const result = await getPublicKeyOwner(organization, publicKey);
 
     expect(result).toBeNull();
   });
@@ -108,7 +114,7 @@ describe('getPublicKeyOwner', () => {
       }),
     );
 
-    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+    await expect(getPublicKeyOwner(organization, publicKey)).rejects.toThrow(
       SESSION_EXPIRED_MESSAGE,
     );
   });
@@ -120,7 +126,7 @@ describe('getPublicKeyOwner', () => {
       createAxiosError('Forbidden', '403', 403),
     );
 
-    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+    await expect(getPublicKeyOwner(organization, publicKey)).rejects.toThrow(
       PUBLIC_KEY_OWNER_STATUS_MESSAGES[403],
     );
   });
@@ -130,7 +136,7 @@ describe('getPublicKeyOwner', () => {
       createAxiosError('Not Found', '404', 404),
     );
 
-    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+    await expect(getPublicKeyOwner(organization, publicKey)).rejects.toThrow(
       PUBLIC_KEY_OWNER_STATUS_MESSAGES[404],
     );
   });
@@ -140,7 +146,7 @@ describe('getPublicKeyOwner', () => {
       createAxiosError('Server Error', '500', 500),
     );
 
-    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+    await expect(getPublicKeyOwner(organization, publicKey)).rejects.toThrow(
       PUBLIC_KEY_OWNER_STATUS_MESSAGES[500],
     );
   });
@@ -152,7 +158,7 @@ describe('getPublicKeyOwner', () => {
       createAxiosError('Too Many Requests', '429', 429),
     );
 
-    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+    await expect(getPublicKeyOwner(organization, publicKey)).rejects.toThrow(
       'Too many requests. Please try again later.',
     );
   });
@@ -162,7 +168,7 @@ describe('getPublicKeyOwner', () => {
       createAxiosError('Teapot', '418', 418),
     );
 
-    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+    await expect(getPublicKeyOwner(organization, publicKey)).rejects.toThrow(
       PUBLIC_KEY_OWNER_DEFAULT_MESSAGE,
     );
   });
@@ -171,7 +177,7 @@ describe('getPublicKeyOwner', () => {
     const axiosError = new AxiosError('Network Error', 'ERR_NETWORK');
     vi.mocked(axiosWithCredentials.get).mockRejectedValueOnce(axiosError);
 
-    await expect(getPublicKeyOwner(serverUrl, publicKey)).rejects.toThrow(
+    await expect(getPublicKeyOwner(organization, publicKey)).rejects.toThrow(
       'Failed to connect to the server',
     );
   });


### PR DESCRIPTION
**Description**:

Changes below update functions that expect `serverUrl` : they now expect an `Organization` instance.This gives these functions access to `org.serverUrl` and also `org.id` (which enables to retrieve JWT token).

**Related issue(s)**:

Contributes to #2936

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
