### PR TITLE
fix: Fix and harden transaction comment creation

### DIFF
--- a/back-end/apps/api/src/transactions/comments/comments.controller.spec.ts
+++ b/back-end/apps/api/src/transactions/comments/comments.controller.spec.ts
@@ -7,7 +7,7 @@ import { User } from '@entities';
 
 import { TransactionCommentDto } from '../dto';
 
-import { VerifiedUserGuard } from '../../guards';
+import { UserThrottlerGuard, VerifiedUserGuard } from '../../guards';
 import { TransactionAccessGuard } from '../../guards/transaction-access.guard';
 
 import { CommentsController } from './comments.controller';
@@ -42,6 +42,8 @@ describe('CommentsController', () => {
       .overrideGuard(VerifiedUserGuard)
       .useValue(guardMock())
       .overrideGuard(TransactionAccessGuard)
+      .useValue(guardMock())
+      .overrideGuard(UserThrottlerGuard)
       .useValue(guardMock())
       .compile();
 
@@ -89,7 +91,7 @@ describe('CommentsController', () => {
       const dto = plainToInstance(TransactionCommentDto, raw, { excludeExtraneousValues: true });
 
       expect(dto.user).toEqual({ id: 2, email: 'user@test.com' });
-      expect((dto.user as any).password).toBeUndefined();
+      expect(dto.user).not.toHaveProperty('password');
     });
   });
 });

--- a/back-end/apps/api/src/transactions/comments/comments.controller.ts
+++ b/back-end/apps/api/src/transactions/comments/comments.controller.ts
@@ -3,7 +3,7 @@ import { ApiTags } from '@nestjs/swagger';
 
 import { User } from '@entities';
 
-import { JwtAuthGuard, JwtBlackListAuthGuard, VerifiedUserGuard } from '../../guards';
+import { JwtAuthGuard, JwtBlackListAuthGuard, UserThrottlerGuard, VerifiedUserGuard } from '../../guards';
 import { TransactionAccessGuard } from '../../guards/transaction-access.guard';
 
 import { GetUser } from '../../decorators';
@@ -20,6 +20,7 @@ export class CommentsController {
   constructor(private commentsService: CommentsService) {}
 
   @Post()
+  @UseGuards(UserThrottlerGuard)
   @Serialize(TransactionCommentDto)
   createComment(
     @GetUser() user: User,

--- a/back-end/apps/api/src/transactions/comments/comments.service.spec.ts
+++ b/back-end/apps/api/src/transactions/comments/comments.service.spec.ts
@@ -57,7 +57,11 @@ describe('CommentsService', () => {
 
       const result = await service.createComment(user as User, transactionId, dto);
 
-      expect(repo.create).toHaveBeenCalledWith(dto);
+      expect(repo.create).toHaveBeenCalledWith({
+        ...dto,
+        transaction: { id: transactionId },
+        user,
+      });
       expect(repo.save).toHaveBeenCalledWith(expectedComment);
       expect(result).toEqual(expectedComment);
     });

--- a/back-end/apps/api/src/transactions/comments/comments.service.ts
+++ b/back-end/apps/api/src/transactions/comments/comments.service.ts
@@ -20,9 +20,11 @@ export class CommentsService {
     transactionId: number,
     dto: CreateCommentDto,
   ): Promise<TransactionComment> {
-    const comment = this.repo.create(dto);
-    comment['transaction'].id = transactionId;
-    comment.user = user;
+    const comment = this.repo.create({
+      ...dto,
+      transaction: { id: transactionId },
+      user,
+    });
     try {
       return await this.repo.save(comment);
     } catch (error) {

--- a/back-end/apps/api/src/transactions/dto/create-comment.dto.spec.ts
+++ b/back-end/apps/api/src/transactions/dto/create-comment.dto.spec.ts
@@ -1,0 +1,30 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+
+import { MAX_TRANSACTION_COMMENT_LENGTH } from '@entities';
+
+import { CreateCommentDto } from './create-comment.dto';
+
+const toDto = (plain: Record<string, unknown>) =>
+  plainToInstance(CreateCommentDto, plain, { enableImplicitConversion: true });
+
+describe('CreateCommentDto', () => {
+  test('passes validation for a message within the max length', () => {
+    const dto = toDto({ message: 'a'.repeat(MAX_TRANSACTION_COMMENT_LENGTH) });
+
+    const errors = validateSync(dto as object);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  test('fails validation when message exceeds the max length', () => {
+    const dto = toDto({ message: 'a'.repeat(MAX_TRANSACTION_COMMENT_LENGTH + 1) });
+
+    const errors = validateSync(dto as object);
+
+    expect(errors.length).toBeGreaterThan(0);
+    const messageError = errors.find(e => e.property === 'message');
+    expect(messageError?.constraints).toHaveProperty('maxLength');
+  });
+});

--- a/back-end/apps/api/src/transactions/dto/create-comment.dto.ts
+++ b/back-end/apps/api/src/transactions/dto/create-comment.dto.ts
@@ -1,6 +1,9 @@
-import { IsString } from 'class-validator';
+import { IsString, MaxLength } from 'class-validator';
+
+import { MAX_TRANSACTION_COMMENT_LENGTH } from '@entities';
 
 export class CreateCommentDto {
   @IsString()
+  @MaxLength(MAX_TRANSACTION_COMMENT_LENGTH)
   message: string;
 }

--- a/back-end/libs/common/src/database/entities/transaction-comment.entity.ts
+++ b/back-end/libs/common/src/database/entities/transaction-comment.entity.ts
@@ -2,6 +2,8 @@ import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } f
 import { Transaction } from './transaction.entity';
 import { User } from './user.entity';
 
+export const MAX_TRANSACTION_COMMENT_LENGTH = 2000;
+
 @Entity()
 export class TransactionComment {
   @PrimaryGeneratedColumn()
@@ -13,7 +15,7 @@ export class TransactionComment {
   @ManyToOne(() => User, user => user.comments)
   user: User;
 
-  @Column()
+  @Column({ length: MAX_TRANSACTION_COMMENT_LENGTH })
   message: string;
 
   @CreateDateColumn()

--- a/back-end/typeorm/migrations/1784625969022-TransactionCommentMessageMaxLength.ts
+++ b/back-end/typeorm/migrations/1784625969022-TransactionCommentMessageMaxLength.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class TransactionCommentMessageMaxLength1784625969022 implements MigrationInterface {
+  name = 'TransactionCommentMessageMaxLength1784625969022';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "transaction_comment" ALTER COLUMN "message" TYPE character varying(2000)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "transaction_comment" ALTER COLUMN "message" TYPE character varying`,
+    );
+  }
+}


### PR DESCRIPTION
**Description**:

- Fix the `POST /transactions/:transactionId/comments` endpoint
- Add database constraint for the length of the comment message (2000 char max).
- Apply `UserThrottlerGuard` to the comment creation endpoint
- Note that the check that the requester has any relationship to the target transaction has already been implemented as part of #3020 (`TransactionAccessGuard` is applied to all the routes of the `CommentsController`

**Related issue(s)**:

Fixes #2933 

 **/!\ Needs to be merged with main once #3157 has been integrated**