### PR TITLE
chore: fixed some errors reported by typecheck:node

### DIFF
--- a/front-end/src/main/services/localUser/dataMigration.ts
+++ b/front-end/src/main/services/localUser/dataMigration.ts
@@ -23,6 +23,7 @@ import { safeAwait } from '@main/utils/safeAwait';
 import { addAccount } from './accounts';
 import { addClaim } from './claim';
 import { addPublicKey } from './publicKeyMapping';
+import { HashOptions } from 'argon2';
 
 const logger = createLogger('main.dataMigration');
 
@@ -85,7 +86,7 @@ export function getSalt(token: string): Buffer {
 }
 
 export async function generateArgon2id(password: string, salt: Buffer) {
-  const options = {
+  const options: HashOptions & { raw?: boolean } = {
     type: argon2.argon2id,
     memoryCost: 262144, // 256MB
     timeCost: 3, // iterations

--- a/front-end/src/main/services/localUser/organizationCredentials.ts
+++ b/front-end/src/main/services/localUser/organizationCredentials.ts
@@ -226,8 +226,8 @@ export const updateOrganizationCredentials = async (
       where: { id: credentials.id },
       data: {
         email: email || credentials.email,
-        password: password !== undefined ? password : credentials.password,
-        jwtToken: jwtToken !== undefined ? jwtToken : credentials.jwtToken,
+        password: password ?? credentials.password,
+        jwtToken: jwtToken ?? credentials.jwtToken,
       },
     });
 

--- a/front-end/src/main/utils/electronInfra.ts
+++ b/front-end/src/main/utils/electronInfra.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 
-export const renameFunc = (func: (...args: any[]) => void|Promise<void>, name: string) => {
+export const renameFunc = (func: (...args: any[]) => unknown | Promise<unknown>, name: string) => {
   const newFunc = (...args: any[]) => func(...args);
   Object.defineProperty(newFunc, 'name', { value: name });
   return newFunc;

--- a/front-end/src/main/utils/files.ts
+++ b/front-end/src/main/utils/files.ts
@@ -126,6 +126,7 @@ const extractUnzipperFile = (file: unzipper.File, dist: string, abortSignal?: Ab
       .on('data', () => {
         if (abortSignal?.aborted) {
           stream.destroy();
+          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
           reject('File extraction aborted');
         }
       })
@@ -143,6 +144,7 @@ export const extractUnzipperFileToBuffer = (file: unzipper.File, abortSignal?: A
       .on('data', (d: Buffer) => {
         if (abortSignal?.aborted) {
           stream.destroy();
+          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
           reject('File extraction aborted');
         } else {
           result.push(d);
@@ -163,6 +165,7 @@ export const copyFile = (filePath: string, fileDist: string, signal?: AbortSigna
     readStream.on('data', () => {
       if (signal?.aborted) {
         readStream.destroy();
+        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
         reject('File copying aborted');
       }
     });

--- a/front-end/src/main/utils/index.ts
+++ b/front-end/src/main/utils/index.ts
@@ -31,7 +31,7 @@ export const deleteDirectory = async (directoryPath: string) => {
     const pathStat = await fs.stat(directoryPath);
 
     if (pathStat.isDirectory()) {
-      await fs.rmdir(directoryPath, { recursive: true });
+      await fs.rm(directoryPath, { recursive: true, force: true });
     }
 
     return true;

--- a/front-end/src/main/utils/sdk.ts
+++ b/front-end/src/main/utils/sdk.ts
@@ -1,4 +1,4 @@
-export const getStatusCodeFromMessage = (message: string) => {
+export const getStatusCodeFromMessage = (message: string): number | null => {
   if (message.includes('TRANSACTION_EXPIRED')) {
     return 4;
   } else {

--- a/front-end/src/renderer/App.vue
+++ b/front-end/src/renderer/App.vue
@@ -5,7 +5,7 @@ import { useRouter } from 'vue-router';
 import 'bootstrap/dist/js/bootstrap.bundle.min';
 
 import useUserStore from '@renderer/stores/storeUser';
-import useWebsocketSubscription from '@renderer/composables/useWebsocketSubscription.ts';
+import useWebsocketSubscription from '@renderer/composables/useWebsocketSubscription';
 
 import {
   provideDynamicLayout,
@@ -22,7 +22,7 @@ import GlobalAppProcesses from '@renderer/components/GlobalAppProcesses';
 import { ToastManager } from './utils/ToastManager';
 import { createLogger, getErrorMessage, isLoggedInOrganization } from '@renderer/utils';
 import { AppCache } from './caches/AppCache';
-import { parseTransactionActionPayload } from '@renderer/utils/parseTransactionActionPayload.ts';
+import { parseTransactionActionPayload } from '@renderer/utils/parseTransactionActionPayload';
 import { TRANSACTION_ACTION } from '@shared/constants';
 
 /* Composables */

--- a/front-end/src/renderer/caches/backend/BackendTransactionCache.ts
+++ b/front-end/src/renderer/caches/backend/BackendTransactionCache.ts
@@ -1,5 +1,5 @@
 import { TransactionId } from '@hiero-ledger/sdk';
-import { EntityCache } from '@renderer/caches/base/EntityCache.ts';
+import { EntityCache } from '@renderer/caches/base/EntityCache';
 import { getTransactionById } from '@renderer/services/organization';
 import type { ITransactionFull } from '@shared/interfaces';
 

--- a/front-end/src/renderer/components/ExternalSigning/ExportTransactionsModal.vue
+++ b/front-end/src/renderer/components/ExternalSigning/ExportTransactionsModal.vue
@@ -4,7 +4,7 @@ import AppButton from '@renderer/components/ui/AppButton.vue';
 import { ref } from 'vue';
 import type { ITransaction, TransactionFile } from '@shared/interfaces';
 import { writeTransactionFile } from '@renderer/services/transactionFileService.ts';
-import { flattenNodeCollection } from '@shared/utils/transactionFile.ts';
+import { flattenNodeCollection } from '@renderer/utils/transactionFileSigning.ts';
 import useUserStore from '@renderer/stores/storeUser.ts';
 import useNetworkStore from '@renderer/stores/storeNetwork';
 import {

--- a/front-end/src/renderer/components/ExternalSigning/SignTransactionFileModal.vue
+++ b/front-end/src/renderer/components/ExternalSigning/SignTransactionFileModal.vue
@@ -7,7 +7,7 @@ import { readTransactionFile, writeTransactionFile } from '@renderer/services/tr
 import {
   collectMissingSignerKeys,
   filterTransactionFileItemsToBeSigned,
-} from '@shared/utils/transactionFile.ts';
+} from '@renderer/utils/transactionFileSigning.ts';
 import useUserStore from '@renderer/stores/storeUser.ts';
 import useNetworkStore from '@renderer/stores/storeNetwork';
 import { AppCache } from '@renderer/caches/AppCache.ts';

--- a/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserEntry.ts
+++ b/front-end/src/renderer/components/ExternalSigning/TransactionBrowser/TransactionBrowserEntry.ts
@@ -5,7 +5,7 @@ import { hexToUint8Array, type SignatureAudit } from '@renderer/utils';
 import {
   filterAuditByUser,
   filterTransactionSignersByUser,
-} from '@shared/utils/transactionFile.ts';
+} from '@renderer/utils/transactionFileSigning.ts';
 
 export class TransactionBrowserEntry {
   public readonly fullySignedByUser: boolean;

--- a/front-end/src/renderer/pages/AccountSetup/AccountSetup.vue
+++ b/front-end/src/renderer/pages/AccountSetup/AccountSetup.vue
@@ -19,7 +19,7 @@ import GenerateOrImport from './components/GenerateOrImport.vue';
 import KeyPairs from './components/KeyPairs.vue';
 import NewPassword from './components/NewPassword.vue';
 import useVersionCheck from '@renderer/composables/useVersionCheck';
-import useAccountSetupStore from '@renderer/stores/storeAccountSetup.ts';
+import useAccountSetupStore from '@renderer/stores/storeAccountSetup';
 
 /* Types */
 type StepName = 'newPassword' | 'recoveryPhrase' | 'keyPairs';

--- a/front-end/src/renderer/pages/Accounts/Accounts.vue
+++ b/front-end/src/renderer/pages/Accounts/Accounts.vue
@@ -33,7 +33,7 @@ import AppModal from '@renderer/components/ui/AppModal.vue';
 import KeyStructureModal from '@renderer/components/KeyStructureModal.vue';
 import AppInput from '@renderer/components/ui/AppInput.vue';
 import AppCheckBox from '@renderer/components/ui/AppCheckBox.vue';
-import { AppCache } from '@renderer/caches/AppCache.ts';
+import { AppCache } from '@renderer/caches/AppCache';
 
 /* Stores */
 const user = useUserStore();

--- a/front-end/src/renderer/pages/ContactList/SignUpUser/SignUpUser.vue
+++ b/front-end/src/renderer/pages/ContactList/SignUpUser/SignUpUser.vue
@@ -25,7 +25,7 @@ const logger = createLogger('renderer.component.signUpUser');
 import AppButton from '@renderer/components/ui/AppButton.vue';
 import AppInput from '@renderer/components/ui/AppInput.vue';
 import AppTextArea from '@renderer/components/ui/AppTextArea.vue';
-import useContactsStore from '@renderer/stores/storeContacts.ts';
+import useContactsStore from '@renderer/stores/storeContacts';
 
 /* Injected */
 const toastManager = ToastManager.inject();

--- a/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
+++ b/front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
@@ -10,7 +10,7 @@ import { ToastManager } from '@renderer/utils/ToastManager';
 import { useRouter, useRoute, onBeforeRouteLeave, type _RouterClassic } from 'vue-router';
 import useSetDynamicLayout, { LOGGED_IN_LAYOUT } from '@renderer/composables/useSetDynamicLayout';
 
-import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting.ts';
+import useDateTimeSetting from '@renderer/composables/user/useDateTimeSetting';
 
 import { deleteGroup } from '@renderer/services/transactionGroupsService';
 
@@ -36,7 +36,7 @@ import DateTimeString from '@renderer/components/ui/DateTimeString.vue';
 import ImportCSVController from '@renderer/pages/CreateTransactionGroup/ImportCSVController.vue';
 import useNextTransactionV2, {
   type TransactionNodeId,
-} from '@renderer/stores/storeNextTransactionV2.ts';
+} from '@renderer/stores/storeNextTransactionV2';
 import { MAX_TRANSACTION_GROUP_DESCRIPTION_LENGTH } from '@shared/interfaces';
 
 /* Injected */

--- a/front-end/src/renderer/utils/transactionFileSigning.ts
+++ b/front-end/src/renderer/utils/transactionFileSigning.ts
@@ -1,5 +1,5 @@
 import { Transaction as SDKTransaction } from '@hiero-ledger/sdk';
-import { hexToUint8Array, type SignatureAudit } from '@renderer/utils';
+import { hexToUint8Array, type SignatureAudit } from '@renderer/utils/index.ts';
 import type { ITransaction, TransactionFileItem } from '@shared/interfaces';
 import { AppCache } from '@renderer/caches/AppCache.ts';
 import { flattenKeyList } from '@renderer/services/keyPairService.ts';

--- a/front-end/src/tests/main/index.spec.ts
+++ b/front-end/src/tests/main/index.spec.ts
@@ -15,7 +15,7 @@ import { deleteAllTempFolders } from '@main/services/localUser';
 vi.mock('path', () => mockDeep());
 vi.mock('@electron-toolkit/utils', () => mockDeep());
 vi.mock('electron', () => {
-  const mocked = mockDeep();
+  const mocked = mockDeep<typeof Electron>();
   mocked.app.requestSingleInstanceLock.mockReturnValue(true);
   mocked.app.whenReady.mockResolvedValue();
   return mocked;
@@ -208,12 +208,11 @@ describe('Electron entry file', async () => {
     // Re-trigger ready so mainWindow is set
     //@ts-expect-error Incorrect type definition
     const readyHandler = vi.mocked(app).on.mock.calls.find(([event]) => event === 'ready');
-    readyHandler && (await readyHandler[1]());
+    readyHandler && readyHandler[1]();
 
-    //@ts-expect-error Incorrect type definition
     const secondInstanceHandler = vi
       .mocked(app)
-      .on.mock.calls.find(([event]) => event === 'second-instance');
+      .on.mock.calls.find(([event]) => event === 'second-instance' as any);
     expect(secondInstanceHandler).toBeDefined();
 
     vi.mocked(mainWindow.isMinimized).mockReturnValue(true);
@@ -232,10 +231,9 @@ describe('Electron entry file', async () => {
     const readyHandler = vi.mocked(app).on.mock.calls.find(([event]) => event === 'ready');
     readyHandler && (await readyHandler[1]());
 
-    //@ts-expect-error Incorrect type definition
     const secondInstanceHandler = vi
       .mocked(app)
-      .on.mock.calls.find(([event]) => event === 'second-instance');
+      .on.mock.calls.find(([event]) => event === 'second-instance' as any);
     expect(secondInstanceHandler).toBeDefined();
 
     vi.mocked(mainWindow.isMinimized).mockReturnValue(false);
@@ -264,10 +262,9 @@ describe('Electron entry file', async () => {
     vi.mocked(restoreOrCreateWindow).mockClear();
     vi.mocked(mainWindow.focus).mockClear();
 
-    //@ts-expect-error Incorrect type definition
     const secondInstanceHandler = vi
       .mocked(app)
-      .on.mock.calls.find(([event]) => event === 'second-instance');
+      .on.mock.calls.find(([event]) => event === 'second-instance' as any);
     expect(secondInstanceHandler).toBeDefined();
 
     secondInstanceHandler && (await secondInstanceHandler[1]());

--- a/front-end/src/tests/main/modules/ipcHandlers/localUser/transactionGroups.spec.ts
+++ b/front-end/src/tests/main/modules/ipcHandlers/localUser/transactionGroups.spec.ts
@@ -93,7 +93,7 @@ describe('IPC handlers transaction groups', () => {
       atomic: true,
     };
     const drafts: Prisma.TransactionDraftUncheckedCreateInput[] = [
-      { user_id: userId, transactionBytes: 'a', type: 'Transfer' },
+      { user_id: userId, transactionBytes: 'a', type: 'Transfer', description: '' },
     ];
 
     await invokeIPCHandler('transactionGroups:updateGroupWithItems', groupId, group, drafts);

--- a/front-end/src/tests/main/modules/ipcHandlers/update.spec.ts
+++ b/front-end/src/tests/main/modules/ipcHandlers/update.spec.ts
@@ -38,7 +38,7 @@ describe('registerUpdateListeners', () => {
       downloadUpdate: mockDownloadUpdate,
       quitAndInstall: mockQuitAndInstall,
       cancelUpdate: mockCancelUpdate,
-    } as ReturnType<typeof getUpdaterService>);
+    } as unknown as ReturnType<typeof getUpdaterService>);
     registerUpdateListeners();
   });
 

--- a/front-end/src/tests/main/modules/ipcHandlers/utils.spec.ts
+++ b/front-end/src/tests/main/modules/ipcHandlers/utils.spec.ts
@@ -2,13 +2,13 @@ import { mockDeep } from 'vitest-mock-extended';
 
 vi.mock('bcrypt', () => mockDeep());
 vi.mock('crypto', () => mockDeep());
-vi.mock('electron', () => {
-  const actualElectron = vi.importActual('electron');
+vi.mock('electron', async () => {
+  const actualElectron = await vi.importActual('electron');
   return {
     ...actualElectron,
-    ipcMain: { on: vi.fn(), removeListener: vi.fn(), ...actualElectron.ipcMain },
+    ipcMain: { on: vi.fn(), removeListener: vi.fn(), ...actualElectron.ipcMain as any },
     BrowserWindow: {
-      ...actualElectron.BrowserWindow,
+      ...actualElectron.BrowserWindow as any,
       getAllWindows: vi.fn(), // add a stub for getAllWindows
     },
     app: actualElectron.app,
@@ -32,6 +32,7 @@ import { getNumberArrayFromString } from '@main/utils';
 import { hash, dualCompareHash } from '@main/utils/crypto';
 import fs from 'fs';
 import { createHash, X509Certificate } from 'crypto';
+import { Mock, vi } from 'vitest';
 
 describe('createChannelName', () => {
   test('Should create correct channel name', () => {
@@ -544,7 +545,7 @@ describe('setDockBounce listener', () => {
     vi.resetAllMocks();
 
     registerUtilsListeners();
-    const calls = (ipcMain.on as vi.Mock).mock.calls;
+    const calls = (ipcMain.on as Mock).mock.calls;
     const call = calls.find(([channel]) => channel === 'utils:setDockBounce');
     if (call) {
       listenerCallback = call[1];

--- a/front-end/src/tests/main/services/localUser/accounts.spec.ts
+++ b/front-end/src/tests/main/services/localUser/accounts.spec.ts
@@ -182,7 +182,7 @@ describe('Services Local User Accounts', () => {
     test('Should throw error if account already exists', async () => {
       prisma.hederaAccount.count.mockResolvedValueOnce(1);
 
-      expect(addAccount(userId, accountId, network, nickname)).rejects.toThrowError(
+      await expect(addAccount(userId, accountId, network, nickname)).rejects.toThrowError(
         'Account ID or Nickname already exists!',
       );
     });

--- a/front-end/src/tests/main/services/localUser/dataMigration.spec.ts
+++ b/front-end/src/tests/main/services/localUser/dataMigration.spec.ts
@@ -74,7 +74,7 @@ describe('Data Migration', () => {
         update: vi.fn().mockReturnValue(Buffer.from(mockDecryptedMnemonic)),
         final: vi.fn().mockReturnValue(Buffer.from('')),
         setAuthTag: vi.fn(),
-      } as unknown as crypto.Decipher);
+      } as unknown as crypto.Decipheriv);
 
       const result = await decryptMigrationMnemonic(mockPassword);
       expect(result).toEqual(mockDecryptedMnemonic.split(' '));
@@ -92,7 +92,7 @@ describe('Data Migration', () => {
         update: vi.fn().mockReturnValue(Buffer.from(mockDecryptedMnemonic)),
         final: vi.fn().mockReturnValue(Buffer.from('')),
         setAuthTag: vi.fn(),
-      } as unknown as crypto.Decipher);
+      } as unknown as crypto.Decipheriv);
 
       const result = await decryptMigrationMnemonic(mockPassword);
       expect(result).toEqual(mockDecryptedMnemonic.split(' '));
@@ -132,7 +132,7 @@ describe('Data Migration', () => {
         update: vi.fn().mockReturnValue(''),
         final: vi.fn().mockReturnValue(''),
         setAuthTag: vi.fn(),
-      } as unknown as crypto.Decipher);
+      } as unknown as crypto.Decipheriv);
 
       const result = await decryptMigrationMnemonic(mockPassword);
       expect(result).toBe(null);
@@ -150,7 +150,7 @@ describe('Data Migration', () => {
           throw new Error('Final error');
         }),
         setAuthTag: vi.fn(),
-      } as unknown as crypto.Decipher);
+      } as unknown as crypto.Decipheriv);
 
       const result = await decryptMigrationMnemonic(mockPassword);
       expect(result).toBe(null);

--- a/front-end/src/tests/main/services/localUser/encryptedKeys.spec.ts
+++ b/front-end/src/tests/main/services/localUser/encryptedKeys.spec.ts
@@ -36,7 +36,7 @@ describe('Encrypted Keys Utilities', () => {
     });
 
     test('calls searchFiles with correct arguments', async () => {
-      vi.mocked(searchFiles).mockImplementation(async (filePaths, extensions, processFile) => {
+      vi.mocked(searchFiles).mockImplementation(async (filePaths, _extensions, processFile) => {
         // Simulate calling processFile for each filePath
         const results: any[] = [];
         for (const filePath of filePaths) {

--- a/front-end/src/tests/main/services/localUser/files.spec.ts
+++ b/front-end/src/tests/main/services/localUser/files.spec.ts
@@ -101,7 +101,7 @@ describe('Services Local User Files', () => {
     test('Should throw error if file already exists', async () => {
       prisma.hederaFile.count.mockResolvedValueOnce(1);
 
-      expect(addFile(file)).rejects.toThrowError('File ID or Nickname already exists!');
+      await expect(addFile(file)).rejects.toThrowError('File ID or Nickname already exists!');
     });
   });
 

--- a/front-end/src/tests/main/services/localUser/organizationCredentials.spec.ts
+++ b/front-end/src/tests/main/services/localUser/organizationCredentials.spec.ts
@@ -601,7 +601,7 @@ describe('Services Local User Organization Credentials', () => {
 
       prisma.organizationCredentials.findFirst.mockResolvedValue(null);
 
-      expect(() => updateOrganizationCredentials('123', '321', email, password)).rejects.toThrow(
+      await expect(() => updateOrganizationCredentials('123', '321', email, password)).rejects.toThrow(
         'Failed to update organization credentials',
       );
     });
@@ -897,7 +897,7 @@ describe('Services Local User Organization Credentials', () => {
 
       prisma.organizationCredentials.create.mockRejectedValue('Database Error');
 
-      expect(() =>
+      await expect(() =>
         addOrganizationCredentials(email, password, '123', '321', 'token', encryptPassword, true),
       ).rejects.toThrow('Failed to add organization credentials');
     });
@@ -932,7 +932,7 @@ describe('Services Local User Organization Credentials', () => {
     test('Should throw error if there is a database error', async () => {
       prisma.organizationCredentials.deleteMany.mockRejectedValue('Database error');
 
-      expect(() => deleteOrganizationCredentials('123', '321')).rejects.toThrow(
+      await expect(() => deleteOrganizationCredentials('123', '321')).rejects.toThrow(
         'Failed to delete organization credentials',
       );
     });
@@ -985,7 +985,7 @@ describe('Services Local User Organization Credentials', () => {
       });
       vi.mocked(login).mockRejectedValue('Failed login in server');
 
-      expect(() => tryAutoSignIn('123', '321')).rejects.toThrow('Incorrect decryption password');
+      await expect(() => tryAutoSignIn('123', '321')).rejects.toThrow('Incorrect decryption password');
     });
   });
 

--- a/front-end/src/tests/main/services/localUser/publicKeyMapping.spec.ts
+++ b/front-end/src/tests/main/services/localUser/publicKeyMapping.spec.ts
@@ -140,9 +140,9 @@ describe('PublicKeyMapping Service', () => {
         }
       ];
 
-      vi.mocked(searchFiles).mockImplementation(async (filePaths, extensions, processFile) => {
+      vi.mocked(searchFiles).mockImplementation(async (filePaths, _extensions, processFile) => {
         // Simulate calling processFile for each filePath
-        const results = [];
+        const results: any[] = [];
         for (const filePath of filePaths) {
           const res = [await processFile(filePath)];
           results.push(...res);

--- a/front-end/src/tests/main/services/localUser/transactionDrafts.spec.ts
+++ b/front-end/src/tests/main/services/localUser/transactionDrafts.spec.ts
@@ -67,7 +67,7 @@ describe('Services Local User Public Keys Linked', () => {
 
       prisma.transactionDraft.findFirst.mockResolvedValue(null);
 
-      expect(() => getDraft(id)).rejects.toThrow('Transaction draft not found');
+      await expect(() => getDraft(id)).rejects.toThrow('Transaction draft not found');
     });
   });
 
@@ -103,7 +103,7 @@ describe('Services Local User Public Keys Linked', () => {
 
       prisma.transactionDraft.count.mockResolvedValue(1);
 
-      expect(() => addDraft(draft)).rejects.toThrow('Transaction draft already exists');
+      await expect(() => addDraft(draft)).rejects.toThrow('Transaction draft already exists');
     });
   });
 
@@ -185,8 +185,8 @@ describe('Services Local User Public Keys Linked', () => {
         new Error('Transaction draft Database error'),
       );
 
-      expect(() => getDraftsCount(userId)).rejects.toThrow('Failed to get drafts count');
-      expect(() => getDraftsCount(userId)).rejects.toThrow(
+      await expect(() => getDraftsCount(userId)).rejects.toThrow('Failed to get drafts count');
+      await expect(() => getDraftsCount(userId)).rejects.toThrow(
         new Error('Transaction draft Database error'),
       );
     });

--- a/front-end/src/tests/main/services/organization/auth.spec.ts
+++ b/front-end/src/tests/main/services/organization/auth.spec.ts
@@ -31,6 +31,6 @@ describe('Services Organization Auth', () => {
   test('login: throws and error when failed to login', async () => {
     vi.spyOn(axios, 'post').mockRejectedValueOnce('');
 
-    expect(login(serverUrl, email, password)).rejects.toThrowError('Failed Sign in Organization');
+    await expect(login(serverUrl, email, password)).rejects.toThrowError('Failed Sign in Organization');
   });
 });

--- a/front-end/src/tests/main/utils/files.spec.ts
+++ b/front-end/src/tests/main/utils/files.spec.ts
@@ -81,13 +81,13 @@ describe('Files utilities', () => {
       vi.mocked(fsp.stat).mockResolvedValue({
         isFile: () => true,
         isDirectory: () => false,
-      });
+      } as any);
       vi.mocked(fsp.access).mockRejectedValue(new Error('File does not exist'));
 
-      processor.mockResolvedValue({ file: '/file.pub' });
+      processor.mockResolvedValue([{ file: '/file.pub' }]);
       const result = await files.searchFiles(['/file.pub'], extensions, processor);
       expect(processor).toHaveBeenCalledWith(expect.stringMatching(/\/file\.pub$/));
-      expect(result).toEqual([{ file: '/file.pub' }]);
+      expect(result).toEqual([[{ file: '/file.pub' }]]);
     });
 
     test('Should process a directory and recurse into files', async () => {
@@ -95,7 +95,7 @@ describe('Files utilities', () => {
         isFile: () => false,
         isDirectory: () => true,
       } as any);
-      vi.mocked(fsp.readdir).mockResolvedValue(['file1.pub', 'file2.pub']);
+      vi.mocked(fsp.readdir).mockResolvedValue(['file1.pub', 'file2.pub'] as any);
       vi.mocked(fsp.stat).mockResolvedValue({
         isFile: () => true,
         isDirectory: () => false,
@@ -104,18 +104,18 @@ describe('Files utilities', () => {
         filePath.endsWith('.pub') ? '.pub' : '.enc'
       );
       vi.mocked(fsp.access).mockRejectedValue(new Error('File does not exist'));
-      processor.mockResolvedValueOnce({ file: '/dir/file1.pub' });
-      processor.mockResolvedValueOnce({ file: '/dir/file2.pub' });
+      processor.mockResolvedValueOnce([{ file: '/dir/file1.pub' }]);
+      processor.mockResolvedValueOnce([{ file: '/dir/file2.pub' }]);
       const result = await files.searchFiles(['/dir'], extensions, processor);
       expect(fsp.readdir).toHaveBeenCalledWith('/dir');
-      expect(result).toEqual([{ file: '/dir/file1.pub' }, { file: '/dir/file2.pub' }]);
+      expect(result).toEqual([[{ file: '/dir/file1.pub' }], [{ file: '/dir/file2.pub' }]]);
     });
 
     test('Should handles errors in processor gracefully', async () => {
       vi.mocked(fsp.stat).mockResolvedValue({
         isFile: () => true,
         isDirectory: () => false,
-      });
+      } as any);
       vi.mocked(fsp.access).mockRejectedValue(new Error('File does not exist'));
       vi.mocked(fsp.rm).mockResolvedValue(undefined);
       processor.mockRejectedValue(new Error('Processing error'));
@@ -156,6 +156,7 @@ describe('Files utilities', () => {
 
         mockStream = {
           on: vi.fn((event, callback) => {
+            // eslint-disable-next-line @typescript-eslint/no-implied-eval
             if (event === 'data' || event === 'close') setTimeout(callback, 0);
             if (event === 'error') return this;
             return mockStream;
@@ -182,14 +183,14 @@ describe('Files utilities', () => {
           return '';
         });
         vi.mocked(fsp.access).mockRejectedValue(new Error('File does not exist'));
-        vi.mocked(fsp.readdir).mockResolvedValue(['file1.pub']);
+        vi.mocked(fsp.readdir).mockResolvedValue(['file1.pub'] as any);
       });
 
       test('Should process a zip file', async () => {
-        processor.mockResolvedValue({ file: '/tmp/unzipped_123/file1.pub' });
+        processor.mockResolvedValue([{ file: '/tmp/unzipped_123/file1.pub' }]);
         const result = await files.searchFiles(['/archive.zip'], extensions, processor);
         expect(unzipper.Open.file).toHaveBeenCalled();
-        expect(result).toEqual([{ file: '/tmp/unzipped_123/file1.pub' }]);
+        expect(result).toEqual([[{ file: '/tmp/unzipped_123/file1.pub' }]]);
       });
 
       test('Should abort unzipping if signal is aborted', async () => {
@@ -213,7 +214,7 @@ describe('Files utilities', () => {
         vi.mocked(fsp.rm).mockResolvedValue(undefined);
         processor.mockImplementation(async (filePath: string) => {
           abortFileSearch();
-          return filePath;
+          return [{file: filePath}];
         });
         const results = await files.searchFiles(['/archive.zip'], extensions, processor);
         expect(fsp.rm).toHaveBeenCalledWith(expect.stringMatching(/^\/tmp\/search_/), { recursive: true });
@@ -231,7 +232,7 @@ describe('Files utilities', () => {
         });
         processor.mockImplementation(async (filePath: string) => {
           abortFileSearch();
-          return filePath;
+          return [{file: filePath}];
         });
 
         const results = await files.searchFiles(['/archive.zip'], extensions, processor);
@@ -261,7 +262,7 @@ describe('Files utilities', () => {
     test('Should handle abort state during file copy', async () => {
       const filePath = '/path/to/source/file.txt';
       const fileDist = '/path/to/dest/file.txt';
-      const signal = { aborted: true };
+      const signal = { aborted: true } as unknown as AbortSignal;
 
       await expect(files.copyFile(filePath, fileDist, signal)).rejects.toEqual('File copying aborted');
 

--- a/front-end/src/tests/main/utils/importV1.spec.ts
+++ b/front-end/src/tests/main/utils/importV1.spec.ts
@@ -69,6 +69,6 @@ describe('V1 import utilities', () => {
       expect(error).toBe('File extraction aborted');
     }
     const f = async () => await extractUnzipperFileToBuffer(txFile!, abortSignal);
-    expect(f).rejects.toThrow('File extraction aborted');
+    await expect(f).rejects.toThrow('File extraction aborted');
   });
 });

--- a/front-end/src/tests/main/windows/mainWindow.spec.ts
+++ b/front-end/src/tests/main/windows/mainWindow.spec.ts
@@ -37,7 +37,7 @@ vi.mock('electron', () => {
     callbacks.close && callbacks.close();
     callbacks.closed && callbacks.closed();
   });
-  bw.prototype.emit = vi.fn((e: string, ...args: any): boolean => {
+  bw.prototype.emit = vi.fn((e: string | symbol, ...args: any[]): boolean => {
     callbacks[e] && callbacks[e](args);
     return false;
   });

--- a/front-end/tsconfig.node.json
+++ b/front-end/tsconfig.node.json
@@ -13,17 +13,16 @@
     "../shared/src/**/*.ts"
   ],
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "composite": true,
     "noImplicitAny": false,
     "forceConsistentCasingInFileNames": true,
     "types": ["vitest/globals"],
     "strict": true,
-    "baseUrl": ".",
     "paths": {
-      "@main/*": ["src/main/*"],
-      "@renderer/*": ["src/renderer/*"],
-      "@shared/*": ["src/shared/*"],
-      "@prisma/client": ["src/generated/prisma/client.ts"]
+      "@main/*": ["./src/main/*"],
+      "@shared/*": ["./src/shared/*"],
+      "@prisma/client": ["./src/generated/prisma/client.ts"]
     }
   }
 }


### PR DESCRIPTION
**Description**:

Changes below fix some errors reported by `rpm run typecheck:node` since we move to typescript 6.
They don't fix all errors : remaining ones (related to `src/tests/main/modules/logger.spec.ts`) will be fixed with another PR.

One noticeable change: 
- `@renderer` is removed from paths in `tsconfig.node.json`
- this avoids `tsc` to typecheck renderer code with `tsconfig.node.json` and produce useless errors
- this requires to move `transactionFile.ts` from `@shared` to `@renderer` (code in `@shared` should have no deps on `@renderer` or `@main`).


**Notes for Reviewer**

```
M   front-end/eslint.config.ts
    # Disabled @typescript-eslint/prefer-promise-reject-errors
    # because there are many throws which throw string value

M   front-end/tsconfig.node.json
    # Removed "@renderer/*": ["src/renderer/*"] from "paths"
    # to avoid checking renderer code with tsconfig.node.json
    # This oblige to move

A   front-end/src/renderer/utils/transactionFileSigning.ts
R   front-end/src/shared/utils/transactionFile.ts
    # Moved transactionFile.ts from shared to renderer
    # Also renamed it as transactionFileSigning.ts to
    # avoid confusing with front-end existing transactionFile.ts

M   front-end/src/main/utils/index.ts
    # deleteDirectory() now uses fs.rm() in place of fs.rmdir()
    # as stated in nodejs doc when recursive removal is needed

M   front-end/src/main/utils/electronInfra.ts
M   front-end/src/.../localUser/organizationCredentials.ts
M   front-end/src/main/utils/sdk.ts
M   front-end/src/...services/localUser/dataMigration.ts
    # Fixed / improved typing

M   front-end/src/renderer/caches/backend/BackendTransactionCache.ts
M   front-end/src/.../TransactionBrowser/TransactionBrowserEntry.ts
M   front-end/src/renderer/components/ExternalSigning/ExportTransactionsModal.vue
M   front-end/src/renderer/components/ExternalSigning/SignTransactionFileModal.vue
M   front-end/src/renderer/pages/Accounts/Accounts.vue
M   front-end/src/renderer/pages/AccountSetup/AccountSetup.vue
M   front-end/src/renderer/pages/ContactList/SignUpUser/SignUpUser.vue
M   front-end/src/renderer/pages/CreateTransactionGroup/CreateTransactionGroup.vue
M   front-end/src/renderer/App.vue
    # Removed '.ts' in import statements

##
## TESTS
##

M   front-end/src/tests/main/modules/ipcHandlers/localUser/transactionGroups.spec.ts
M   front-end/src/tests/main/modules/ipcHandlers/update.spec.ts
M   front-end/src/tests/main/modules/ipcHandlers/utils.spec.ts
M   front-end/src/tests/main/services/localUser/publicKeyMapping.spec.ts
M   front-end/src/tests/main/utils/files.spec.ts
M   front-end/src/tests/main/windows/mainWindow.spec.ts
M   front-end/src/tests/main/index.spec.ts
    # Fixed/improved typing

M   front-end/src/tests/main/services/localUser/accounts.spec.ts
M   front-end/src/tests/main/services/localUser/files.spec.ts
M   front-end/src/tests/main/services/localUser/organizationCredentials.spec.ts
M   front-end/src/tests/main/services/localUser/transactionDrafts.spec.ts
M   front-end/src/tests/main/services/organization/auth.spec.ts
M   front-end/src/tests/main/utils/importV1.spec.ts
    # Added missing await in front of some expect()

M   front-end/src/tests/main/services/localUser/dataMigration.spec.ts
    # crypto.Decipher -> crypto.Decipheriv

M   front-end/src/tests/main/services/localUser/encryptedKeys.spec.ts
    # added _ to unused param names
```
