### PR TITLE
fix: blacklist jwt on user removal

### DIFF
--- a/back-end/apps/api/src/users/users.service.spec.ts
+++ b/back-end/apps/api/src/users/users.service.spec.ts
@@ -4,7 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { FindOptionsWhere, Repository } from 'typeorm';
 import { mockDeep } from 'jest-mock-extended';
 
-import { ErrorCodes, checkFrontendVersion, isUpdateAvailable } from '@app/common';
+import { BlacklistService, ErrorCodes, checkFrontendVersion, isUpdateAvailable } from '@app/common';
 import { Client, User, UserKey } from '@entities';
 
 import * as bcrypt from 'bcryptjs';
@@ -26,6 +26,7 @@ describe('UsersService', () => {
   const userRepository = mockDeep<Repository<User>>();
   const clientRepository = mockDeep<Repository<Client>>();
   const configService = mockDeep<ConfigService>();
+  const blacklistService = mockDeep<BlacklistService>();
 
   const email = 'some@email.com';
   const password = 'password';
@@ -50,6 +51,10 @@ describe('UsersService', () => {
         {
           provide: ConfigService,
           useValue: configService,
+        },
+        {
+          provide: BlacklistService,
+          useValue: blacklistService,
         },
       ],
     }).compile();
@@ -541,6 +546,8 @@ describe('UsersService', () => {
     expect(userRepository.manager.softDelete).toHaveBeenCalledWith(UserKey, { userId: 1 });
     // Then user is soft-deleted
     expect(userRepository.softRemove).toHaveBeenCalledWith(user);
+    // Every JWT issued before removal is invalidated
+    expect(blacklistService.blacklistPreviousUserTokens).toHaveBeenCalledWith(1);
   });
 
   it('should throw if the user is not found', async () => {

--- a/back-end/apps/api/src/users/users.service.spec.ts
+++ b/back-end/apps/api/src/users/users.service.spec.ts
@@ -550,6 +550,16 @@ describe('UsersService', () => {
     expect(blacklistService.blacklistPreviousUserTokens).toHaveBeenCalledWith(1);
   });
 
+  it('should not remove the user if JWT invalidation fails', async () => {
+    userRepository.findOne.mockResolvedValue(user as User);
+    blacklistService.blacklistPreviousUserTokens.mockRejectedValueOnce(new Error('Redis unavailable'));
+
+    await expect(service.removeUser(1)).rejects.toThrow('Redis unavailable');
+
+    expect(userRepository.manager.softDelete).not.toHaveBeenCalled();
+    expect(userRepository.softRemove).not.toHaveBeenCalled();
+  });
+
   it('should throw if the user is not found', async () => {
     userRepository.findOne.mockResolvedValue(null);
 

--- a/back-end/apps/api/src/users/users.service.ts
+++ b/back-end/apps/api/src/users/users.service.ts
@@ -168,14 +168,16 @@ export class UsersService {
       throw new BadRequestException(ErrorCodes.UNF);
     }
 
+    // Revoke existing JWTs before changing the account state. If Redis is
+    // unavailable, fail the removal rather than deleting the user while the
+    // revocation record cannot be written.
+    await this.blacklistService.blacklistPreviousUserTokens(id);
+
     // Soft-delete all user keys first
     await this.repo.manager.softDelete(UserKey, { userId: id });
 
     // Then soft-delete the user
     await this.repo.softRemove(user);
-
-    // Invalidate every JWT issued for this user until now.
-    await this.blacklistService.blacklistPreviousUserTokens(id);
 
     return true;
   }

--- a/back-end/apps/api/src/users/users.service.ts
+++ b/back-end/apps/api/src/users/users.service.ts
@@ -15,7 +15,13 @@ import { FindOptionsWhere } from 'typeorm/find-options/FindOptionsWhere';
 import * as bcrypt from 'bcryptjs';
 import * as argon2 from 'argon2';
 
-import { ErrorCodes, checkFrontendVersion, isUpdateAvailable, VersionCheckResult } from '@app/common';
+import {
+  BlacklistService,
+  checkFrontendVersion,
+  ErrorCodes,
+  isUpdateAvailable,
+  VersionCheckResult,
+} from '@app/common';
 import { Client, User, UserKey, UserStatus } from '@entities';
 
 @Injectable()
@@ -26,6 +32,7 @@ export class UsersService {
     @InjectRepository(User) private repo: Repository<User>,
     @InjectRepository(Client) private clientRepo: Repository<Client>,
     private readonly configService: ConfigService,
+    private readonly blacklistService: BlacklistService,
   ) {}
 
   /* Creates a user with a given email and password. */
@@ -110,6 +117,7 @@ export class UsersService {
       return user;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { clients: _clients, ...userWithoutClients }: User = user;
     // Type assertion needed: serialization interceptor handles the actual shape
     return userWithoutClients as User;
@@ -165,6 +173,9 @@ export class UsersService {
 
     // Then soft-delete the user
     await this.repo.softRemove(user);
+
+    // Invalidate every JWT issued for this user until now.
+    await this.blacklistService.blacklistPreviousUserTokens(id);
 
     return true;
   }

--- a/back-end/libs/common/src/blacklist/blacklist.service.spec.ts
+++ b/back-end/libs/common/src/blacklist/blacklist.service.spec.ts
@@ -49,6 +49,24 @@ describe('BlacklistService', () => {
     });
   });
 
+  describe('blacklistPreviousUserTokens', () => {
+    it('should store a per-user invalidation cutoff for the JWT lifetime', async () => {
+      const expirationDays = 7;
+      const expirationSeconds = expirationDays * 24 * 60 * 60;
+      jest.spyOn(configService, 'get').mockReturnValue(expirationDays);
+      jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+
+      await service.blacklistPreviousUserTokens(42);
+
+      expect(client.set).toHaveBeenCalledWith(
+        'blacklisted:user:42',
+        '1700000000',
+        'EX',
+        expirationSeconds,
+      );
+    });
+  });
+
   describe('isTokenBlacklisted', () => {
     it('should return true if the token is blacklisted', async () => {
       const jwt = 'testToken';
@@ -71,5 +89,36 @@ describe('BlacklistService', () => {
       expect(result).toBe(false);
       expect(client.get).toHaveBeenCalledWith(jwt);
     });
+
+    it('should reject a JWT issued before the user was removed', async () => {
+      const jwt = createJwt({ userId: 42, iat: 1_700_000_000 });
+      client.get.mockImplementation(async key =>
+        key === 'blacklisted:user:42' ? '1700000001' : null,
+      );
+
+      await expect(service.isTokenBlacklisted(jwt)).resolves.toBe(true);
+      expect(client.get).toHaveBeenCalledWith('blacklisted:user:42');
+    });
+
+    it('should not reject another user JWT', async () => {
+      const jwt = createJwt({ userId: 43, iat: 1_700_000_000 });
+      client.get.mockResolvedValue(null);
+
+      await expect(service.isTokenBlacklisted(jwt)).resolves.toBe(false);
+      expect(client.get).toHaveBeenCalledWith('blacklisted:user:43');
+    });
+
+    it('should allow a JWT issued after the invalidation cutoff', async () => {
+      const jwt = createJwt({ userId: 42, iat: 1_700_000_002 });
+      client.get.mockImplementation(async key =>
+        key === 'blacklisted:user:42' ? '1700000001' : null,
+      );
+
+      await expect(service.isTokenBlacklisted(jwt)).resolves.toBe(false);
+    });
   });
 });
+
+function createJwt(payload: object): string {
+  return `header.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.signature`;
+}

--- a/back-end/libs/common/src/blacklist/blacklist.service.spec.ts
+++ b/back-end/libs/common/src/blacklist/blacklist.service.spec.ts
@@ -54,10 +54,10 @@ describe('BlacklistService', () => {
       const expirationDays = 7;
       const expirationSeconds = expirationDays * 24 * 60 * 60;
       jest.spyOn(configService, 'get').mockReturnValue(expirationDays);
-      jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
 
       await service.blacklistPreviousUserTokens(42);
-
+      nowSpy.mockRestore();
       expect(client.set).toHaveBeenCalledWith(
         'blacklisted:user:42',
         '1700000000',

--- a/back-end/libs/common/src/blacklist/blacklist.service.ts
+++ b/back-end/libs/common/src/blacklist/blacklist.service.ts
@@ -15,14 +15,16 @@ export class BlacklistService {
   }
 
   async blacklistToken(jwt: string) {
-    const expirationDays = this.configService.get<number>('JWT_EXPIRATION');
-    const expirationSeconds = Number(expirationDays) * 24 * 60 * 60;
-
-    await this.client.set(jwt, this.BLACKLISTED, 'EX', expirationSeconds);
+    await this.client.set(jwt, this.BLACKLISTED, 'EX', this.getJwtExpirationSeconds());
   }
 
   async isTokenBlacklisted(jwt: string) {
     const data = await this.client.get(jwt);
     return data === this.BLACKLISTED;
+  }
+
+  private getJwtExpirationSeconds(): number {
+    const expirationDays = this.configService.get<number>('JWT_EXPIRATION');
+    return Number(expirationDays) * 24 * 60 * 60;
   }
 }

--- a/back-end/libs/common/src/blacklist/blacklist.service.ts
+++ b/back-end/libs/common/src/blacklist/blacklist.service.ts
@@ -44,8 +44,17 @@ export class BlacklistService {
       return false;
     }
 
-    const cutoffTimestamp = await this.client.get(this.getUserInvalidationKey(payload.userId));
-    return cutoffTimestamp !== null && payload.iat <= Number(cutoffTimestamp);
+    const cutoffTimestampStr = await this.client.get(this.getUserInvalidationKey(payload.userId));
+    if (cutoffTimestampStr === null) {
+      return false;
+    }
+
+    const cutoffTimestamp = Number(cutoffTimestampStr);
+    if (!Number.isFinite(cutoffTimestamp)) {
+      return true;
+    }
+
+    return payload.iat <= cutoffTimestamp;
   }
 
   private getJwtExpirationSeconds(): number {

--- a/back-end/libs/common/src/blacklist/blacklist.service.ts
+++ b/back-end/libs/common/src/blacklist/blacklist.service.ts
@@ -6,6 +6,7 @@ import { Redis } from 'ioredis';
 @Injectable()
 export class BlacklistService {
   private BLACKLISTED = 'blacklisted';
+  private USER_INVALID_BEFORE_PREFIX = 'blacklisted:user:';
 
   client: Redis;
 
@@ -18,13 +19,51 @@ export class BlacklistService {
     await this.client.set(jwt, this.BLACKLISTED, 'EX', this.getJwtExpirationSeconds());
   }
 
+  /*
+   * Invalidates every access token issued to a user before current date by storing a cutoff timestamp in Redis.
+   * The cutoff timestamp only needs to be stored as long as the token with the longest expiration time
+   */
+  async blacklistPreviousUserTokens(userId: number) {
+    const issuedBefore = Math.floor(Date.now() / 1000);
+    await this.client.set(
+      this.getUserInvalidationKey(userId),
+      String(issuedBefore),
+      'EX',
+      this.getJwtExpirationSeconds(),
+    );
+  }
+
   async isTokenBlacklisted(jwt: string) {
     const data = await this.client.get(jwt);
-    return data === this.BLACKLISTED;
+    if (data === this.BLACKLISTED) {
+      return true;
+    }
+
+    const payload = this.decodePayload(jwt);
+    if (!payload?.userId || typeof payload.iat !== 'number') {
+      return false;
+    }
+
+    const cutoffTimestamp = await this.client.get(this.getUserInvalidationKey(payload.userId));
+    return cutoffTimestamp !== null && payload.iat <= Number(cutoffTimestamp);
   }
 
   private getJwtExpirationSeconds(): number {
     const expirationDays = this.configService.get<number>('JWT_EXPIRATION');
     return Number(expirationDays) * 24 * 60 * 60;
+  }
+
+  private getUserInvalidationKey(userId: number): string {
+    return `${this.USER_INVALID_BEFORE_PREFIX}${userId}`;
+  }
+
+  private decodePayload(jwt: string): { userId?: number; iat?: number } | null {
+    try {
+      const payload = jwt.split('.')[1];
+      if (!payload) return null;
+      return JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+    } catch {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
**Description**:

Invalidate existing JWTs when a user is removed.

Approach: Since JWTs are not persisted, we cannot enumerate the JWTs issued for a user and blacklist them.
Instead, we store a per user invalidation cutoff timestamp in Redis when the user is (soft) deleted.
The key used is: `blacklisted:user:<userId>`. 

**Related issue(s)**:

Fixes #2946 
