### PR TITLE
fix: fixing regression in migration wizard

### DIFF
--- a/front-end/src/renderer/pages/Migrate/Migrate.vue
+++ b/front-end/src/renderer/pages/Migrate/Migrate.vue
@@ -56,6 +56,7 @@ const recoveryPhrase: Ref<RecoveryPhrase | null> = ref(null);
 const recoveryPhrasePassword = ref<string | null>(null);
 const personalUser = ref<PersonalUser | null>(null);
 const organizationSetup = ref<ModelValue | null>(null);
+const jwtToken = ref<string | null>(null);
 
 const userInitialized = ref(false);
 const keysImported = ref(0);
@@ -116,8 +117,9 @@ const handleSetPersonalUser = async (value: PersonalUser) => {
   step.value = 'organization';
 };
 
-const handleSetOrganizationSetup = async (value: ModelValue | null) => {
+const handleSetOrganizationSetup = async (value: ModelValue | null, token: string | null) => {
   organizationSetup.value = value;
+  jwtToken.value = token;
   await initializeUserStore();
   userInitialized.value = true;
   // Write the skip claim now that the org (if any) is selected, using the correct claim key.
@@ -229,6 +231,7 @@ const initializeUserStore = async () => {
           <PerformSetup
             :personal-user="personalUser!"
             :organization-setup="organizationSetup"
+            :jwt-token="jwtToken!"
             :recovery-phrase="recoveryPhrase"
             :recovery-phrase-password="recoveryPhrasePassword"
             :selected-keys="selectedKeysToRecover"

--- a/front-end/src/renderer/pages/Migrate/Migrate.vue
+++ b/front-end/src/renderer/pages/Migrate/Migrate.vue
@@ -236,7 +236,6 @@ const initializeUserStore = async () => {
             :recovery-phrase-password="recoveryPhrasePassword"
             :selected-keys="selectedKeysToRecover"
             @didPerformSetup="didPerformSetup"
-            @didCancelSetup="handleStopMigration"
           />
         </template>
 

--- a/front-end/src/renderer/pages/Migrate/Migrate.vue
+++ b/front-end/src/renderer/pages/Migrate/Migrate.vue
@@ -227,7 +227,7 @@ const initializeUserStore = async () => {
         </template>
 
         <!-- Perform Migration Step -->
-        <template v-if="stepIs('performSetup') && personalUser !== null && jwtToken !== null">
+        <template v-if="stepIs('performSetup') && personalUser !== null">
           <PerformSetup
             :personal-user="personalUser"
             :organization-setup="organizationSetup"

--- a/front-end/src/renderer/pages/Migrate/Migrate.vue
+++ b/front-end/src/renderer/pages/Migrate/Migrate.vue
@@ -227,15 +227,16 @@ const initializeUserStore = async () => {
         </template>
 
         <!-- Perform Migration Step -->
-        <template v-if="stepIs('performSetup')">
+        <template v-if="stepIs('performSetup') && personalUser !== null && jwtToken !== null">
           <PerformSetup
-            :personal-user="personalUser!"
+            :personal-user="personalUser"
             :organization-setup="organizationSetup"
-            :jwt-token="jwtToken!"
+            :jwt-token="jwtToken"
             :recovery-phrase="recoveryPhrase"
             :recovery-phrase-password="recoveryPhrasePassword"
             :selected-keys="selectedKeysToRecover"
             @didPerformSetup="didPerformSetup"
+            @didCancelSetup="handleStopMigration"
           />
         </template>
 

--- a/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
+++ b/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
@@ -15,7 +15,6 @@ import {
 } from '@renderer/utils';
 import {
   addOrganizationCredentials,
-  encryptOrganizationPassword,
   updateOrganizationCredentials,
 } from '@renderer/services/organizationCredentials.ts';
 import DecryptKeys from '@renderer/components/KeyPair/ImportEncrypted/components/DecryptKeys.vue';
@@ -73,10 +72,6 @@ const setupOrganization = async (setup: ModelValue, jwtToken: string) => {
     emit('didCancelSetup');
     return;
   }
-  const encryptedNewPassword = await encryptOrganizationPassword(
-    setup.newOrganizationPassword,
-    personalPassword || undefined,
-  );
 
   // 2) Add organization and credentials to prisma db
   const email = setup.organizationEmail!; // Checked by SetupOrganization.checkLoginInOrganization()
@@ -105,9 +100,9 @@ const setupOrganization = async (setup: ModelValue, jwtToken: string) => {
     organizationId,
     props.personalUser.personalId,
     undefined,
+    setup.newOrganizationPassword,
     undefined,
-    undefined,
-    encryptedNewPassword,
+    personalPassword ?? undefined,
   );
 
   // 5) Initialize user store

--- a/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
+++ b/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
@@ -36,7 +36,6 @@ const props = defineProps<{
 /* Emits */
 const emit = defineEmits<{
   (event: 'didPerformSetup', importedKeyCount: number, error: unknown): void;
-  (event: 'didCancelSetup'): void;
 }>();
 
 /* Stores */

--- a/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
+++ b/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
@@ -87,6 +87,7 @@ const setupOrganization = async (setup: ModelValue, jwtToken: string) => {
     props.personalUser.personalId,
     jwtToken,
     null,
+    false
   );
   await user.refetchOrganizations();
 

--- a/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
+++ b/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
@@ -38,6 +38,7 @@ const props = defineProps<{
 /* Emits */
 const emit = defineEmits<{
   (event: 'didPerformSetup', importedKeyCount: number, error: unknown): void;
+  (event: 'didCancelSetup'): void;
 }>();
 
 /* Composables */
@@ -67,6 +68,11 @@ const setupOrganization = async (setup: ModelValue) => {
   const personalPassword = await getPasswordAsync({
     subHeading: 'Enter your application password to encrypt your organization credentials',
   });
+  if (personalPassword === false) {
+    // User has refused to enter his application password => setup is cancelled
+    emit('didCancelSetup');
+    return;
+  }
   const encryptedNewPassword = await encryptOrganizationPassword(
     setup.newOrganizationPassword,
     personalPassword || undefined,

--- a/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
+++ b/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
@@ -22,7 +22,6 @@ import { compareHash } from '@renderer/services/electronUtilsService.ts';
 import useUserStore from '@renderer/stores/storeUser.ts';
 import { restorePrivateKey, storeKeyPair } from '@renderer/services/keyPairService.ts';
 import type { Prisma } from '@prisma/client';
-import usePersonalPassword from '@renderer/composables/usePersonalPassword.ts';
 
 /* Props */
 const props = defineProps<{
@@ -39,9 +38,6 @@ const emit = defineEmits<{
   (event: 'didPerformSetup', importedKeyCount: number, error: unknown): void;
   (event: 'didCancelSetup'): void;
 }>();
-
-/* Composables */
-const { getPasswordAsync } = usePersonalPassword();
 
 /* Stores */
 const user = useUserStore();
@@ -63,17 +59,7 @@ const concludeSetup = async (importedKeyCount: number, error: unknown) => {
 };
 
 const setupOrganization = async (setup: ModelValue, jwtToken: string) => {
-  // 1) Encrypt new password
-  const personalPassword = await getPasswordAsync({
-    subHeading: 'Enter your application password to encrypt your organization credentials',
-  });
-  if (personalPassword === false) {
-    // User has refused to enter his application password => setup is cancelled
-    emit('didCancelSetup');
-    return;
-  }
-
-  // 2) Add organization and credentials to prisma db
+  // 1) Add organization and credentials to prisma db
   const email = setup.organizationEmail!; // Checked by SetupOrganization.checkLoginInOrganization()
   const { id: organizationId } = await addOrganization({
     nickname: setup.organizationNickname,
@@ -86,12 +72,12 @@ const setupOrganization = async (setup: ModelValue, jwtToken: string) => {
     organizationId,
     props.personalUser.personalId,
     jwtToken,
-    null,
-    false
+    props.personalUser.password,
+    false,
   );
   await user.refetchOrganizations();
 
-  // 3) Set new password and update prisma db
+  // 2) Set new password and update prisma db
   await changePassword(
     setup.organizationURL,
     setup.temporaryOrganizationPassword,
@@ -103,16 +89,16 @@ const setupOrganization = async (setup: ModelValue, jwtToken: string) => {
     undefined,
     setup.newOrganizationPassword,
     undefined,
-    personalPassword ?? undefined,
+    props.personalUser.password ?? undefined,
   );
 
-  // 5) Initialize user store
+  // 3) Initialize user store
   await user.refetchOrganizations();
   if (user.organizations[0]) {
     await user.selectOrganization(user.organizations[0]);
   }
 
-  // 6) Wait a little to avoid flash effect and help user identify what's happening
+  // 4) Wait a little to avoid flash effect and help user identify what's happening
   await eyePersistence;
 };
 

--- a/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
+++ b/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
@@ -13,12 +13,17 @@ import {
   safeDuplicateUploadKey,
   userKeyHasMnemonic,
 } from '@renderer/utils';
-import { addOrganizationCredentials } from '@renderer/services/organizationCredentials.ts';
+import {
+  addOrganizationCredentials,
+  encryptOrganizationPassword,
+  updateOrganizationCredentials,
+} from '@renderer/services/organizationCredentials.ts';
 import DecryptKeys from '@renderer/components/KeyPair/ImportEncrypted/components/DecryptKeys.vue';
 import { compareHash } from '@renderer/services/electronUtilsService.ts';
 import useUserStore from '@renderer/stores/storeUser.ts';
 import { restorePrivateKey, storeKeyPair } from '@renderer/services/keyPairService.ts';
 import type { Prisma } from '@prisma/client';
+import usePersonalPassword from '@renderer/composables/usePersonalPassword.ts';
 
 /* Props */
 const props = defineProps<{
@@ -33,6 +38,9 @@ const props = defineProps<{
 const emit = defineEmits<{
   (event: 'didPerformSetup', importedKeyCount: number, error: unknown): void;
 }>();
+
+/* Composables */
+const { getPasswordAsync } = usePersonalPassword();
 
 /* Stores */
 const user = useUserStore();
@@ -54,14 +62,16 @@ const concludeSetup = async (importedKeyCount: number, error: unknown) => {
 };
 
 const setupOrganization = async (setup: ModelValue) => {
-  // 1) Add organization
-  const { id: organizationId } = await addOrganization({
-    nickname: setup.organizationNickname,
-    serverUrl: setup.organizationURL,
-    key: '',
+  // 0) Encrypt new password
+  const personalPassword = await getPasswordAsync({
+    subHeading: 'Enter your application password to encrypt your organization credentials',
   });
+  const encryptedNewPassword = await encryptOrganizationPassword(
+    setup.newOrganizationPassword,
+    personalPassword || undefined,
+  );
 
-  // 2) Login to organization
+  // 1) Login to organization
   const email = setup.organizationEmail!; // Checked by SetupOrganization.checkLoginInOrganization()
   const { jwtToken } = await login(
     setup.organizationURL,
@@ -69,22 +79,35 @@ const setupOrganization = async (setup: ModelValue) => {
     setup.temporaryOrganizationPassword,
   );
 
-  // 3) Set new password
+  // 2) Add organization and credentials to prisma db
+  const { id: organizationId } = await addOrganization({
+    nickname: setup.organizationNickname,
+    serverUrl: setup.organizationURL,
+    key: '',
+  });
+  await addOrganizationCredentials(
+    email,
+    setup.temporaryOrganizationPassword,
+    organizationId,
+    props.personalUser.personalId,
+    jwtToken,
+    null,
+  );
+  await user.refetchOrganizations();
+
+  // 3) Set new password and update prisma db
   await changePassword(
     setup.organizationURL,
     setup.temporaryOrganizationPassword,
     setup.newOrganizationPassword,
   );
-
-  // 4) Add Organization Credentials
-  await addOrganizationCredentials(
-    email,
-    setup.newOrganizationPassword,
+  await updateOrganizationCredentials(
     organizationId,
     props.personalUser.personalId,
-    jwtToken,
-    props.personalUser.password,
-    true,
+    undefined,
+    undefined,
+    undefined,
+    encryptedNewPassword,
   );
 
   // 5) Initialize user store

--- a/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
+++ b/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
@@ -29,7 +29,7 @@ import usePersonalPassword from '@renderer/composables/usePersonalPassword.ts';
 const props = defineProps<{
   personalUser: PersonalUser;
   organizationSetup: ModelValue | null;
-  jwtToken: string;
+  jwtToken: string | null;
   recoveryPhrase: RecoveryPhrase | null;
   recoveryPhrasePassword: string | null;
   selectedKeys: KeyPathWithName[];
@@ -63,7 +63,7 @@ const concludeSetup = async (importedKeyCount: number, error: unknown) => {
   emit('didPerformSetup', importedKeyCount, error);
 };
 
-const setupOrganization = async (setup: ModelValue) => {
+const setupOrganization = async (setup: ModelValue, jwtToken: string) => {
   // 1) Encrypt new password
   const personalPassword = await getPasswordAsync({
     subHeading: 'Enter your application password to encrypt your organization credentials',
@@ -90,7 +90,7 @@ const setupOrganization = async (setup: ModelValue) => {
     setup.temporaryOrganizationPassword,
     organizationId,
     props.personalUser.personalId,
-    props.jwtToken,
+    jwtToken,
     null,
   );
   await user.refetchOrganizations();
@@ -212,8 +212,8 @@ const restoreExistingKeys = async () => {
 /* Hooks */
 onMounted(async () => {
   try {
-    if (props.organizationSetup !== null) {
-      await setupOrganization(props.organizationSetup);
+    if (props.organizationSetup !== null && props.jwtToken !== null) {
+      await setupOrganization(props.organizationSetup, props.jwtToken);
     }
     if (props.selectedKeys.length > 0) {
       await startKeyImport(); // Will call concludeSetup()

--- a/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
+++ b/front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
@@ -5,7 +5,7 @@ import type { RecoveryPhrase } from '@renderer/types';
 import type { PersonalUser } from './SetupPersonal.vue';
 import type { ModelValue } from './SetupOrganizationForm.vue';
 import { addOrganization } from '@renderer/services/organizationsService.ts';
-import { changePassword, getUserState, login } from '@renderer/services/organization';
+import { changePassword, getUserState } from '@renderer/services/organization';
 import {
   isLoggedInOrganization,
   isUserLoggedIn,
@@ -29,6 +29,7 @@ import usePersonalPassword from '@renderer/composables/usePersonalPassword.ts';
 const props = defineProps<{
   personalUser: PersonalUser;
   organizationSetup: ModelValue | null;
+  jwtToken: string;
   recoveryPhrase: RecoveryPhrase | null;
   recoveryPhrasePassword: string | null;
   selectedKeys: KeyPathWithName[];
@@ -62,7 +63,7 @@ const concludeSetup = async (importedKeyCount: number, error: unknown) => {
 };
 
 const setupOrganization = async (setup: ModelValue) => {
-  // 0) Encrypt new password
+  // 1) Encrypt new password
   const personalPassword = await getPasswordAsync({
     subHeading: 'Enter your application password to encrypt your organization credentials',
   });
@@ -71,15 +72,8 @@ const setupOrganization = async (setup: ModelValue) => {
     personalPassword || undefined,
   );
 
-  // 1) Login to organization
-  const email = setup.organizationEmail!; // Checked by SetupOrganization.checkLoginInOrganization()
-  const { jwtToken } = await login(
-    setup.organizationURL,
-    email,
-    setup.temporaryOrganizationPassword,
-  );
-
   // 2) Add organization and credentials to prisma db
+  const email = setup.organizationEmail!; // Checked by SetupOrganization.checkLoginInOrganization()
   const { id: organizationId } = await addOrganization({
     nickname: setup.organizationNickname,
     serverUrl: setup.organizationURL,
@@ -90,7 +84,7 @@ const setupOrganization = async (setup: ModelValue) => {
     setup.temporaryOrganizationPassword,
     organizationId,
     props.personalUser.personalId,
-    jwtToken,
+    props.jwtToken,
     null,
   );
   await user.refetchOrganizations();

--- a/front-end/src/renderer/pages/Migrate/components/SetupOrganization.vue
+++ b/front-end/src/renderer/pages/Migrate/components/SetupOrganization.vue
@@ -16,7 +16,7 @@ defineProps<{
 
 /* Emits */
 const emit = defineEmits<{
-  (event: 'setOrganizationSetup', value: ModelValue | null): void;
+  (event: 'setOrganizationSetup', value: ModelValue | null, jwtToken: string | null): void;
   (event: 'migration:cancel'): void;
 }>();
 
@@ -25,6 +25,7 @@ const loading = ref(false);
 const loadingText = ref<string>('');
 const organizationURL = ref<string | null>(null);
 const organizationEmail = ref<string | null>(null);
+const jwtToken = ref<string | null>(null);
 
 /* Handlers */
 const handleFormSubmit: SubmitCallback = async (
@@ -56,28 +57,31 @@ const handleFormSubmit: SubmitCallback = async (
       return { error: loginInOrganizationResult.error.message };
     }
     organizationEmail.value = formData.organizationEmail;
+    jwtToken.value = loginInOrganizationResult.data!;
   }
 
-  emit('setOrganizationSetup', formData);
+  emit('setOrganizationSetup', formData, jwtToken.value);
   loading.value = false;
 
   return { error: null };
 };
 
 const handleSkip = () => {
-  emit('setOrganizationSetup', null);
+  emit('setOrganizationSetup', null, null);
 };
 
 const handleMigrationCancel = () => emit('migration:cancel');
 
 /* Functions */
-const checkLoginInOrganization = async (data: ModelValue) => {
+const checkLoginInOrganization = async (data: ModelValue): Promise<string> => {
   if (!data.organizationEmail) {
     throw new Error('(BUG) Organization email is required');
   }
   const email = data.organizationEmail;
 
-  await login(data.organizationURL, email, data.temporaryOrganizationPassword);
+  const { jwtToken } = await login(data.organizationURL, email, data.temporaryOrganizationPassword);
+
+  return jwtToken;
 };
 </script>
 <template>


### PR DESCRIPTION
**Description**:

Changes below fix a regression introduced in #3058 (and revealed by #3106) and adds an optimization:
- `PerformSetup.setupOrganization()` now makes sure to refresh user store before calling`changePassword()` so this one can retrieve JWT token when connecting to backend
- `SetupOrganization` now propagates JWT token to `PerformSetup` which avoids an extra call to `login()` and some possible `429` errors.

**Notes for reviewer**:
```
M   front-end/src/renderer/pages/Migrate/components/PerformSetup.vue
    # setupOrganization() now makes sure to refresh user/organization stores before calling changePassword().
```
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
