### PR TITLE
chore: migrate to otplib 13.4.1

### DIFF
--- a/back-end/apps/api/package.json
+++ b/back-end/apps/api/package.json
@@ -16,7 +16,9 @@
     "test:e2e": "jest --config ./test/jest-e2e.config.ts --runInBand --detectOpenHandles"
   },
   "dependencies": {
-    "otplib": "12.0.1",
+    "@otplib/plugin-crypto-node": "13.4.1",
+    "@otplib/totp": "13.4.1",
+    "otplib": "13.4.1",
     "passport": "0.7.0",
     "passport-jwt": "4.0.1",
     "passport-local": "1.0.0"

--- a/back-end/apps/api/src/auth/auth.service.spec.ts
+++ b/back-end/apps/api/src/auth/auth.service.spec.ts
@@ -10,12 +10,16 @@ import * as bcrypt from 'bcryptjs';
 import * as argon2 from 'argon2';
 import { ErrorCodes, NatsPublisherService } from '@app/common';
 import { User, UserStatus } from '@entities';
-import { totp } from 'otplib';
+import * as otplib from '@otplib/totp';
 import { UsersService } from '../users/users.service';
 import { SignUpUserDto } from './dtos';
 
 jest.mock('bcryptjs');
 jest.mock('argon2');
+jest.mock('@otplib/totp', () => ({
+  generate: jest.fn(),
+  verify: jest.fn(),
+}));
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -90,7 +94,7 @@ describe('AuthService', () => {
 
     jwtService.sign.mockReturnValue('token');
 
-    jest.spyOn(totp, 'generate').mockReturnValue(totpRes);
+    jest.mocked(otplib.generate).mockResolvedValue(totpRes);
 
     await service.createOtp(email);
 
@@ -113,7 +117,12 @@ describe('AuthService', () => {
       //@ts-expect-error - incorrect overload expected
       .calledWith('NODE_ENV')
       .mockReturnValue(production ? 'production' : 'development');
-    jest.spyOn(totp, 'check').mockReturnValue(true);
+    jest.mocked(otplib.verify).mockResolvedValue({
+      valid: true,
+      delta: 0,
+      epoch: 0,
+      timeStep: 0,
+    });
 
     await service.verifyOtp(user as User, { token: '123456' });
 
@@ -272,21 +281,43 @@ describe('AuthService', () => {
   it('should create otp in dev', async () => {
     const { user, otpSecret, totpRes } = await invokeCreateOtp(false);
 
-    expect(totp.generate).toHaveBeenCalledWith(`${otpSecret}${user.email}`);
-    expect(notificationsPublisher.publish).toHaveBeenCalledWith('notifications.queue.email.password-reset', [{
-      email: user.email,
-      additionalData: { otp: totpRes },
-    }]);
+    expect(otplib.generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        secret: Buffer.from(`${otpSecret}${user.email}`),
+        digits: 8,
+        period: 60,
+      }),
+    );
+    expect(notificationsPublisher.publish).toHaveBeenCalledWith(
+      'notifications.queue.email.password-reset',
+      [
+        {
+          email: user.email,
+          additionalData: { otp: totpRes },
+        },
+      ],
+    );
   });
 
   it('should create otp in production', async () => {
     const { user, otpSecret, totpRes } = await invokeCreateOtp(true);
 
-    expect(totp.generate).toHaveBeenCalledWith(`${otpSecret}${user.email}`);
-    expect(notificationsPublisher.publish).toHaveBeenCalledWith('notifications.queue.email.password-reset', [{
-      email: user.email,
-      additionalData: { otp: totpRes },
-    }]);
+    expect(otplib.generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        secret: Buffer.from(`${otpSecret}${user.email}`),
+        digits: 8,
+        period: 60,
+      }),
+    );
+    expect(notificationsPublisher.publish).toHaveBeenCalledWith(
+      'notifications.queue.email.password-reset',
+      [
+        {
+          email: user.email,
+          additionalData: { otp: totpRes },
+        },
+      ],
+    );
   });
 
   it('should not create otp if user not found', async () => {
@@ -318,7 +349,7 @@ describe('AuthService', () => {
       .calledWith('OTP_SECRET')
       .mockReturnValue('');
 
-    jest.spyOn(totp, 'check').mockReturnValue(false);
+    jest.mocked(otplib.verify).mockResolvedValue({ valid: false });
 
     await expect(service.verifyOtp(user as User, { token: '123456' })).rejects.toThrow(
       'Incorrect token',
@@ -334,7 +365,12 @@ describe('AuthService', () => {
       .calledWith('OTP_SECRET')
       .mockReturnValue('');
 
-    jest.spyOn(totp, 'check').mockReturnValue(true);
+    jest.mocked(otplib.verify).mockResolvedValue({
+      valid: true,
+      delta: 0,
+      epoch: 0,
+      timeStep: 0,
+    });
     userService.updateUser.mockRejectedValue(new Error());
 
     await expect(service.verifyOtp(user as User, { token: '123456' })).rejects.toThrow(

--- a/back-end/apps/api/src/auth/auth.service.ts
+++ b/back-end/apps/api/src/auth/auth.service.ts
@@ -10,7 +10,8 @@ import { JwtService } from '@nestjs/jwt';
 import type { StringValue } from 'ms';
 import { randomInt } from 'crypto';
 
-import { totp } from 'otplib';
+import * as otplib from '@otplib/totp';
+import { crypto } from '@otplib/plugin-crypto-node';
 import * as bcrypt from 'bcryptjs';
 import * as argon2 from 'argon2';
 
@@ -29,11 +30,12 @@ import { UsersService } from '../users/users.service';
 
 import { ChangePasswordDto, SignUpUserDto, OtpDto } from './dtos';
 
-totp.options = {
+const TOTP_OPTIONS = {
   digits: 8,
-  step: 60,
-  window: 20,
-};
+  period: 60,
+} as const;
+
+const TOTP_EPOCH_TOLERANCE = TOTP_OPTIONS.period * 20;
 
 @Injectable()
 export class AuthService {
@@ -103,7 +105,11 @@ export class AuthService {
     if (!user) return;
 
     const secret = this.getOtpSecret(user.email);
-    const otp = totp.generate(secret);
+    const otp = await otplib.generate({
+      secret,
+      crypto,
+      ...TOTP_OPTIONS,
+    });
 
     emitUserPasswordResetEmail(this.notificationsPublisher, [{ email: user.email, additionalData: { otp } }]);
 
@@ -114,7 +120,15 @@ export class AuthService {
   async verifyOtp(user: User, { token }: OtpDto): Promise<{ token: string }> {
     const secret = this.getOtpSecret(user.email);
 
-    if (!totp.check(token, secret)) throw new UnauthorizedException('Incorrect token');
+    const { valid } = await otplib.verify({
+      token,
+      secret,
+      crypto,
+      ...TOTP_OPTIONS,
+      epochTolerance: TOTP_EPOCH_TOLERANCE,
+    });
+
+    if (!valid) throw new UnauthorizedException('Incorrect token');
 
     try {
       await this.usersService.updateUser(user, { status: UserStatus.NEW });
@@ -126,8 +140,8 @@ export class AuthService {
   }
 
   /* Return unique OTP secret for each user */
-  private getOtpSecret(email: string): string {
-    return this.configService.get<string>('OTP_SECRET').concat(email);
+  private getOtpSecret(email: string): Uint8Array {
+    return Buffer.from(this.configService.get<string>('OTP_SECRET').concat(email));
   }
 
   /* Sets the OTP jwt */

--- a/back-end/apps/api/src/auth/auth.service.ts
+++ b/back-end/apps/api/src/auth/auth.service.ts
@@ -146,9 +146,6 @@ export class AuthService {
 
   /* Sets the OTP jwt */
   private getOtpToken(otpPayload: OtpPayload) {
-    const expires = new Date();
-    expires.setSeconds(expires.getSeconds() + totp.options.step * (totp.options.window as number));
-
     return this.jwtService.sign(otpPayload, {
       expiresIn: `${this.configService.get('OTP_EXPIRATION')}m`,
     });

--- a/back-end/apps/api/src/auth/auth.service.ts
+++ b/back-end/apps/api/src/auth/auth.service.ts
@@ -77,11 +77,9 @@ export class AuthService {
     const payload: JwtPayload = { userId: user.id, email: user.email };
     const expiresIn = `${this.configService.get('JWT_EXPIRATION')}d` as StringValue;
 
-    const accessToken: string = this.jwtService.sign(payload, {
+    return this.jwtService.sign(payload, {
       expiresIn,
     });
-
-    return accessToken;
   }
 
   /* Change the password for the given user */

--- a/back-end/apps/api/test/spec/auth.e2e-spec.ts
+++ b/back-end/apps/api/test/spec/auth.e2e-spec.ts
@@ -1,8 +1,9 @@
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { ClientProxy } from '@nestjs/microservices';
-import * as request from 'supertest';
+import request from 'supertest';
 
-import { totp } from 'otplib';
+import { generate } from '@otplib/totp';
+import { crypto } from '@otplib/plugin-crypto-node';
 
 import { API_SERVICE } from '@app/common';
 import { User, UserStatus } from '@entities';
@@ -362,7 +363,12 @@ describe('Auth (e2e)', () => {
     });
 
     it('(POST) should verify OTP', async () => {
-      const token = totp.generate(`${process.env.OTP_SECRET}${dummy.email}`);
+      const token = await generate({
+        secret: Buffer.from(`${process.env.OTP_SECRET}${dummy.email}`),
+        crypto,
+        digits: 8,
+        period: 60,
+      });
 
       const { body } = await request(server)
         .post('/auth/verify-reset')
@@ -376,7 +382,12 @@ describe('Auth (e2e)', () => {
     });
 
     it('(POST) should blacklist OTP token after verification', async () => {
-      const token = totp.generate(`${process.env.OTP_SECRET}${dummy.email}`);
+      const token = await generate({
+        secret: Buffer.from(`${process.env.OTP_SECRET}${dummy.email}`),
+        crypto,
+        digits: 8,
+        period: 60,
+      });
 
       await request(server)
         .post('/auth/verify-reset')

--- a/back-end/tsconfig.json
+++ b/back-end/tsconfig.json
@@ -17,6 +17,7 @@
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
     "resolveJsonModule": true,
+    "types": ["node", "jest"],
     "paths": {
       "@app/common": ["libs/common/src"],
       "@app/common/*": ["libs/common/src/*"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,9 +501,15 @@ importers:
 
   back-end/apps/api:
     dependencies:
+      '@otplib/plugin-crypto-node':
+        specifier: 13.4.1
+        version: 13.4.1
+      '@otplib/totp':
+        specifier: 13.4.1
+        version: 13.4.1
       otplib:
-        specifier: 12.0.1
-        version: 12.0.1
+        specifier: 13.4.1
+        version: 13.4.1
       passport:
         specifier: 0.7.0
         version: 0.7.0
@@ -2173,23 +2179,26 @@ packages:
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
-  '@otplib/core@12.0.1':
-    resolution: {integrity: sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==}
+  '@otplib/core@13.4.1':
+    resolution: {integrity: sha512-KIXgK1hNtWJEBMTastbe1bpmuais+3f+ATeO8TkMs2rNkfGO1FbQy8+/UWVEu3TR/iTJerU0idkPudaPmLP2BA==}
 
-  '@otplib/plugin-crypto@12.0.1':
-    resolution: {integrity: sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==}
-    deprecated: Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
+  '@otplib/hotp@13.4.1':
+    resolution: {integrity: sha512-g9q04SwpG5ZtMnVkUcgcoAlwCH4YLROZN1qhyBwgkBzqYYVSYhpP6gSGaxGHwePLt1c+e6NqDlgIZN+e1/XPuA==}
 
-  '@otplib/plugin-thirty-two@12.0.1':
-    resolution: {integrity: sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==}
-    deprecated: Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
+  '@otplib/plugin-base32-scure@13.4.1':
+    resolution: {integrity: sha512-Fs/r5qisC05SRhT6xWXaypB6PVC0vgWf6zztmi0J5RnQ09OJiPDWCJFH6cDm6ANsrdvB9di7X+Jb7L13BoEbUA==}
 
-  '@otplib/preset-default@12.0.1':
-    resolution: {integrity: sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==}
-    deprecated: Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
+  '@otplib/plugin-crypto-noble@13.4.1':
+    resolution: {integrity: sha512-PJfVW8/1hdS6CfxLheKPZSLTwDq4TijZbN4yRjxlv0ODdzmxpM+wGwWr1JXMdy0xJPxLziydQD5gdVqrR4/gAg==}
 
-  '@otplib/preset-v11@12.0.1':
-    resolution: {integrity: sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==}
+  '@otplib/plugin-crypto-node@13.4.1':
+    resolution: {integrity: sha512-ce4Y+6Al+NI8rlyVcOCrTQh/LxQamdAlJCDVTDSYnxApT2dDyK7ADsxVjuDmnh6giZ//vhgMipu1S9NBt7aEzQ==}
+
+  '@otplib/totp@13.4.1':
+    resolution: {integrity: sha512-QOkBVPrf6AM4qZaReZPSk9/I8ATVdZpIISJz115MqeVtcrbcr5llPZ0J7804tpnjnp1vCRkI5Qjd47HhgVteBQ==}
+
+  '@otplib/uri@13.4.1':
+    resolution: {integrity: sha512-xaIm7bvICMhoB2rZIR5luiaMdssWR5nY5nXnR1fdezUgZuEO58D6zrGzLp7pQuBmlpmL0HagnscDQFoskp9yiA==}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -2762,6 +2771,9 @@ packages:
 
   '@scure/base@1.2.4':
     resolution: {integrity: sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==}
+
+  '@scure/base@2.2.0':
+    resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
 
   '@scure/bip32@1.6.2':
     resolution: {integrity: sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==}
@@ -6906,8 +6918,8 @@ packages:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
 
-  otplib@12.0.1:
-    resolution: {integrity: sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==}
+  otplib@13.4.1:
+    resolution: {integrity: sha512-o5CxfDw6bh7hoDv0NUUIcc0RqzJ9ipfUrzeKheKJ+vs4rXZnDlA9n4a/7R1cDjpmLjKLix4BgNVRmoDkm5rLSQ==}
 
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
@@ -8084,10 +8096,6 @@ packages:
 
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
-
-  thirty-two@1.0.2:
-    resolution: {integrity: sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==}
-    engines: {node: '>=0.2.6'}
 
   thread-stream@3.2.0:
     resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
@@ -10725,28 +10733,36 @@ snapshots:
 
   '@one-ini/wasm@0.1.1': {}
 
-  '@otplib/core@12.0.1': {}
+  '@otplib/core@13.4.1': {}
 
-  '@otplib/plugin-crypto@12.0.1':
+  '@otplib/hotp@13.4.1':
     dependencies:
-      '@otplib/core': 12.0.1
+      '@otplib/core': 13.4.1
+      '@otplib/uri': 13.4.1
 
-  '@otplib/plugin-thirty-two@12.0.1':
+  '@otplib/plugin-base32-scure@13.4.1':
     dependencies:
-      '@otplib/core': 12.0.1
-      thirty-two: 1.0.2
+      '@otplib/core': 13.4.1
+      '@scure/base': 2.2.0
 
-  '@otplib/preset-default@12.0.1':
+  '@otplib/plugin-crypto-noble@13.4.1':
     dependencies:
-      '@otplib/core': 12.0.1
-      '@otplib/plugin-crypto': 12.0.1
-      '@otplib/plugin-thirty-two': 12.0.1
+      '@noble/hashes': 2.2.0
+      '@otplib/core': 13.4.1
 
-  '@otplib/preset-v11@12.0.1':
+  '@otplib/plugin-crypto-node@13.4.1':
     dependencies:
-      '@otplib/core': 12.0.1
-      '@otplib/plugin-crypto': 12.0.1
-      '@otplib/plugin-thirty-two': 12.0.1
+      '@otplib/core': 13.4.1
+
+  '@otplib/totp@13.4.1':
+    dependencies:
+      '@otplib/core': 13.4.1
+      '@otplib/hotp': 13.4.1
+      '@otplib/uri': 13.4.1
+
+  '@otplib/uri@13.4.1':
+    dependencies:
+      '@otplib/core': 13.4.1
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -11234,6 +11250,8 @@ snapshots:
   '@scarf/scarf@1.4.0': {}
 
   '@scure/base@1.2.4': {}
+
+  '@scure/base@2.2.0': {}
 
   '@scure/bip32@1.6.2':
     dependencies:
@@ -16195,11 +16213,14 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
-  otplib@12.0.1:
+  otplib@13.4.1:
     dependencies:
-      '@otplib/core': 12.0.1
-      '@otplib/preset-default': 12.0.1
-      '@otplib/preset-v11': 12.0.1
+      '@otplib/core': 13.4.1
+      '@otplib/hotp': 13.4.1
+      '@otplib/plugin-base32-scure': 13.4.1
+      '@otplib/plugin-crypto-noble': 13.4.1
+      '@otplib/totp': 13.4.1
+      '@otplib/uri': 13.4.1
 
   p-cancelable@2.1.1: {}
 
@@ -17607,8 +17628,6 @@ snapshots:
       - react-native-b4a
 
   text-hex@1.0.0: {}
-
-  thirty-two@1.0.2: {}
 
   thread-stream@3.2.0:
     dependencies:


### PR DESCRIPTION
**Description**:

 - Bump otplib from 12.0.1 to 13.4.1 (has breaking changes). Cf [migration guide](https://github.com/hashgraph/hedera-transaction-tool/pull/3174#issue-5020559889).
 - Migrate password-reset TOTP generation and verification to the new API
 - Update unit tests
 - Add `"types": ["node", "jest"]` to back-end/tsconfig.json so TypeScript 6 does not complain with tests
 
Note:  otplib v13 is more modular than v12. The top-level `otplib` package no longer provides a preconfigured Node.js TOTP instance equivalent to the old `totp` preset. The application must explicitly assemble the functionality it needs. Hence the 2 new dependencies:
  - `@otplib/totp` provides the TOTP generate() and verify() functions.
  - `@otplib/plugin-crypto-node` provides the underlying Node.js cryptographic implementation used
