### PR TITLE
fix: provide user feedback from failed signing process

### DIFF
--- a/front-end/src/renderer/pages/TransactionGroupDetails/SignAllController.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/SignAllController.vue
@@ -37,13 +37,13 @@ const progressText = ref<string>('');
 
 /* Handlers */
 const handleSignAll = async (userPersonalPassword: string | null): Promise<ActionReport | null> => {
-  let result: ActionReport | null;
+  let result: ActionReport | null = null;
   if (props.groupOrId !== null) {
     const groupId = typeof props.groupOrId == 'number' ? props.groupOrId : props.groupOrId.id;
     try {
       result = await performSignAll(userPersonalPassword);
     } finally {
-      await props.callback(groupId, true);
+      await props.callback(groupId, result === null);
     }
   } else {
     result = makeBugReport('Sign All', 'Failed to sign transactions');

--- a/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
+++ b/front-end/src/renderer/pages/TransactionGroupDetails/TransactionGroupDetails.vue
@@ -238,7 +238,9 @@ const handleDetails = async (id: number) => {
   await nextTransaction.routeDown({ transactionId: id }, nodeIds, router, pageTitle.value);
 };
 
-const didSignAll = async (groupId: number | null /*, signed: boolean */) => {
+const didSignAll = async (groupId: number | null, signed: boolean) => {
+  if (!signed) return;
+
   if (goNextAfterSignAll.value) {
     // We route to the next transaction
     if (nextTransaction.hasNext) {

--- a/front-end/src/renderer/pages/Transactions/components/SignGroupButton.vue
+++ b/front-end/src/renderer/pages/Transactions/components/SignGroupButton.vue
@@ -21,7 +21,9 @@ const handleClick = () => {
   signAllStarted.value = true;
 };
 
-const didSignAll = async (groupId: number , signed: boolean) => {
+const didSignAll = async (groupId: number, signed: boolean) => {
+  if (!signed) return;
+
   emit('transactionGroupSigned', { groupId, signed });
 };
 </script>

--- a/front-end/src/renderer/pages/Transactions/components/SignSingleButton.vue
+++ b/front-end/src/renderer/pages/Transactions/components/SignSingleButton.vue
@@ -40,7 +40,9 @@ const handleClick = async () => {
   signStarted.value = true;
 };
 
-const didSign = async () => {
+const didSign = async (signed: boolean) => {
+  if (!signed) return;
+
   if (props.refreshTransaction) {
     assertIsLoggedInOrganization(user.selectedOrganization);
 


### PR DESCRIPTION
**Description**:
When signing fails due to a missing key from the Ready to Sign tab or group details page, the error modal was being destroyed before it could render — because callbacks always triggered a refresh or navigation regardless of outcome. Fixed by threading the success/failure result through the callback chain so refreshes and navigation only happen when signing actually succeeds.

**Related issue(s)**:

Fixes #2865 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
