### PR TITLE
chore: moving to latest vue-datepicker 

### DIFF
--- a/automation/pages/OrganizationPage.ts
+++ b/automation/pages/OrganizationPage.ts
@@ -83,8 +83,8 @@ export class OrganizationPage extends BasePage {
   addUserButtonSelector = 'button-add-user';
   openDatePickerButtonSelector =
     '[data-testid="date-picker-valid-start"] [data-test-id="dp-input"]';
-  datePickerCalendarSelector = 'css=.dp__instance_calendar';
-  datePickerInputSelector = 'css=.dp__time_input';
+  datePickerCalendarSelector = 'css=.dp--instance-calendar';
+  datePickerInputSelector = 'css=.dp--time-input';
   timePickerIconSelector = 'css=.dp--tp-wrap button[aria-label="Open time picker"]';
   incrementSecondsButtonSelector = 'css=button[aria-label="Increment seconds"]';
   incrementMinutesButtonSelector = 'css=button[aria-label="Increment minutes"]';

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -41,7 +41,7 @@
     "@hiero-ledger/sdk": "catalog:",
     "@prisma/adapter-better-sqlite3": "7.8.0",
     "@prisma/client": "7.8.0",
-    "@vuepic/vue-datepicker": "11.0.3",
+    "@vuepic/vue-datepicker": "12.1.0",
     "@vueuse/core": "12.8.2",
     "argon2": "catalog:",
     "axios": "catalog:",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -41,7 +41,7 @@
     "@hiero-ledger/sdk": "catalog:",
     "@prisma/adapter-better-sqlite3": "7.8.0",
     "@prisma/client": "7.8.0",
-    "@vuepic/vue-datepicker": "12.1.0",
+    "@vuepic/vue-datepicker": "13.0.0",
     "@vueuse/core": "12.8.2",
     "argon2": "catalog:",
     "axios": "catalog:",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -41,7 +41,7 @@
     "@hiero-ledger/sdk": "catalog:",
     "@prisma/adapter-better-sqlite3": "7.8.0",
     "@prisma/client": "7.8.0",
-    "@vuepic/vue-datepicker": "13.0.0",
+    "@vuepic/vue-datepicker": "14.0.0",
     "@vueuse/core": "12.8.2",
     "argon2": "catalog:",
     "axios": "catalog:",

--- a/front-end/src/renderer/components/RunningClockDatePicker.vue
+++ b/front-end/src/renderer/components/RunningClockDatePicker.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts">
-import type { VueDatePickerProps } from '@vuepic/vue-datepicker';
+import type { DateValue } from '@vuepic/vue-datepicker';
 
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 
 import AppDatePicker from '@renderer/components/ui/AppDatePicker.vue';
 
 /* Props */
-const props = defineProps<
-  {
-    modelValue: Date;
-    nowButtonVisible?: boolean;
-  } & VueDatePickerProps
->();
+const props = defineProps<{
+  modelValue: Date;
+  nowButtonVisible?: boolean;
+  placeholder?: string;
+  minDate?: DateValue;
+  maxDate?: DateValue;
+}>();
 
 /* Emits */
 const emit = defineEmits<{

--- a/front-end/src/renderer/components/RunningClockDatePicker.vue
+++ b/front-end/src/renderer/components/RunningClockDatePicker.vue
@@ -9,7 +9,6 @@ import AppDatePicker from '@renderer/components/ui/AppDatePicker.vue';
 const props = defineProps<{
   modelValue: Date;
   nowButtonVisible?: boolean;
-  placeholder?: string;
   minDate?: DateValue;
   maxDate?: DateValue;
 }>();
@@ -85,7 +84,6 @@ onUnmounted(() => {
     :minDate="minDate"
     :maxDate="maxDate"
     :clearable="false"
-    :placeholder="placeholder"
     :nowButtonVisible="nowButtonVisible"
     @open="handleOpen"
     @closed="handleClosed"

--- a/front-end/src/renderer/components/Transaction/Create/Freeze/FreezeFormData.vue
+++ b/front-end/src/renderer/components/Transaction/Create/Freeze/FreezeFormData.vue
@@ -76,7 +76,6 @@ const columnClass = 'col-4 col-xxxl-3';
             startTimestamp: $event,
           })
         "
-        placeholder="Select Start Time"
         :min-date="new Date()"
         :now-button-visible="true"
       />

--- a/front-end/src/renderer/components/ui/AppDatePicker.vue
+++ b/front-end/src/renderer/components/ui/AppDatePicker.vue
@@ -61,7 +61,6 @@ function handleUpdate(value: string | Date) {
     :timezone="isUtcSelected ? 'utc' : undefined"
     :input-attrs="{ clearable: props.clearable }"
     auto-apply
-    :flow="{ partial: true }"
     text-input
     :config="{
       keepActionRow: true,

--- a/front-end/src/renderer/components/ui/AppDatePicker.vue
+++ b/front-end/src/renderer/components/ui/AppDatePicker.vue
@@ -1,19 +1,20 @@
 <script setup lang="ts">
-import type { DatePickerInstance, VueDatePickerProps } from '@vuepic/vue-datepicker';
+import { VueDatePicker, type DateValue } from '@vuepic/vue-datepicker';
 
 import { computed, ref } from 'vue';
 
-import DatePicker from '@vuepic/vue-datepicker';
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts';
 
 /* Props */
-const props = defineProps<
-  {
-    modelValue: Date | undefined;
-    nowButtonVisible?: boolean;
-  } & VueDatePickerProps
->();
+const props = defineProps<{
+  modelValue: Date | undefined;
+  nowButtonVisible?: boolean;
+  clearable?: boolean;
+  placeholder?: string;
+  minDate?: DateValue;
+  maxDate?: DateValue;
+}>();
 
 /* Emits */
 const emit = defineEmits<{
@@ -26,7 +27,7 @@ const emit = defineEmits<{
 const { isUtcSelected } = useDateTimeSetting();
 
 /* State */
-const datePicker = ref<DatePickerInstance|null>(null);
+const datePicker = ref<typeof VueDatePicker | null>(null);
 
 /* Computed */
 const inputValue = computed(() => {
@@ -54,13 +55,13 @@ function handleUpdate(value: string | Date) {
 }
 </script>
 <template>
-  <DatePicker
+  <VueDatePicker
     ref="datePicker"
     :model-value="inputValue"
-    :utc="isUtcSelected ? 'preserve' : undefined"
-    :clearable="clearable"
+    :timezone="isUtcSelected ? 'utc' : undefined"
+    :input-attrs="{ clearable: props.clearable }"
     auto-apply
-    partial-flow
+    :flow="{ partial: true }"
     text-input
     :config="{
       keepActionRow: true,
@@ -74,9 +75,9 @@ function handleUpdate(value: string | Date) {
     :placeholder="placeholder"
     :min-date="minDate"
     :max-date="maxDate"
-    teleport="body"
+    :teleport="true"
     class="is-fill"
-    enable-seconds
+    :time-config="{enableSeconds: true}"
     @open="$emit('open')"
     @closed="$emit('closed')"
     @update:model-value="handleUpdate"
@@ -103,5 +104,5 @@ function handleUpdate(value: string | Date) {
         </AppButton>
       </div>
     </template>
-  </DatePicker>
+  </VueDatePicker>
 </template>

--- a/front-end/src/renderer/main.ts
+++ b/front-end/src/renderer/main.ts
@@ -8,7 +8,7 @@ import { addGuards } from '@renderer/router/guards';
 
 import ToastPlugin from 'vue-toast-notification';
 
-import DatePicker from '@vuepic/vue-datepicker';
+import { VueDatePicker } from '@vuepic/vue-datepicker';
 
 import App from './App.vue';
 
@@ -36,7 +36,7 @@ app.use(ToastPlugin, { position: 'bottom-right', duration: 4000 });
 app.directive('focus-first-input', AutoFocusFirstInputDirective);
 
 /* Custom Components */
-app.component('DatePicker', DatePicker);
+app.component('DatePicker', VueDatePicker);
 
 /* App mount */
 app.mount('#app');

--- a/front-end/src/renderer/styles/_ui-elements.scss
+++ b/front-end/src/renderer/styles/_ui-elements.scss
@@ -1015,7 +1015,7 @@ td .btn {
 }
 
 /* Vue Date Time Picker */
-.dp__theme_light {
+.dp--theme-light {
   --dp-background-color: var(--#{$prefix}body-bg);
   --dp-text-color: var(--#{$prefix}body-color);
   --dp-hover-color: var(--#{$prefix}primary);
@@ -1051,21 +1051,21 @@ td .btn {
     // To update
     --dp-border-color: var(--#{$prefix}input-fill-bg-color);
 
-    .dp__input:hover {
+    .dp--input:hover {
       border-color: var(--#{$prefix}input-fill-bg-color);
     }
   }
 
-  .dp__input {
+  .dp--input {
     line-height: 2 !important;
 
-    &.dp__input_focus,
+    &.dp--input-focus,
     &:focus {
       --dp-background-color: var(--#{$prefix}input-fill-focus-bg-color);
     }
   }
 
-  .dp__inc_dec_button:hover {
+  .dp--inc-dec-button:hover {
     color: var(--#{$prefix}white);
   }
 
@@ -1077,11 +1077,11 @@ td .btn {
     border-radius: 50%;
   }
 
-  .dp__overlay_cell_disabled {
+  .dp--overlay-cell-disabled {
     color: var(--dp-disabled-color-text);
   }
 
-  .dp__arrow_top {
+  .dp--arrow-top {
     display: none;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,8 +582,8 @@ importers:
         specifier: 7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.7.3))(typescript@5.7.3)
       '@vuepic/vue-datepicker':
-        specifier: 12.1.0
-        version: 12.1.0(vue@3.5.34(typescript@5.7.3))
+        specifier: 13.0.0
+        version: 13.0.0(vue@3.5.34(typescript@5.7.3))
       '@vueuse/core':
         specifier: 12.8.2
         version: 12.8.2(typescript@5.7.3)
@@ -3641,8 +3641,8 @@ packages:
       vue:
         optional: true
 
-  '@vuepic/vue-datepicker@12.1.0':
-    resolution: {integrity: sha512-QuWcO+CqIGYFoRNCagp9xUY9sMK/OHUlVIDxBYjw7HjCTWXfuE/r3l3loB00faEtb0Teo3DeBn26hT3tYA5pgg==}
+  '@vuepic/vue-datepicker@13.0.0':
+    resolution: {integrity: sha512-7emyDtXcTDn0w1+RLcyYhdZFw2pE9EGbDuyFrN3XJju8nJVPcU822M2znrzmNdZU82R5ItyBeagZBtsYzUVy3g==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
       vue: '>=3.5.0'
@@ -12436,7 +12436,7 @@ snapshots:
       typescript: 5.7.3
       vue: 3.5.34(typescript@5.7.3)
 
-  '@vuepic/vue-datepicker@12.1.0(vue@3.5.34(typescript@5.7.3))':
+  '@vuepic/vue-datepicker@13.0.0(vue@3.5.34(typescript@5.7.3))':
     dependencies:
       '@date-fns/tz': 1.5.0
       '@floating-ui/vue': 1.1.11(vue@3.5.34(typescript@5.7.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,8 +582,8 @@ importers:
         specifier: 7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.7.3))(typescript@5.7.3)
       '@vuepic/vue-datepicker':
-        specifier: 13.0.0
-        version: 13.0.0(vue@3.5.34(typescript@5.7.3))
+        specifier: 14.0.0
+        version: 14.0.0(vue@3.5.34(typescript@5.7.3))
       '@vueuse/core':
         specifier: 12.8.2
         version: 12.8.2(typescript@5.7.3)
@@ -3641,8 +3641,8 @@ packages:
       vue:
         optional: true
 
-  '@vuepic/vue-datepicker@13.0.0':
-    resolution: {integrity: sha512-7emyDtXcTDn0w1+RLcyYhdZFw2pE9EGbDuyFrN3XJju8nJVPcU822M2znrzmNdZU82R5ItyBeagZBtsYzUVy3g==}
+  '@vuepic/vue-datepicker@14.0.0':
+    resolution: {integrity: sha512-zDl1U2MRk+udu0gYA3pdY2f0O+ckqUPiKgWmp7qQV3D7CRgDKYvUXFpnt+rgMQ+uLydtlRqzy4eS6nvtVjNS4A==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
       vue: '>=3.5.0'
@@ -12436,7 +12436,7 @@ snapshots:
       typescript: 5.7.3
       vue: 3.5.34(typescript@5.7.3)
 
-  '@vuepic/vue-datepicker@13.0.0(vue@3.5.34(typescript@5.7.3))':
+  '@vuepic/vue-datepicker@14.0.0(vue@3.5.34(typescript@5.7.3))':
     dependencies:
       '@date-fns/tz': 1.5.0
       '@floating-ui/vue': 1.1.11(vue@3.5.34(typescript@5.7.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,8 +582,8 @@ importers:
         specifier: 7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react@19.2.14)(better-sqlite3@12.11.1)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.7.3))(typescript@5.7.3)
       '@vuepic/vue-datepicker':
-        specifier: 11.0.3
-        version: 11.0.3(vue@3.5.34(typescript@5.7.3))
+        specifier: 12.1.0
+        version: 12.1.0(vue@3.5.34(typescript@5.7.3))
       '@vueuse/core':
         specifier: 12.8.2
         version: 12.8.2(typescript@5.7.3)
@@ -1057,6 +1057,9 @@ packages:
 
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
+
+  '@date-fns/tz@1.5.0':
+    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
 
   '@discoveryjs/json-ext@1.1.0':
     resolution: {integrity: sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==}
@@ -1578,6 +1581,18 @@ packages:
 
   '@ethersproject/web@5.8.0':
     resolution: {integrity: sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==}
+
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@floating-ui/vue@1.1.11':
+    resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
@@ -3539,9 +3554,6 @@ packages:
   '@vue/compiler-ssr@3.5.34':
     resolution: {integrity: sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==}
 
-  '@vue/devtools-api@6.6.4':
-    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
-
   '@vue/devtools-api@7.7.9':
     resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
 
@@ -3629,20 +3641,33 @@ packages:
       vue:
         optional: true
 
-  '@vuepic/vue-datepicker@11.0.3':
-    resolution: {integrity: sha512-sb2adwqwK2PizLQOpxCYps2SwhVT6/ic2HMIOqHJXuYa6iAJZWGL5YVlS7O4aW+sk6ZyxlDURLO7kDZPL4HB/w==}
+  '@vuepic/vue-datepicker@12.1.0':
+    resolution: {integrity: sha512-QuWcO+CqIGYFoRNCagp9xUY9sMK/OHUlVIDxBYjw7HjCTWXfuE/r3l3loB00faEtb0Teo3DeBn26hT3tYA5pgg==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
-      vue: '>=3.3.0'
+      vue: '>=3.5.0'
 
   '@vueuse/core@12.8.2':
     resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
 
+  '@vueuse/core@14.3.0':
+    resolution: {integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==}
+    peerDependencies:
+      vue: ^3.5.0
+
   '@vueuse/metadata@12.8.2':
     resolution: {integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==}
 
+  '@vueuse/metadata@14.3.0':
+    resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
+
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
+
+  '@vueuse/shared@14.3.0':
+    resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
+    peerDependencies:
+      vue: ^3.5.0
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -8822,6 +8847,17 @@ packages:
   vue-component-type-helpers@3.2.9:
     resolution: {integrity: sha512-S3BiWYaLSzHxTpln665ELSrMR9UYmrIDUmhik7nVZxmJjTKL2/a+ew1hvGxksKelivm0ujjWfG1fYOiU/2e8rA==}
 
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
   vue-eslint-parser@9.4.3:
     resolution: {integrity: sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==}
     engines: {node: ^14.17.0 || >=16.0.0}
@@ -9473,6 +9509,8 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
+  '@date-fns/tz@1.5.0': {}
+
   '@discoveryjs/json-ext@1.1.0': {}
 
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
@@ -9975,6 +10013,26 @@ snapshots:
       '@ethersproject/logger': 5.8.0
       '@ethersproject/properties': 5.8.0
       '@ethersproject/strings': 5.8.0
+
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/utils@0.2.12': {}
+
+  '@floating-ui/vue@1.1.11(vue@3.5.34(typescript@5.7.3))':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@floating-ui/utils': 0.2.12
+      vue-demi: 0.14.10(vue@3.5.34(typescript@5.7.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
 
   '@gar/promisify@1.1.3':
     optional: true
@@ -12250,8 +12308,6 @@ snapshots:
       '@vue/compiler-dom': 3.5.34
       '@vue/shared': 3.5.34
 
-  '@vue/devtools-api@6.6.4': {}
-
   '@vue/devtools-api@7.7.9':
     dependencies:
       '@vue/devtools-kit': 7.7.9
@@ -12380,10 +12436,15 @@ snapshots:
       typescript: 5.7.3
       vue: 3.5.34(typescript@5.7.3)
 
-  '@vuepic/vue-datepicker@11.0.3(vue@3.5.34(typescript@5.7.3))':
+  '@vuepic/vue-datepicker@12.1.0(vue@3.5.34(typescript@5.7.3))':
     dependencies:
+      '@date-fns/tz': 1.5.0
+      '@floating-ui/vue': 1.1.11(vue@3.5.34(typescript@5.7.3))
+      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.7.3))
       date-fns: 4.4.0
       vue: 3.5.34(typescript@5.7.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   '@vueuse/core@12.8.2(typescript@5.7.3)':
     dependencies:
@@ -12394,13 +12455,26 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@vueuse/core@14.3.0(vue@3.5.34(typescript@5.7.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 14.3.0
+      '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@5.7.3))
+      vue: 3.5.34(typescript@5.7.3)
+
   '@vueuse/metadata@12.8.2': {}
+
+  '@vueuse/metadata@14.3.0': {}
 
   '@vueuse/shared@12.8.2(typescript@5.7.3)':
     dependencies:
       vue: 3.5.34(typescript@5.7.3)
     transitivePeerDependencies:
       - typescript
+
+  '@vueuse/shared@14.3.0(vue@3.5.34(typescript@5.7.3))':
+    dependencies:
+      vue: 3.5.34(typescript@5.7.3)
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -18351,6 +18425,10 @@ snapshots:
   vscode-uri@3.1.0: {}
 
   vue-component-type-helpers@3.2.9: {}
+
+  vue-demi@0.14.10(vue@3.5.34(typescript@5.7.3)):
+    dependencies:
+      vue: 3.5.34(typescript@5.7.3)
 
   vue-eslint-parser@9.4.3(eslint@9.39.3(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:


### PR DESCRIPTION
**Description**:

Changes below move `vue-datepicker` to 14.0.0 and update source code accordingly.

**Notes for reviewer**

```
M   front-end/package.json
M   pnpm-lock.yaml
    # Moved vue-datepicker from 11.0.3 to 14.0.0

M   front-end/src/renderer/components/ui/AppDatePicker.vue
M   front-end/src/renderer/main.ts
    # - DatePicker is now named VueDatePicker
    # - adjusted VueDatePicker setup to new prop names
    # - Adjusted AppDatePicker props since VueDatePickerProps has been removed

M   front-end/src/renderer/components/RunningClockDatePicker.vue
M   front-end/src/renderer/components/Transaction/Create/Freeze/FreezeFormData.vue
    # Removed RunningClockDataPicker.placeholder (no effect since clearable == false)

M   front-end/src/renderer/styles/_ui-elements.scss
    # Applied css class renaming from vue-datepicker 13.0.0.
```